### PR TITLE
Clarify supervisor routing for blocking findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Completed PR worktree cleanup now removes the managed task worktree with `git worktree remove --force` and clears leftover non-Git directories, so ignored or generated files no longer leave repeated daemon cleanup errors after a PR is closed or merged.
+- Supervisor prompts now classify blocking findings by the next actor: executor-actionable blockers request `needs_revision`, human judgment blockers request `needs_supervisor_review`, and external or unrecoverable blockers request `hard_stop`.
 
 ## v0.3.2 - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,9 @@ Otherwise the task is retried until `execution_policy.loop_budget` is exhausted;
 | Condition | Result |
 | --- | --- |
 | `completed` with diff, satisfied ACs, evidence, and required checks | `tasks/done/` with status `accepted` |
-| `completed` with missing ACs, unsatisfied ACs, or missing required checks | retry, then `tasks/failed/` with status `needs_supervisor_review` |
+| `completed` with executor-actionable implementation, scope, acceptance, or verification blockers | retry, then `tasks/failed/` with status `needs_supervisor_review` if the loop budget is exhausted |
+| `completed` with blockers that require human product, design, business, environment setup, external service, or required-check policy judgment | `tasks/failed/` with status `needs_supervisor_review` |
+| `completed` with an external or unrecoverable blocker that prevents meaningful progress | `tasks/failed/` with status `failed` |
 | `completed_with_risks` | retry, then `tasks/failed/` with status `needs_supervisor_review` |
 | Parse failure or schema validation failure | retry, then `tasks/failed/` with status `needs_supervisor_review` |
 | Two consecutive attempts with no git diff | stop early as a no-progress safeguard |

--- a/prompts/claude-supervisor-review.md
+++ b/prompts/claude-supervisor-review.md
@@ -162,7 +162,7 @@ Pass policy:
 - Set `blocks_acceptance` to true exactly when the finding severity is included in the active blocking severities.
 - To require low-severity cleanup before acceptance, the quality profile must include `low` in `blocking_severities`.
 
-If any finding blocks acceptance, return `needs_revision` and put only those required fixes in `next_work_order`. If a blocking finding is enough to reject the attempt, continue reviewing the relevant files before returning so the next executor attempt receives the complete set of required fixes.
+A blocking finding prevents `accepted`. Classify the next actor before choosing the status. Use `needs_revision` when another executor attempt can reasonably fix the blocker with a concrete work order. Use `needs_supervisor_review` when the blocker depends on human judgment about product, design, business, environment setup, external services, or required-check policy. Use `hard_stop` when the blocker prevents meaningful progress rather than leaving a human review decision. For `needs_supervisor_review`, set `next_work_order` to an empty string and explain the human decision needed in `summary` and `acceptance_gaps`. Continue reviewing the relevant files before returning so the verdict includes the complete set of blockers.
 
 Non-blocking findings remain in `findings` with `blocks_acceptance=false`. Record concrete problems in `findings` even when their severity is non-blocking under the pass policy.
 

--- a/prompts/codex-supervisor-review.md
+++ b/prompts/codex-supervisor-review.md
@@ -71,7 +71,7 @@ Apply the quality profile pass policy:
 - Set `blocks_acceptance` to true exactly when the finding severity is included in the active blocking severities.
 - To require low-severity cleanup before acceptance, the quality profile must include `low` in `blocking_severities`.
 
-If any finding blocks acceptance, return `needs_revision` and put only those required fixes in `next_work_order`. If a blocking finding is enough to reject the attempt, continue reviewing the relevant files before returning so the next executor attempt receives the complete set of required fixes.
+When a blocking finding is executor-actionable, return `needs_revision` and put only those required fixes in `next_work_order`. When the blocker needs human judgment, return `needs_supervisor_review`, set `next_work_order` to an empty string, and explain the human decision needed in `summary` and `acceptance_gaps`. Use `hard_stop` when the blocker prevents meaningful progress rather than leaving a human review decision. Continue reviewing the relevant files before returning so the verdict includes the complete set of blockers.
 
 Non-blocking findings remain in `findings` with `blocks_acceptance=false`. Record concrete problems in `findings` even when their severity is non-blocking under the pass policy.
 

--- a/prompts/supervisor-review-common.md
+++ b/prompts/supervisor-review-common.md
@@ -14,10 +14,12 @@ Use exactly one status:
 
 - `accepted`: repository evidence satisfies the task, pending revision requests, active pass policy, and required verification.
 - `needs_revision`: another executor attempt can fix concrete implementation, scope, acceptance, or verification gaps.
-- `needs_supervisor_review`: the next decision needs human product, design, business, or environment judgment.
+- `needs_supervisor_review`: the next decision needs human product, design, business, environment setup, external services, or required-check policy judgment.
 - `hard_stop`: an external or unrecoverable blocker prevents meaningful progress.
 
 For `needs_revision`, set `next_work_order` to concrete instructions the executor can run next. For all other statuses, set `next_work_order` to an empty string.
+
+A blocking finding prevents `accepted`. Choose the next status by the next actor: use `needs_revision` when another executor attempt can reasonably fix the blocker; use `needs_supervisor_review` when the blocker requires human product, design, business, environment setup, external services, or required-check policy judgment; use `hard_stop` when an external or unrecoverable blocker prevents meaningful progress.
 
 ## Evidence
 


### PR DESCRIPTION
## Summary
- Clarify that blocking findings prevent acceptance but route by the next actor
- Align Claude and Codex supervisor prompts for needs_revision, needs_supervisor_review, and hard_stop decisions
- Update README and CHANGELOG to document the new routing language

## Tests
- go test ./...