### PR TITLE
Fix Galley user-visible output so that supervisor-accepted tasks no long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ This project follows semantic versioning.
 ### Changed
 
 - PR body acceptance criterion lines now reflect the supervisor verdict (`satisfied` / `partially_satisfied`) instead of the original draft `pending` placeholder. Acceptance criterion IDs listed under the supervisor's `acceptance_gaps` render as `partially_satisfied`; everything else under an accepted verdict reads as `satisfied`.
-- `galley task show` no longer surfaces the last attempt's `latest_claude_status` and `latest_error_*` fields as if they were the active state once a task has reached an accepted terminal status (`accepted` or `pr_opened`). The same fields are relabeled under the `prior_attempt_*` prefix so the audit trail remains visible without misleading reviewers.
-- Generated PR titles are now truncated at the last whitespace boundary inside the rune budget and append a single `…` ellipsis marker. Goals without any whitespace inside the budget fall back to a hard rune cut and still receive the ellipsis.
+- `galley task show` no longer surfaces the last attempt's `latest_claude_status` and `latest_error_*` fields as if they were the active state once a task has reached an accepted terminal status (`accepted`, `pr_opened`, `closed`, or `merged`). The same fields are relabeled under the `prior_attempt_*` prefix so the audit trail remains visible after the daemon's PR cleanup loop transitions the task without regressing to active "failed" framing.
+- Generated PR titles are now truncated at the last whitespace boundary inside the rune budget and append a single `…` ellipsis marker. The truncation also enforces GitHub's 256-byte PR title limit while preserving valid UTF-8 boundaries, so goals containing 4-byte runes (for example emoji) no longer overflow the limit. Goals without any whitespace inside the budget fall back to a hard rune-aligned cut and still receive the ellipsis.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- PR body acceptance criterion lines now reflect the supervisor verdict (`satisfied` / `partially_satisfied`) instead of the original draft `pending` placeholder. Acceptance criterion IDs listed under the supervisor's `acceptance_gaps` render as `partially_satisfied`; everything else under an accepted verdict reads as `satisfied`.
+- `galley task show` no longer surfaces the last attempt's `latest_claude_status` and `latest_error_*` fields as if they were the active state once a task has reached an accepted terminal status (`accepted` or `pr_opened`). The same fields are relabeled under the `prior_attempt_*` prefix so the audit trail remains visible without misleading reviewers.
+- Generated PR titles are now truncated at the last whitespace boundary inside the rune budget and append a single `…` ellipsis marker. Goals without any whitespace inside the budget fall back to a hard rune cut and still receive the ellipsis.
+
+### Added
+
+- `runs/<run-id>/validation.json` records auditable evidence — `valid`, `task_id`, `schema_version`, and `generated_at` (UTC, RFC3339 nano) — alongside the existing `errors`, `warnings`, and `task` fields. The file path is unchanged and decoders that ignore unknown fields keep working.
+
 ## v0.2.0 - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ galley task archive ~/.galley/tasks/done/TASK.yaml
 
 `galley task list` shows task state, status, PR URL, latest verdict, and latest summary across the workflow root.
 
-`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context.
+`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Once a task reaches an accepted terminal status (`accepted` or `pr_opened`), the last attempt's claude status and error fields are relabeled under the `prior_attempt_*` prefix so they read as audit history rather than an active failure.
 
 `galley task requeue` accepts a task ID or task file, returns a reviewed task from `tasks/failed`, `tasks/done`, or `tasks/running` to `tasks/queued`, records an optional reason, and increments `supervisor.review_iterations`.
 
@@ -361,6 +361,8 @@ PR automation requires GitHub CLI (`gh`) to be installed and authenticated.
 When `pr.enabled: true` is set in the environment profile, accepted worktree changes are committed with a Galley task commit message and `git_commit_result.json` is written to the run directory.
 
 With `pr.enabled: true`, Galley pushes the current worktree branch to `origin`, writes `pr_body.md`, runs `gh pr create`, updates `pr.url` and `pr.status`, and moves the task to `done/pr_opened`. For AFK implementation tasks, PR creation plus comment polling is the recommended review loop. Local-only runs can leave PR automation disabled when GitHub credentials or network access are unavailable. The branch is the task YAML `worktree.branch`; the base branch comes from `pr.base`.
+
+Galley renders each acceptance criterion in `pr_body.md` using the supervisor verdict, so accepted ACs read as `Status: satisfied` and any IDs the supervisor flagged in `acceptance_gaps` read as `Status: partially_satisfied`. Generated PR titles are truncated at the last whitespace inside Galley's rune budget and end with a single `…` so reviewers can tell the title was shortened.
 
 With `pr.comments.enabled: true`, the daemon scans task files with `pr.url`, reads GitHub issue comments through `gh api`, and processes the oldest unprocessed `/galley rerun ...` or `/galley requeue ...` command for each task. Processed comment IDs are stored in `pr.processed_comment_ids` so rerun commands are not applied twice.
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ galley task archive ~/.galley/tasks/done/TASK.yaml
 
 `galley task list` shows task state, status, PR URL, latest verdict, and latest summary across the workflow root.
 
-`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Once a task reaches an accepted terminal status (`accepted` or `pr_opened`), the last attempt's claude status and error fields are relabeled under the `prior_attempt_*` prefix so they read as audit history rather than an active failure.
+`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Once a task reaches an accepted terminal status (`accepted`, `pr_opened`, `closed`, or `merged`), the last attempt's claude status and error fields are relabeled under the `prior_attempt_*` prefix so they read as audit history rather than an active failure even after the daemon's PR cleanup loop transitions the task.
 
 `galley task requeue` accepts a task ID or task file, returns a reviewed task from `tasks/failed`, `tasks/done`, or `tasks/running` to `tasks/queued`, records an optional reason, and increments `supervisor.review_iterations`.
 
