### PR TITLE
Fix release installer asset version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -134,7 +134,8 @@ install_release() {
     fi
   fi
 
-  asset="galley_${version}_${os}_${arch}.tar.gz"
+  asset_version="${version#v}"
+  asset="galley_${asset_version}_${os}_${arch}.tar.gz"
   url="https://github.com/$OWNER/$REPO/releases/download/$version/$asset"
   tmp_dir="$(mktemp -d)"
   archive="$tmp_dir/$asset"


### PR DESCRIPTION
## Summary

- Strip the leading v from release tags when constructing GoReleaser asset names.
- Keep download URLs using the original tag, e.g. v0.1.0.

## Why

GoReleaser produced assets such as galley_0.1.0_darwin_arm64.tar.gz, while the installer was looking for galley_v0.1.0_darwin_arm64.tar.gz.

## Verification

- sh -n scripts/install.sh