### PR TITLE
Refine Galley task authoring guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Improved Galley task-authoring guidance so reference-file intake happens before additional task scoping questions, supplied plans are treated as single-task implementation guidance, execution settings scale from ordinary-task baselines, and approval summaries favor referenceable decision items over fixed table layouts.
+- Bumped the packaged Claude and Codex Galley plugins to `0.1.3`.
+
 ## v0.2.1 - 2026-05-10
 
 ### Changed

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/authoring-quality.md
+++ b/plugins/galley/skills/galley/references/authoring-quality.md
@@ -49,7 +49,7 @@ For each reference file, decide:
 
 When the user supplies reference files and has not stated commit policy, ask explicitly. Recommend context-only for specs, work plans, logs, screenshots, issue exports, and review notes. Use `commit: true` only after the user confirms the supplied file should become part of the branch output.
 
-For Galley task authoring, read supplied reference files after the reference-file intake is complete: path/content, execution-workspace destination, and commit policy are known. Use the content to extract goal, ACs, scope, risks, and verification signals before drafting. When a supplied path is unreadable, record the risk and ask for usable content or a usable path.
+For Galley task authoring, read supplied reference files after the reference-file intake is complete: path/content, execution-workspace destination, and commit policy are known. Use the content to extract goal, ACs, implementation boundaries, allowed/protected paths, risks, and verification signals before drafting. When a supplied path is unreadable, record the risk and ask for usable content or a usable path.
 
 ## Goal Quality
 
@@ -162,7 +162,7 @@ When repository profiles exist, use them before inventing ACs, verification, or 
 2. Use `quality.required_checks` as the first source for task verification commands.
 3. Use `environment.commands` as the first source for runnable command text.
 4. Use `quality.review_dimensions[].pass` and `pass_policy` as the baseline for ACs, risks, and quality-basis notes.
-5. Use `environment.constraints`, `pr`, and `worktree` settings to shape scope, risks, queueing assumptions, and execution-setting explanations.
+5. Use `environment.constraints`, `pr`, and `worktree` settings to shape implementation boundaries, risks, queueing assumptions, and execution-setting explanations.
 6. Add repo, CI, or generic checks only for gaps not covered by the profiles.
 
 Runnable verification commands should fail when the checked condition fails. Prefer exact commands from `environment.commands`, `quality.required_checks`, or CI. Treat inspection-only commands as evidence sources unless they are wrapped with a failing assertion.
@@ -227,7 +227,7 @@ Prefer making and recording a reversible decision when the risk is low. Record a
 
 A decision is reversible when undoing it requires only editing the task YAML, rerunning the same command, reverting one commit, or applying a small follow-up patch.
 
-Ask for documents only when the missing information blocks safe goal, AC, scope, or verification definition. Otherwise proceed with the current request and repo evidence.
+Ask for documents only when the missing information blocks safe goal, AC, implementation boundary, or verification definition. Otherwise proceed with the current request and repo evidence.
 
 ## Extracting From Existing Planning Docs
 
@@ -237,14 +237,14 @@ When PRDs, design docs, work plans, or task docs exist, use their useful parts w
 | --- | --- | --- |
 | PRD / issue | user value, must-have requirements, ACs, out-of-scope items | broad roadmap items unrelated to the task |
 | Design doc | affected paths, contracts, data flow, invariants, verification strategy | long rationale not needed by the executor |
-| Work plan | phase/task objective, dependencies, quality mechanisms, risks | schedule estimates and human assignment details |
+| Work plan | overall objective, ordered implementation steps, dependencies, quality mechanisms, risks | schedule estimates, human assignment details, and phase labels used as task-splitting instructions |
 | Existing task doc | investigation targets, target files, operation verification, constraints | task runner instructions that conflict with Galley |
 
 Convert extracted material into Galley fields:
 
 - Goal: one outcome from the source document's objective or task purpose.
 - ACs: EARS-style or measurable requirements with verification evidence.
-- Scope: target files, protected boundaries, and allowed/forbidden paths.
+- Execution boundary: target files, protected boundaries, and allowed/forbidden paths.
 - Reference files: source documents copied through `files[]` only when the executor benefits from reading them in the worktree.
 - Quality basis: existing profile, CI command, documented quality mechanism, or a domain-specific fallback.
 

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -2,13 +2,13 @@
 
 Use this reference when creating or repairing a Galley task YAML file.
 
