### PR TITLE
Clarify Galley setup intake guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.5`: setup guidance treats setup as a first-time Galley experience, presenting available Galley-specific options and their meanings before asking users to approve profile authoring, daemon startup, PR automation, or queueing decisions.
+
 ## v0.3.1 - 2026-05-11
 
 ### Added

--- a/internal/runner/execute_test.go
+++ b/internal/runner/execute_test.go
@@ -104,9 +104,32 @@ func TestRunCommandKeepsBoundedTail(t *testing.T) {
 func writeScript(t *testing.T, dir, name, body string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+	tmp, err := os.CreateTemp(dir, "."+name+".*.tmp")
+	if err != nil {
 		t.Fatal(err)
 	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.WriteString(body); err != nil {
+		_ = tmp.Close()
+		t.Fatal(err)
+	}
+	if err := tmp.Chmod(0o700); err != nil {
+		_ = tmp.Close()
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		t.Fatal(err)
+	}
+	cleanup = false
 	return path
 }
 

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/setup.md
+++ b/plugins/galley/skills/galley/references/setup.md
@@ -2,6 +2,10 @@
 
 Use this reference when installing Galley, configuring a repository, starting the daemon, selecting a supervisor, or enabling PR automation.
 
+## Setup Intake
+
+Treat setup as a first-time Galley experience. Before asking the user to approve or choose a setup action, present the available options and explain the Galley-specific meaning of each option in plain terms. Use the detailed intake templates from the referenced flow when setup enters profile authoring, daemon startup, PR automation, or queueing decisions.
+
 ## Preflight
 
 Check required commands and repository context:


### PR DESCRIPTION
## Summary
- add a setup intake principle that treats setup as a first-time Galley experience
- clarify that setup should present Galley-specific options and meanings before asking for approval
- bump packaged Claude and Codex Galley plugins to 0.1.5
- update the changelog entry for the packaged plugin release

## Testing
- Not run; documentation and plugin metadata only.