### PR TITLE
Fix smoke script portability

### DIFF
--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -eu
-set -o pipefail 2>/dev/null || true
 
 ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- Remove non-portable pipefail setup from scripts/smoke-local.sh.
- Keep the smoke script POSIX sh compatible for Ubuntu CI where /bin/sh is dash.

## Verification

- sh -n scripts/smoke-local.sh
- sh ./scripts/smoke-local.sh
- go test ./...