-Task authoring has three approvals: task direction, execution settings, then queueing after validation. Keep task questions separate from execution-environment questions.
+Task authoring has three approvals: task direction, execution settings, then queueing after validation. Keep task questions separate from execution-environment questions. When presenting settings or approval decisions, optimize for referenceability so the user can easily name the item to change.
 
 Use `references/authoring-quality.md` for goal, AC, quality gate, reference file, and question strategy rules. Use `references/task.schema.json` as the machine-readable task YAML contract bundled with this skill.
 
 ## Step 1: Ask For Reference Material, Destination, And Commit Policy First
 
-For a new implementation task, first ask one combined question about reference material and file handling. Ask this as a standalone question before repository investigation, profile resolution, design choices, execution settings, or payload-shape questions. Existing specs or work plans may already contain the goal, ACs, scope, test plan, and design decisions.
+For a new implementation task, first ask one combined question about reference material and file handling. Reference files may contain the goal, requirements, target area, design decisions, boundaries, and verification plan, so complete reference-file intake before collecting additional task details. Ask this as a standalone question before repository investigation, profile resolution, design choices, execution settings, or payload-shape questions. Existing specs or work plans may already contain the goal, ACs, execution boundary, test plan, and design decisions.
 
 If the user already supplied planning/reference files or named an existing PRD, design, work plan, issue, review, log, screenshot, or docs path, treat that as reference-file intake. When path/content, execution-workspace destination, and commit policy are all present, read those files before asking task-design questions. When destination or commit policy is missing, ask for the missing file-handling details first.
 
@@ -50,12 +50,12 @@ Identify the target repository and user intent. Extract from the request and ava
 - task essence: fix, feature, refactor, docs, investigation, or mixed
 - goal
 - AC candidates
-- scope and exclusions
+- implementation boundaries and exclusions
 - constraints and risks
 - verification signals
 - reference files that should be copied into the execution worktree
 
-Use available files when they exist. Ask for missing documents only when the missing information blocks goal, AC, scope, or verification definition.
+Use available files when they exist. Treat supplied work plans and design docs as implementation guidance for the single Galley task unless the user explicitly asks for decomposition. Galley executes the approved request as one task. Use the whole supplied work plan or design doc as implementation guidance for that single task. Use task decomposition only when the user explicitly requests it. When available request text or supplied references identify the target product area, carry that target into task direction and ask for approval there. Ask for missing documents only when the missing information blocks goal, AC, implementation boundary, or verification definition.
 
 ## Step 3: Inspect Repository And Profiles
 
@@ -63,7 +63,7 @@ Use the current git repository root as the target repository. Galley task author
 
 Use a user-provided repository path when the user explicitly gives one. When the current shell is outside a git repository and the user has not provided a path, ask for the target repository path before continuing.
 
-Keep the repository choice anchored to the current git root or explicit user path. Treat feature names, tool names, package names, and references to Galley itself as task context inside that repository. Always show the resolved repository path in Step 4 task direction as `Scope` so the user can correct it before approval.
+Keep the repository choice anchored to the current git root or explicit user path. Treat feature names, tool names, package names, and references to Galley itself as task context inside that repository. Always show the resolved repository path in Step 4 task direction as `Execution target repository` so the user can correct it before approval.
 
 Explore the resolved target repository with the goal of finding enough local guidance to draft a correct task:
 
@@ -91,7 +91,7 @@ Before discussing Galley runtime settings or writing task YAML, present the prop
 - task essence
 - AC direction
 - key design decisions to encode
-- scope and forbidden paths
+- execution target repository, implementation boundaries, allowed paths, and protected paths
 - reference files and commit policy
 - reference file execution-workspace destinations
 - quality/profile basis
@@ -102,7 +102,10 @@ Use a direct approval question, not an open-ended label:
 Task direction:
 - Goal: <goal>
 - Acceptance criteria direction: <AC summary>
-- Scope: <paths>
+- Execution target repository: <absolute repo path>
+- Implementation boundaries: <included behavior/areas>
+- Allowed paths: <paths needed for edits and reference-file destinations>
+- Protected paths: <paths>
 - Reference files: <files or none>
 - Reference file destination: <source -> destination>
 - Reference file commit policy: <context-only or committed files>