@@ -362,7 +362,7 @@ When `pr.enabled: true` is set in the environment profile, accepted worktree cha
 
 With `pr.enabled: true`, Galley pushes the current worktree branch to `origin`, writes `pr_body.md`, runs `gh pr create`, updates `pr.url` and `pr.status`, and moves the task to `done/pr_opened`. For AFK implementation tasks, PR creation plus comment polling is the recommended review loop. Local-only runs can leave PR automation disabled when GitHub credentials or network access are unavailable. The branch is the task YAML `worktree.branch`; the base branch comes from `pr.base`.
 
-Galley renders each acceptance criterion in `pr_body.md` using the supervisor verdict, so accepted ACs read as `Status: satisfied` and any IDs the supervisor flagged in `acceptance_gaps` read as `Status: partially_satisfied`. Generated PR titles are truncated at the last whitespace inside Galley's rune budget and end with a single `…` so reviewers can tell the title was shortened.
+Galley renders each acceptance criterion in `pr_body.md` using the supervisor verdict, so accepted ACs read as `Status: satisfied` and any IDs the supervisor flagged in `acceptance_gaps` read as `Status: partially_satisfied`. Generated PR titles are truncated at the last whitespace inside Galley's rune budget, enforced against GitHub's 256-byte PR title limit on a valid UTF-8 boundary (so 4-byte runes such as emoji never overflow), and end with a single `…` so reviewers can tell the title was shortened.
 
 With `pr.comments.enabled: true`, the daemon scans task files with `pr.url`, reads GitHub issue comments through `gh api`, and processes the oldest unprocessed `/galley rerun ...` or `/galley requeue ...` command for each task. Processed comment IDs are stored in `pr.processed_comment_ids` so rerun commands are not applied twice.
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -334,6 +334,88 @@ func TestTaskShowByIDWithDots(t *testing.T) {
 	}
 }
 
