### PR TITLE
Prepare v0.3.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.3.3 - 2026-05-12
+
 ### Changed
 
 - Completed PR worktree cleanup now removes the managed task worktree with `git worktree remove --force` and clears leftover non-Git directories, so ignored or generated files no longer leave repeated daemon cleanup errors after a PR is closed or merged.


### PR DESCRIPTION
## Summary
- Add the v0.3.3 changelog heading for the next patch release
- Keep the Unreleased section open for future changes

## Tests
- Not run; changelog-only change