@@ -111,7 +114,7 @@ Task direction:
 Approve this task direction before I choose execution settings and create the task YAML?
 ```
 
-Ask targeted task questions here when they affect correctness, safety, scope, or verification. Write YAML only after the user approves the task direction or provides adjustments.
+Ask targeted task questions here when they affect correctness, safety, implementation boundaries, allowed paths, or verification. Write YAML only after the user approves the task direction or provides adjustments.
 
 ## Step 5: Confirm Execution Settings
 
@@ -128,52 +131,22 @@ Interpret daemon-dependent settings before asking:
 - If no daemon is running, ask the user to approve the planned daemon startup settings because they will be applied when starting the daemon.
 - If daemon status is unclear, report that uncertainty and ask whether to inspect or start a fresh daemon before queueing.
 
-Then propose execution settings with user-facing explanations and choices. Choose values from the table below; deviate when task scope, repository checks, daemon state, profile state, or user policy requires it. Split task YAML settings, environment profile operations, and daemon startup settings so the user can see where each value is stored.
+Then propose execution settings with user-facing explanations and choices. Treat `loop_budget: 10` and `timeout_ms: 1800000` as the ordinary-task baseline. Compare the actual task size and verification cost against that baseline using the user request, task direction, repository evidence, and supplied references. Increase timeout and retry budget for broader, slower, or more uncertain tasks; use smaller values when the user explicitly wants a short or low-cost run. Briefly state the comparison evidence.
 
-For ordinary implementation tasks, recommend:
+Execution-setting content requirements:
 
-```markdown
-Execution settings:
+- Task YAML settings: edit authority, retry budget, per-attempt timeout, and blocking severity policy.
+- Environment profile operation settings: PR behavior, PR base branch, PR comments, and worktree cleanup from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work.
+- Supervisor: present the planned or current supervisor. Use `claude` as the default review gate and offer `codex` when the user wants Codex review.
+- Daemon concurrency: present planned or current `max_concurrent_tasks` and `max_concurrent_per_repo`. Explain that default or low concurrency fits a single heavy task, while higher values are available for parallel execution.
+- For each user-changeable setting, include the recommended or current value, why it fits the current task, and practical alternatives.
+- For settings stored outside task YAML, name the change path, such as `environment.yaml` edits or daemon restart with different flags.
 
-Task YAML settings (can be changed before queueing):
-| Item | Recommended value and reason | Other choices |
-| --- | --- | --- |
-| Edit authority | Broad operations inside an isolated worktree (`sandbox-full-access`) because implementation usually needs file edits plus local checks. | Investigation only (`read-only`), or normal edits with less authority (`edit`). |
-| Retry budget | `10` attempts because supervisor findings may need several correction loops. | Smaller number for low-cost trial runs; `0` for unlimited when explicitly requested. |
-| Per-attempt timeout | `30min` because build/test/lint can take time. | Longer for slow builds/E2E/migrations; shorter for small docs or review tasks. |
-| Blocking severity policy | Use the current quality profile's blocking severities. This is the enforced review threshold for correction loops. | Change repository-wide blocking severities through quality profile authoring before queueing. Record task-specific review preferences in `decisions` as guidance only. |
+Presentation guidance:
 
-Environment profile operation settings:
+Use a readable format appropriate to the amount of explanation. Prefer concise bullets when reasons are long. Use compact tables only when each entry stays short. The required part is the decision content above, not a specific visual format.
 