+func TestTaskShowAcceptedTerminalSuppressesPriorFailure(t *testing.T) {
+	root := t.TempDir()
+	taskPath := writeCLITaskYAML(t)
+	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(donePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(donePath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := taskpkg.Load(donePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Status = "pr_opened"
+	loaded.PR.URL = "https://example.test/pr/1"
+	loaded.PR.Status = "open"
+	loaded.Attempts = []taskpkg.Attempt{{
+		Number:            3,
+		ClaudeStatus:      "failed",
+		SupervisorVerdict: "accepted",
+		Summary:           "executor retried after transient error",
+		Error: &taskpkg.AttemptError{
+			Phase:   "executor",
+			Kind:    "executor_failed",
+			Message: "earlier transient executor failure",
+		},
+	}}
+	if err := taskpkg.Save(donePath, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := executeCommand("task", "show", "--root", root, "task-cli-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr got %q", stderr)
+	}
+	for _, forbidden := range []string{
+		"latest_claude_status: failed",
+		"latest_error_phase: executor",
+		"latest_error_kind: executor_failed",
+		"latest_error_message: earlier transient executor failure",
+	} {
+		if strings.Contains(stdout, forbidden) {
+			t.Fatalf("accepted task output leaked active failure framing %q:\n%s", forbidden, stdout)
+		}
+	}
+	for _, want := range []string{
+		"status: pr_opened",
+		"prior_attempt_attempt: 3",
+		"prior_attempt_claude_status: failed",
+		"prior_attempt_supervisor_verdict: accepted",
+		"prior_attempt_error_phase: executor",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected %q in output, got:\n%s", want, stdout)
+		}
+	}
+
+	jsonStdout, _, err := executeCommand("task", "show", "--root", root, "--output", "json", "task-cli-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Task struct {
+			Status string `json:"status"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(jsonStdout), &payload); err != nil {
+		t.Fatalf("parse json: %v\n%s", err, jsonStdout)
+	}
+	if payload.Task.Status != "pr_opened" {
+		t.Fatalf("json output must reflect accepted terminal status, got %q", payload.Task.Status)
+	}
+}
+
 func TestTaskArchiveText(t *testing.T) {
 	taskPath := writeCLITaskYAML(t)
 	donePath := filepath.Join(t.TempDir(), "tasks", "done", "task.yaml")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -416,6 +416,78 @@ func TestTaskShowAcceptedTerminalSuppressesPriorFailure(t *testing.T) {
 	}
 }
 
+// TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses guards the regression
+// reviewers flagged in iteration 1: once the daemon's PR cleanup loop moves
+// an accepted task from pr_opened to closed or merged, prior failed attempts
+// must remain under the prior_attempt_* prefix instead of regressing to the
+// active "failed" framing.
+func TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses(t *testing.T) {
+	for _, terminalStatus := range []string{"closed", "merged"} {
+		terminalStatus := terminalStatus
+		t.Run(terminalStatus, func(t *testing.T) {
+			root := t.TempDir()
+			taskPath := writeCLITaskYAML(t)
+			donePath := filepath.Join(root, "tasks", "done", "task.yaml")
+			if err := os.MkdirAll(filepath.Dir(donePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(taskPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(donePath, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			loaded, err := taskpkg.Load(donePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			loaded.Status = terminalStatus
+			loaded.PR.URL = "https://example.test/pr/2"
+			loaded.PR.Status = terminalStatus
+			loaded.Attempts = []taskpkg.Attempt{{
+				Number:            2,
+				ClaudeStatus:      "failed",
+				SupervisorVerdict: "accepted",
+				Summary:           "executor retried after transient error",
+				Error: &taskpkg.AttemptError{
+					Phase:   "executor",
+					Kind:    "executor_failed",
+					Message: "earlier transient executor failure",
+				},
+			}}
+			if err := taskpkg.Save(donePath, loaded); err != nil {
+				t.Fatal(err)
+			}
+
+			stdout, stderr, err := executeCommand("task", "show", "--root", root, "task-cli-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stderr != "" {
+				t.Fatalf("stderr got %q", stderr)
+			}
+			for _, forbidden := range []string{
+				"latest_claude_status: failed",
+				"latest_error_phase: executor",
+			} {
+				if strings.Contains(stdout, forbidden) {
+					t.Fatalf("%s task output leaked active failure framing %q:\n%s", terminalStatus, forbidden, stdout)
+				}
+			}
+			for _, want := range []string{
+				"status: " + terminalStatus,
+				"prior_attempt_claude_status: failed",
+				"prior_attempt_error_phase: executor",
+			} {
+				if !strings.Contains(stdout, want) {
+					t.Fatalf("expected %q in %s task output, got:\n%s", want, terminalStatus, stdout)
+				}
+			}
+		})
+	}
+}
+
 func TestTaskArchiveText(t *testing.T) {
 	taskPath := writeCLITaskYAML(t)
 	donePath := filepath.Join(t.TempDir(), "tasks", "done", "task.yaml")

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -144,16 +144,25 @@ func newTaskShowCommand() *cobra.Command {
 				}
 				if len(loaded.Attempts) > 0 {
 					last := loaded.Attempts[len(loaded.Attempts)-1]
-					fmt.Fprintf(cmd.OutOrStdout(), "latest_attempt: %d\n", last.Number)
-					fmt.Fprintf(cmd.OutOrStdout(), "latest_claude_status: %s\n", last.ClaudeStatus)
-					fmt.Fprintf(cmd.OutOrStdout(), "latest_supervisor_verdict: %s\n", last.SupervisorVerdict)
-					fmt.Fprintf(cmd.OutOrStdout(), "latest_summary: %s\n", last.Summary)
+					// Once the supervisor has accepted the task, the last attempt's
+					// raw claude status and error fields are auditable history rather
+					// than the active runtime state. Relabel them under a
+					// prior_attempt_* prefix so accepted/pr_opened tasks no longer
+					// surface "failed" framing as if it were the current state.
+					prefix := "latest"
+					if isAcceptedTerminalStatus(loaded.Status) {
+						prefix = "prior_attempt"
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s_attempt: %d\n", prefix, last.Number)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s_claude_status: %s\n", prefix, last.ClaudeStatus)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s_supervisor_verdict: %s\n", prefix, last.SupervisorVerdict)
+					fmt.Fprintf(cmd.OutOrStdout(), "%s_summary: %s\n", prefix, last.Summary)
 					if last.Error != nil {
-						fmt.Fprintf(cmd.OutOrStdout(), "latest_error_phase: %s\n", last.Error.Phase)
-						fmt.Fprintf(cmd.OutOrStdout(), "latest_error_kind: %s\n", last.Error.Kind)
-						fmt.Fprintf(cmd.OutOrStdout(), "latest_error_message: %s\n", last.Error.Message)
+						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_phase: %s\n", prefix, last.Error.Phase)
+						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_kind: %s\n", prefix, last.Error.Kind)
+						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_message: %s\n", prefix, last.Error.Message)
 						if last.Error.ArtifactDir != "" {
-							fmt.Fprintf(cmd.OutOrStdout(), "latest_error_artifact_dir: %s\n", last.Error.ArtifactDir)
+							fmt.Fprintf(cmd.OutOrStdout(), "%s_error_artifact_dir: %s\n", prefix, last.Error.ArtifactDir)
 						}
 					}
 				}
@@ -271,6 +280,18 @@ func taskFiles(dir string) ([]string, error) {
 	}
 	sort.Strings(paths)
 	return paths, nil
+}
+
+// isAcceptedTerminalStatus reports whether the task has reached a supervisor
+// accepted terminal state. Callers use it to suppress "active failure" framing
+// for the last attempt's error fields when the supervisor already accepted
+// the work.
+func isAcceptedTerminalStatus(status string) bool {
+	switch status {
+	case "accepted", "pr_opened":
+		return true
+	}
+	return false
 }
 
 func taskSummary(path string, loaded task.Task) taskListItem {

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -285,10 +285,15 @@ func taskFiles(dir string) ([]string, error) {
 // isAcceptedTerminalStatus reports whether the task has reached a supervisor
 // accepted terminal state. Callers use it to suppress "active failure" framing
 // for the last attempt's error fields when the supervisor already accepted
-// the work.
+// the work. The set covers the full accepted lifecycle: the initial accepted
+// status, the pr_opened status set when the daemon opens a PR, and the
+// closed/merged statuses that the daemon's PR cleanup loop applies after the
+// PR is closed or merged. Without those tail states a previously accepted
+// task would regress to "active failure" framing once cleanup ran, even
+// though the supervisor already approved the work.
 func isAcceptedTerminalStatus(status string) bool {
 	switch status {
-	case "accepted", "pr_opened":
+	case "accepted", "pr_opened", "closed", "merged":
 		return true
 	}
 	return false

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,8 +17,51 @@ import (
 	"github.com/shinpr/galley/internal/runner"
 	"github.com/shinpr/galley/internal/task"
 	"github.com/shinpr/galley/internal/taskstate"
+	"github.com/shinpr/galley/internal/version"
 	"github.com/shinpr/galley/internal/workspace"
 )
+
+// validationEvidence is the audit-friendly payload written to
+// runs/<run-id>/validation.json. It is a superset of task.ValidationResult so
+// existing readers that decode `errors`, `warnings`, or `task` keep working,
+// while supervisor reviewers and downstream tools can rely on `valid`,
+// `task_id`, `schema_version`, and `generated_at` for evidence.
+type validationEvidence struct {
+	Valid         bool      `json:"valid"`
+	TaskID        string    `json:"task_id"`
+	SchemaVersion string    `json:"schema_version"`
+	GeneratedAt   string    `json:"generated_at"`
+	Errors        []string  `json:"errors"`
+	Warnings      []string  `json:"warnings"`
+	Task          task.Task `json:"task"`
+}
+
+func newValidationEvidence(loaded task.Task, validation task.ValidationResult, now time.Time) validationEvidence {
+	errs := validation.Errors
+	if errs == nil {
+		errs = []string{}
+	}
+	warnings := validation.Warnings
+	if warnings == nil {
+		warnings = []string{}
+	}
+	return validationEvidence{
+		Valid:         validation.Valid(),
+		TaskID:        loaded.ID,
+		SchemaVersion: validationSchemaVersion(),
+		GeneratedAt:   now.UTC().Format(time.RFC3339Nano),
+		Errors:        errs,
+		Warnings:      warnings,
+		Task:          loaded,
+	}
+}
+
+func validationSchemaVersion() string {
+	if version.Commit != "" && version.Commit != "unknown" {
+		return fmt.Sprintf("galley-%s+%s", version.Version, version.Commit)
+	}
+	return fmt.Sprintf("galley-%s", version.Version)
+}
 
 // Options configure the file-backed Galley daemon.
 type Options struct {
@@ -410,7 +453,8 @@ func initializeRunEvidence(root, runningPath string, loaded task.Task, validatio
 	if err := copyFile(runningPath, filepath.Join(runDir, "task.yaml")); err != nil {
 		return "", "", err
 	}
-	if err := writeJSON(filepath.Join(runDir, "validation.json"), validation); err != nil {
+	evidence := newValidationEvidence(loaded, validation, time.Now())
+	if err := writeJSON(filepath.Join(runDir, "validation.json"), evidence); err != nil {
 		return "", "", err
 	}
 	return runID, runDir, nil

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -232,6 +232,7 @@ func applySupervisorVerdict(ctx, shutdownCtx context.Context, req verdictApplica
 
 func acceptSupervisorVerdict(ctx context.Context, opts Options, runningPath string, loaded *task.Task, prepared workspace.Prepared, runDir string, verdict supervisor.Verdict) error {
 	markRevisionRequestsAddressed(loaded, verdict.Summary)
+	applyAcceptedAcceptanceCriteria(loaded, verdict)
 	mergeDiscussionItems(loaded, verdict)
 	if opts.CommitOnAccept {
 		fmt.Fprintf(os.Stderr, "galley: task %s accepted; finalizing commit/pr\n", loaded.ID)
@@ -560,6 +561,30 @@ func mapAcceptanceStatus(status string) string {
 		return status
 	default:
 		return "unknown"
+	}
+}
+
+// applyAcceptedAcceptanceCriteria normalizes per-criterion statuses once the
+// supervisor has accepted the attempt. The supervisor verdict represents the
+// final decision over the whole task, so any AC still marked as pending,
+// unknown, or not_satisfied from earlier executor reports would otherwise leak
+// into the rendered PR body and mislead reviewers. AC IDs that the supervisor
+// flagged as gaps are rendered as partially_satisfied to preserve that nuance.
+func applyAcceptedAcceptanceCriteria(loaded *task.Task, verdict supervisor.Verdict) {
+	if verdict.Status != "accepted" {
+		return
+	}
+	gaps := make(map[string]bool, len(verdict.AcceptanceGaps))
+	for _, id := range verdict.AcceptanceGaps {
+		gaps[strings.TrimSpace(id)] = true
+	}
+	for i := range loaded.AcceptanceCriteria {
+		ac := &loaded.AcceptanceCriteria[i]
+		if gaps[ac.ID] {
+			ac.Status = "partially_satisfied"
+			continue
+		}
+		ac.Status = "satisfied"
 	}
 }
 

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/inputfiles"
 	"github.com/shinpr/galley/internal/strutil"
@@ -88,13 +89,20 @@ func ensureNonCommittedInputsAbsentFromBranch(snapshot workspace.Snapshot, files
 	return nil
 }
 
-// prTitleRuneBudget is the maximum number of runes Galley keeps in a generated
-// PR title. GitHub's PR title byte limit is 256, so 72 runes stays well within
-// it even when every rune is multibyte.
+// prTitleRuneBudget is the soft visual cap on the number of runes Galley keeps
+// in a generated PR title. Most real goals are ASCII or close to it, so this
+// keeps the title visually short. The hard limit that protects against GitHub
+// rejecting the request is prTitleByteBudget below.
 const prTitleRuneBudget = 72
 
+// prTitleByteBudget is the hard byte cap GitHub enforces on PR titles. A
+// 72-rune title can still exceed 256 bytes when every rune is a 4-byte UTF-8
+// character (for example an emoji such as 🎉, which is 4 bytes, so 72*4=288).
+// Any output of prTitle must satisfy len(title) <= prTitleByteBudget.
+const prTitleByteBudget = 256
+
 // prTitleEllipsis marks that prTitle truncated the original task goal so the
-// reader can see the title is shortened.
+// reader can see the title is shortened. "…" (U+2026) is 3 bytes in UTF-8.
 const prTitleEllipsis = "…"
 
 func prTitle(loaded task.Task) string {
@@ -103,6 +111,20 @@ func prTitle(loaded task.Task) string {
 		title = loaded.ID
 	}
 	title = strings.ReplaceAll(title, "\n", " ")
+	// First pass: enforce the visual rune cap with whitespace-preferred
+	// truncation. Most goals fit and are returned untouched.
+	title = truncatePRTitleByRunes(title)
+	// Second pass: enforce GitHub's hard byte cap. The rune cap can still
+	// exceed 256 bytes when every rune is a 4-byte UTF-8 character, so this
+	// pass guarantees the result fits while preserving valid UTF-8 and the
+	// ellipsis marker.
+	title = truncatePRTitleByBytes(title)
+	return title
+}
+
+// truncatePRTitleByRunes enforces prTitleRuneBudget while preferring to cut at
+// a whitespace boundary so the trailing context is not lost mid-word.
+func truncatePRTitleByRunes(title string) string {
 	runes := []rune(title)
 	if len(runes) <= prTitleRuneBudget {
 		return title
@@ -131,6 +153,49 @@ func prTitle(loaded task.Task) string {
 		trimmed = string(runes[:keep])
 	}
 	return trimmed + prTitleEllipsis
+}
+
+// truncatePRTitleByBytes enforces prTitleByteBudget. The cut always lands on a
+// valid UTF-8 rune boundary; the function prefers a whitespace boundary inside
+// the budget and falls back to the nearest rune boundary otherwise. The
+// ellipsis marker is always appended when truncation actually trims the input.
+func truncatePRTitleByBytes(title string) string {
+	if len(title) <= prTitleByteBudget {
+		return title
+	}
+	ellipsisBytes := len(prTitleEllipsis)
+	keep := prTitleByteBudget - ellipsisBytes
+	if keep < 0 {
+		keep = 0
+	}
+	// Walk runes, tracking the largest byte-prefix that fits in keep bytes
+	// while staying on a valid UTF-8 boundary.
+	end := 0
+	lastBreak := -1
+	for i, r := range title {
+		runeEnd := i + utf8.RuneLen(r)
+		if runeEnd > keep {
+			break
+		}
+		end = runeEnd
+		if isPRTitleBreakRune(r) {
+			// Record the byte index BEFORE the whitespace rune so callers
+			// can drop the whitespace itself when cutting.
+			lastBreak = i
+		}
+	}
+	cut := end
+	if lastBreak >= 0 {
+		cut = lastBreak
+	}
+	candidate := strings.TrimRightFunc(title[:cut], isPRTitleBreakRune)
+	if candidate == "" {
+		// No usable whitespace boundary inside the byte budget; fall back to
+		// the largest rune-aligned prefix so callers still receive a
+		// meaningful title prefix.
+		candidate = title[:end]
+	}
+	return candidate + prTitleEllipsis
 }
 
 func isPRTitleBreakRune(r rune) bool {

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -88,6 +88,15 @@ func ensureNonCommittedInputsAbsentFromBranch(snapshot workspace.Snapshot, files
 	return nil
 }
 
+// prTitleRuneBudget is the maximum number of runes Galley keeps in a generated
+// PR title. GitHub's PR title byte limit is 256, so 72 runes stays well within
+// it even when every rune is multibyte.
+const prTitleRuneBudget = 72
+
+// prTitleEllipsis marks that prTitle truncated the original task goal so the
+// reader can see the title is shortened.
+const prTitleEllipsis = "…"
+
 func prTitle(loaded task.Task) string {
 	title := strings.TrimSpace(loaded.Goal)
 	if title == "" {
@@ -95,10 +104,41 @@ func prTitle(loaded task.Task) string {
 	}
 	title = strings.ReplaceAll(title, "\n", " ")
 	runes := []rune(title)
-	if len(runes) > 72 {
-		title = string(runes[:72])
+	if len(runes) <= prTitleRuneBudget {
+		return title
 	}
-	return title
+	// Reserve one rune for the ellipsis marker and try to break at a safe word
+	// boundary inside the remaining budget so the trailing context is not cut
+	// mid-word.
+	keep := prTitleRuneBudget - len([]rune(prTitleEllipsis))
+	if keep < 1 {
+		keep = 1
+	}
+	cut := keep
+	for i := keep - 1; i >= 0; i-- {
+		if isPRTitleBreakRune(runes[i]) {
+			cut = i
+			break
+		}
+	}
+	// Drop trailing whitespace before the ellipsis so the marker reads cleanly.
+	trimmed := strings.TrimRightFunc(string(runes[:cut]), func(r rune) bool {
+		return isPRTitleBreakRune(r)
+	})
+	if trimmed == "" {
+		// No usable break boundary inside the budget; fall back to a hard cut
+		// so callers still receive a meaningful title prefix.
+		trimmed = string(runes[:keep])
+	}
+	return trimmed + prTitleEllipsis
+}
+
+func isPRTitleBreakRune(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '　':
+		return true
+	}
+	return false
 }
 
 func renderPRBody(loaded task.Task) string {

--- a/internal/daemon/pr_test.go
+++ b/internal/daemon/pr_test.go
@@ -83,6 +83,62 @@ func TestPRTitleTruncatesOnWordBoundary(t *testing.T) {
 			t.Fatalf("short goal should not gain ellipsis: %q", title)
 		}
 	})
+
+	// 4-byte UTF-8 runes such as emoji (🎉 = U+1F389, 4 bytes) can push a
+	// rune-budgeted title above GitHub's 256-byte hard limit. Regression
+	// guard for the byte budget enforcement: 200 emoji is 800 bytes, which
+	// must be trimmed back to <= 256 bytes while staying valid UTF-8 and
+	// keeping the ellipsis marker.
+	t.Run("4-byte runes stay within byte budget", func(t *testing.T) {
+		t.Parallel()
+		goal := strings.Repeat("🎉", 200)
+		title := prTitle(task.Task{Goal: goal})
+		if len(title) > prTitleByteBudget {
+			t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
+		}
+		if !utf8.ValidString(title) {
+			t.Fatalf("title is invalid UTF-8: %q", title)
+		}
+		if !strings.HasSuffix(title, prTitleEllipsis) {
+			t.Fatalf("expected ellipsis suffix on truncated 4-byte goal, got %q", title)
+		}
+		// The body before the ellipsis must consist entirely of complete
+		// 🎉 runes — no partial 4-byte sequences sneaking through.
+		core := strings.TrimSuffix(title, prTitleEllipsis)
+		if !utf8.ValidString(core) {
+			t.Fatalf("title core is invalid UTF-8: %q", core)
+		}
+		for _, r := range core {
+			if r != '🎉' {
+				t.Fatalf("title core contains unexpected rune %q in %q", r, title)
+			}
+		}
+	})
+
+	// Mixed ASCII + 4-byte rune goal: GitHub's byte limit must hold even
+	// when the goal carries enough emoji to push a 72-rune cut over 256
+	// bytes. The byte pass should still prefer a whitespace boundary so
+	// reviewers see complete words near the cut.
+	t.Run("ascii plus 4-byte runes break on whitespace under byte budget", func(t *testing.T) {
+		t.Parallel()
+		// 60 emoji * 4 bytes = 240 bytes, plus a long ASCII tail that
+		// forces a break inside the byte budget.
+		goal := strings.Repeat("🎉 ", 60) + "Tail context that should be dropped on truncation"
+		title := prTitle(task.Task{Goal: goal})
+		if len(title) > prTitleByteBudget {
+			t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
+		}
+		if !utf8.ValidString(title) {
+			t.Fatalf("title is invalid UTF-8: %q", title)
+		}
+		if !strings.HasSuffix(title, prTitleEllipsis) {
+			t.Fatalf("expected ellipsis suffix, got %q", title)
+		}
+		core := strings.TrimSuffix(title, prTitleEllipsis)
+		if strings.HasSuffix(core, " ") {
+			t.Fatalf("trailing whitespace before ellipsis: %q", title)
+		}
+	})
 }
 
 func TestRenderPRBodyShowsSupervisorAcceptedStatus(t *testing.T) {

--- a/internal/daemon/pr_test.go
+++ b/internal/daemon/pr_test.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
+	"github.com/shinpr/galley/internal/supervisor"
 	"github.com/shinpr/galley/internal/task"
 	"github.com/shinpr/galley/internal/workspace"
 )
@@ -12,11 +15,184 @@ import (
 func TestPRTitleTruncatesRunes(t *testing.T) {
 	t.Parallel()
 	title := prTitle(task.Task{Goal: strings.Repeat("界", 80)})
-	if len([]rune(title)) != 72 {
-		t.Fatalf("rune length got %d", len([]rune(title)))
+	if got := len([]rune(title)); got != prTitleRuneBudget {
+		t.Fatalf("rune length got %d, want %d", got, prTitleRuneBudget)
 	}
 	if !utf8.ValidString(title) {
 		t.Fatalf("title is invalid UTF-8: %q", title)
+	}
+	if !strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("expected truncated title to end with ellipsis, got %q", title)
+	}
+}
+
+func TestPRTitleTruncatesOnWordBoundary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("english long goal breaks on whitespace", func(t *testing.T) {
+		t.Parallel()
+		goal := "Fix Galley user-visible output so that supervisor-accepted tasks no longer show stale not_satisfied AC status in the PR body"
+		title := prTitle(task.Task{Goal: goal})
+		if len([]rune(title)) > prTitleRuneBudget {
+			t.Fatalf("title exceeds rune budget: len=%d title=%q", len([]rune(title)), title)
+		}
+		if !strings.HasSuffix(title, prTitleEllipsis) {
+			t.Fatalf("expected ellipsis suffix, got %q", title)
+		}
+		// The character immediately before the ellipsis must not be a
+		// whitespace and must come from a complete word in the original goal.
+		core := strings.TrimSuffix(title, prTitleEllipsis)
+		core = strings.TrimRight(core, " \t")
+		if core == "" {
+			t.Fatalf("title core is empty after trimming whitespace: %q", title)
+		}
+		// The core must end at a word boundary in the original goal — i.e.,
+		// the next rune in the goal must be whitespace (or the goal must end).
+		if !strings.HasPrefix(goal, core) {
+			t.Fatalf("title core %q is not a prefix of goal", core)
+		}
+		next := goal[len(core):]
+		if next != "" && next[0] != ' ' && next[0] != '\t' {
+			t.Fatalf("title cut mid-word; next rune in goal is %q (title=%q)", string(next[0]), title)
+		}
+	})
+
+	t.Run("multibyte goal without whitespace falls back to rune cut", func(t *testing.T) {
+		t.Parallel()
+		goal := strings.Repeat("界", 200)
+		title := prTitle(task.Task{Goal: goal})
+		if got := len([]rune(title)); got != prTitleRuneBudget {
+			t.Fatalf("rune length got %d, want %d", got, prTitleRuneBudget)
+		}
+		if !utf8.ValidString(title) {
+			t.Fatalf("title is invalid UTF-8: %q", title)
+		}
+		if !strings.HasSuffix(title, prTitleEllipsis) {
+			t.Fatalf("expected ellipsis suffix on no-whitespace goal, got %q", title)
+		}
+	})
+
+	t.Run("short goal stays untouched", func(t *testing.T) {
+		t.Parallel()
+		goal := "Tighten PR body status rendering"
+		title := prTitle(task.Task{Goal: goal})
+		if title != goal {
+			t.Fatalf("short goal should stay untouched, got %q", title)
+		}
+		if strings.HasSuffix(title, prTitleEllipsis) {
+			t.Fatalf("short goal should not gain ellipsis: %q", title)
+		}
+	})
+}
+
+func TestRenderPRBodyShowsSupervisorAcceptedStatus(t *testing.T) {
+	t.Parallel()
+	loaded := task.Task{
+		ID:   "T1",
+		Goal: "Ship it",
+		AcceptanceCriteria: []task.AcceptanceCriterion{
+			{ID: "AC1", Text: "Behavior", Verification: "go test ./...", Status: "pending"},
+			{ID: "AC2", Text: "Docs", Verification: "grep docs", Status: "not_satisfied"},
+		},
+	}
+	// Simulate the executor's earlier draft pending status moving through the
+	// existing per-attempt merge code path.
+	loaded.AcceptanceCriteria[0].Status = mapAcceptanceStatus("not_satisfied")
+
+	verdict := supervisor.Verdict{Status: "accepted", Summary: "looks good"}
+	applyAcceptedAcceptanceCriteria(&loaded, verdict)
+
+	body := renderPRBody(loaded)
+	if !strings.Contains(body, "`AC1` Behavior") || !strings.Contains(body, "Status: satisfied") {
+		t.Fatalf("expected satisfied AC status in PR body, got:\n%s", body)
+	}
+	if strings.Contains(body, "Status: pending") || strings.Contains(body, "Status: not_satisfied") {
+		t.Fatalf("PR body still shows draft/stale AC status:\n%s", body)
+	}
+}
+
+func TestApplyAcceptedAcceptanceCriteriaPreservesGaps(t *testing.T) {
+	t.Parallel()
+	loaded := task.Task{
+		AcceptanceCriteria: []task.AcceptanceCriterion{
+			{ID: "AC1", Status: "not_satisfied"},
+			{ID: "AC2", Status: "not_satisfied"},
+		},
+	}
+	verdict := supervisor.Verdict{Status: "accepted", AcceptanceGaps: []string{"AC2"}}
+	applyAcceptedAcceptanceCriteria(&loaded, verdict)
+	if loaded.AcceptanceCriteria[0].Status != "satisfied" {
+		t.Fatalf("AC1 status got %q want satisfied", loaded.AcceptanceCriteria[0].Status)
+	}
+	if loaded.AcceptanceCriteria[1].Status != "partially_satisfied" {
+		t.Fatalf("AC2 status got %q want partially_satisfied", loaded.AcceptanceCriteria[1].Status)
+	}
+}
+
+func TestApplyAcceptedAcceptanceCriteriaNoOpOnNonAccepted(t *testing.T) {
+	t.Parallel()
+	loaded := task.Task{
+		AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Status: "not_satisfied"}},
+	}
+	applyAcceptedAcceptanceCriteria(&loaded, supervisor.Verdict{Status: "needs_revision"})
+	if loaded.AcceptanceCriteria[0].Status != "not_satisfied" {
+		t.Fatalf("non-accepted verdict must not mutate AC status, got %q", loaded.AcceptanceCriteria[0].Status)
+	}
+}
+
+func TestNewValidationEvidenceIncludesAuditableFields(t *testing.T) {
+	t.Parallel()
+	loaded := task.Task{ID: "task-evidence-1"}
+	validation := task.ValidationResult{Task: loaded, Errors: []string{}, Warnings: []string{}}
+	now := time.Date(2026, 5, 10, 12, 34, 56, 0, time.UTC)
+	got := newValidationEvidence(loaded, validation, now)
+
+	if !got.Valid {
+		t.Fatalf("expected valid=true, got false")
+	}
+	if got.TaskID != "task-evidence-1" {
+		t.Fatalf("task_id got %q", got.TaskID)
+	}
+	if got.SchemaVersion == "" {
+		t.Fatalf("schema_version must be non-empty")
+	}
+	if got.GeneratedAt == "" || !strings.HasPrefix(got.GeneratedAt, "2026-05-10T12:34:56") {
+		t.Fatalf("generated_at got %q", got.GeneratedAt)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{`"valid"`, `"task_id"`, `"schema_version"`, `"generated_at"`, `"errors"`, `"warnings"`, `"task"`} {
+		if !strings.Contains(string(encoded), key) {
+			t.Fatalf("encoded validation evidence missing %s: %s", key, encoded)
+		}
+	}
+
+	// Decoding into a struct that ignores unknown fields must still recover
+	// the existing errors slice for backward compatibility.
+	var legacy struct {
+		Errors   []string `json:"errors"`
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal(encoded, &legacy); err != nil {
+		t.Fatalf("legacy decode failed: %v", err)
+	}
+	if legacy.Errors == nil {
+		t.Fatal("legacy decode lost errors slice")
+	}
+}
+
+func TestNewValidationEvidenceReportsInvalidTasks(t *testing.T) {
+	t.Parallel()
+	loaded := task.Task{ID: "bad-task"}
+	validation := task.ValidationResult{Task: loaded, Errors: []string{"missing goal"}}
+	got := newValidationEvidence(loaded, validation, time.Now())
+	if got.Valid {
+		t.Fatalf("expected valid=false when validation has errors")
+	}
+	if len(got.Errors) != 1 || got.Errors[0] != "missing goal" {
+		t.Fatalf("errors got %#v", got.Errors)
 	}
 }
 


### PR DESCRIPTION
## Goal

Fix Galley user-visible output so that supervisor-accepted tasks no longer show stale not_satisfied AC status in the PR body, no longer surface latest_claude_status:failed/latest_error_phase:executor as the active state in galley task show, write auditable evidence to runs/<id>/validation.json, and produce PR titles that are truncated at a safe boundary instead of mid-word.

## Acceptance Criteria

- `AC1` When the supervisor accepts a task and the daemon writes pr_body.md, the system shall render each acceptance criterion in the PR body using the status returned by the supervisor verdict (e.g. satisfied/partially_satisfied/not_satisfied) rather than the original draft pending placeholder.
  - Verification: go test ./internal/daemon/... covering renderPRBody plus a new test that feeds a task whose AcceptanceCriteria were merged through loop.go mapAcceptanceStatus and asserts the rendered body contains 'Status: satisfied'.
  - Status: not_satisfied
- `AC2` When galley task show displays a task whose status is accepted or pr_opened, the system shall not present latest_claude_status and latest_error_phase as if they were the active state; failed prior attempts shall be shown only under a clearly labeled prior-attempt section or be suppressed once the task has reached an accepted terminal state.
  - Verification: go test ./internal/cli/... with a new TestTaskShowAcceptedTerminalSuppressesPriorFailure case that loads a task with status=pr_opened plus a failed last attempt and asserts the text/JSON output reflects the accepted state, not active failure.
  - Status: not_satisfied
- `AC3` When the daemon writes runs/<run-id>/validation.json for a successfully validated task, the system shall record auditable evidence including at minimum: validator outcome (valid: true/false), task ID, schema or contract version (commit SHA acceptable as fallback), and a UTC timestamp; an empty body or null errors alone shall not be considered acceptable evidence.
  - Verification: go test ./internal/daemon/... with a new test that runs initializeRunEvidence-equivalent code path, decodes validation.json, and asserts the required fields are present and non-zero.
  - Status: not_satisfied
- `AC4` When a task Goal exceeds the PR title length budget, the system shall truncate at a safe boundary (whitespace or sentence end where possible) and append a single ellipsis marker so the reader can see the title is shortened; the resulting byte length shall remain within GitHub's PR title limit.
  - Verification: go test ./internal/daemon/... with a new TestPRTitleTruncatesOnWordBoundary case covering a long English Goal, a goal containing multibyte characters, and a goal that already fits.
  - Status: not_satisfied
- `AC5` Existing daemon claim/run/accept/retry/escalate behavior, queue state transitions, supervisor verdict handling, AC merge in loop.go, and worktree cleanup shall remain unchanged. go test ./... and ./scripts/smoke-local.sh both pass with output evidence.
  - Verification: go test ./... and ./scripts/smoke-local.sh after the change, with command output captured in attempt evidence.
  - Status: not_satisfied
- `AC6` User-visible changes (PR body shape, task show output, runs/<id>/validation.json shape, PR title shape) shall be reflected in CHANGELOG.md under the Unreleased heading, and any place in docs/ or README.md that already describes those surfaces shall be updated to match the new behavior.
  - Verification: git diff CHANGELOG.md must show a new Unreleased entry; grep -n 'validation.json\|pr_body\|task show' docs/ README.md must show consistent descriptions.
  - Status: not_satisfied

## Final Verification

- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` How should validation.json gain auditable fields without breaking existing readers? -> Add new fields (valid, task_id, schema_version, generated_at) onto the existing serialized payload while keeping the current errors field; do not introduce a new file path.
  - Rationale: Keeps existing automation that reads runs/<id>/validation.json compatible while making the file usable as audit evidence. Reversible by removing added fields.
  - Reversibility: high
- `D2` How should galley task show present a failed last attempt for an accepted/pr_opened task? -> Relabel/suppress the latest_claude_status and latest_error_phase lines when loaded.Status is accepted or pr_opened; surface the same data under a prior_attempt_* prefix or omit when the supervisor accepted the task.
  - Rationale: Avoids the misleading 'failed' framing on accepted runs while preserving auditability. Implementation lives entirely in internal/cli/task.go output rendering.
  - Reversibility: high
- `D3` Where should the AC status fix happen so the rendered PR body reflects the supervisor verdict? -> Investigate internal/daemon/loop.go around line 486 (mapAcceptanceStatus) and the call site that passes loaded into finalizeAcceptedChange in internal/daemon/pr.go; ensure the merged AC slice is what renderPRBody sees.
  - Rationale: loop_test.go already covers the merge; the bug is most likely in ordering or pointer/value copy when handing the loaded task off to the PR-rendering code.
  - Reversibility: high

## Risks

- `R1` regression: Changing validation.json shape may affect external tools or tests that decode it.
  - Mitigation: Only add fields; never rename or remove existing keys. Add a unit test that decodes the new shape and one that ignores unknown fields if applicable.
- `R2` contract: PR body Status formatting is user-visible; supervisor prompts may expect specific verbiage.
  - Mitigation: Render the supervisor-returned status verbatim (satisfied/partially_satisfied/not_satisfied) without inventing new vocabulary; keep formatting identical except for the value.
- `R3` ux: PR title truncation strategy may strip meaningful tail context.
  - Mitigation: Truncate at the last whitespace boundary within the byte budget and append a single ellipsis; cover the no-whitespace fallback path with a test.