-Use the current `environment.yaml` values when present. If the profile is missing, create it through `references/profile-authoring.md` before queueing ordinary implementation work.
-
-| Item | Current/recommended value and reason | Other choices |
-| --- | --- | --- |
-| PR behavior | `pr.enabled: true` so accepted AFK implementation work ends in a reviewable PR. | `false` for local-only or investigation tasks. |
-| PR base branch | `pr.base` from the repository profile or discovered default branch. | Change in `environment.yaml` before queueing. |
-| PR comments | `pr.comments.enabled: true`, `pr.comments.reply: true` so `/galley rerun` and `/galley requeue` are handled. | Disable polling or replies in `environment.yaml`. |
-| Worktree cleanup | `worktree.cleanup: true` so Galley removes clean managed worktrees for closed or merged PR tasks. | `false` when the user wants to keep managed worktrees for inspection. |
-
-Daemon startup settings:
-
-If a verified daemon is already running, present current values as fixed for this queueing decision:
-
-| Item | Current value | Meaning | Change path |
-| --- | --- | --- | --- |
-| Supervisor | `<status.supervisor>` | Reviewer used for acceptance decisions. | Stop/restart daemon with different flags before queueing. |
-| Concurrency | `max_concurrent_tasks=<value>`, `max_concurrent_per_repo=<value>` | Queue parallelism. | Stop/restart daemon with different flags before queueing. |
-
-If no daemon is running, ask the user to approve planned daemon settings:
-
-| Item | Recommended value and reason | Other choices |
-| --- | --- | --- |
-| Supervisor | `claude` as the default review gate. | `codex` when the user wants Codex review. |
-| Daemon concurrency | Use default concurrency for ordinary tasks. | Change max concurrent tasks or per-repo concurrency when the user needs parallel execution. |
-
-Approve these execution settings, or tell me which item to change?
-```
-
-Pair each YAML value with what it means and why it fits the current task.
+Ask the user to approve the execution settings or name the item to change before generating task YAML.
 
 Record the approved task YAML settings, current quality profile blocking severities, environment profile operation settings, and the current or planned daemon startup settings for the queue/daemon step. The task YAML stores the task content; repository operation behavior is applied from `environment.yaml`; daemon startup behavior is applied by the running daemon or the command used when starting it.
 
@@ -248,13 +221,13 @@ Use `decisions: []`, `risks: []`, and `verification.commands: []` when those ent
 - `mode`: use `afk` for daemon execution.
 - `status`: write new tasks as `draft`; `galley task queue` writes the queued copy with `status: queued`.
 - `scope.permission`: prefer broad operations inside the isolated worktree (`sandbox-full-access`) for AFK implementation tasks; use investigation only (`read-only`) for review tasks; use normal edits (`edit`) when broad sandbox authority is unnecessary or unavailable.
-- `allowed_paths`: choose the narrowest paths that still allow the task to succeed.
-- `execution_policy.timeout_ms`: set the approved per-attempt timeout in milliseconds. `30min` is `1800000`.
+- `allowed_paths`: choose the narrowest paths that cover approved edits and any reference-file destinations.
+- `execution_policy.timeout_ms`: set the approved per-attempt timeout in milliseconds. Use `30min` (`1800000`) as the ordinary-task baseline and increase it for broader, slower, or more uncertain tasks.
 - `files`: use it when the user attaches or names specs, work plans, logs, screenshots, issue exports, or other implementation references the executor should read in the worktree.
 - `files[].source`: use an absolute path or a path relative to the task YAML file. Galley resolves relative sources before queueing or requeueing.
 - `files[].destination`: use a relative path inside the execution workspace. It must stay within `scope.allowed_paths`, must not use parent traversal, and must not overwrite an existing file.
 - `files[].commit`: use `false` for context-only inputs; use `true` only when the supplied file is intentionally part of the final branch.
-- `execution_policy.loop_budget`: recommend `10` for AFK implementation so Galley can complete corrective loops. Use less than `5` only when the user explicitly wants a short, low-cost run; use `0` only when the user explicitly requests an unbounded loop.
+- `execution_policy.loop_budget`: use `10` as the ordinary-task baseline for AFK implementation so Galley can complete corrective loops. Increase it for broader or more uncertain tasks. Use less than `5` only when the user explicitly wants a short, low-cost run; use `0` only when the user explicitly requests an unbounded loop.
 - Blocking severity is enforced by the resolved quality profile and supervisor policy, not by a top-level task schema field. Show the current profile threshold in execution settings and the final queue summary. Use profile authoring when the user wants to change repository-wide blocking severities. Record task-specific review preferences in `decisions` only as guidance.
 - `worktree.path`: use a sibling path outside the source repo, such as `../<repo-name>.worktrees/<short-name>`.
 - `supervisor.review_iterations`: start at `0`; Galley increments it when reviewed work is requeued.
@@ -272,7 +245,7 @@ Use the positional form, as in `galley task validate path/to/task.yaml`.
 
 If validation reports decode or unmarshal errors:
 
-1. Keep the user-approved goal, ACs, scope, and runtime choices.
+1. Keep the user-approved goal, ACs, implementation boundaries, allowed/protected paths, and runtime choices.
 2. Restore file shape from the skill-bundled skeleton.
 3. Repair fields against `references/task.schema.json`.
 4. Empty optional arrays that are still failing validation.
@@ -292,7 +265,7 @@ Task content:
 | --- | --- |
 | Goal | <goal> |
 | Acceptance criteria | <AC IDs and short summaries> |
-| Scope | repo `<scope.cwd>`; allowed `<paths>`; protected `<paths>` |
+| Execution boundary | repo `<scope.cwd>`; allowed paths `<paths>`; protected paths `<paths>` |
 | Reference files | <none, or source -> destination with commit policy> |
 | Quality basis | <profile, CI command, repo doc, or inferred domain gate> |
 | Primary investigation targets | <paths and why they matter> |


### PR DESCRIPTION
## Summary
- tighten task authoring guidance so reference-file intake happens before additional task scoping questions
- treat supplied work plans and design docs as single-task implementation guidance unless decomposition is explicitly requested
- make execution settings scale from ordinary-task baselines and keep approval decisions referenceable instead of tied to fixed table layouts
- bump packaged Claude and Codex Galley plugin versions to 0.1.3

## Validation
- git diff --check
- python3 -m json.tool plugins/galley/.codex-plugin/plugin.json
- python3 -m json.tool plugins/galley/.claude-plugin/plugin.json