### PR TITLE
Bump plugin version and release notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.4.0 - 2026-05-14
+
 ### Added
 
 - Task YAML `executor.cli` now accepts `codex` in addition to `claude`. The daemon dispatches implementation attempts through the selected binary (`ClaudeBin` for `claude`, `CodexBin` for `codex`), persists per-attempt evidence under the same `runs/<id>/attempt-N/` layout as the Claude path, records the executor command used (`claude -p` or `codex exec`) in `task.verification.commands`, and classifies executor success, retry, and idle-timeout outcomes consistently across providers. The Codex command plan is built to match the `codex exec` CLI surface: reasoning effort is delivered via `-c model_reasoning_effort="<value>"` because `codex exec` does not expose `--effort`, `executor.prompt_mode=append` is recorded as an informational warning because Codex receives one concatenated stdin prompt, and `executor.max_budget_usd` is recorded as an informational warning because Codex has no equivalent flag. The Codex executor now uses a Codex-specific executor prompt that preserves the same task/result contract as the Claude executor prompt. Generated schemas, the skill-bundled `task.schema.json` reference, the executor-selection guidance in `docs/task-yaml.md`, and the new `examples/afk-task-codex.yaml` describe the selection surface.
@@ -15,6 +17,7 @@ This project follows semantic versioning.
 - Executor attempt evidence now writes structured executor output to `executor_result.json`. Galley still reads legacy `claude_result.json` files for existing run evidence, but new runs no longer write the legacy filename.
 - Task YAML `executor.model` is now optional. When omitted, Galley lets the selected executor CLI use its configured default model; pinned model names remain supported for tasks that need an explicit override.
 - Skill-bundled `scripts/create_task_skeleton.py` now includes the optional acceptance skeleton preflight stage in new task YAML with `enabled: false`. This makes the opt-in preflight setting visible while preserving the existing disabled behavior; enabled-only fields such as `mode`, `required`, `allowed_paths`, and `outputs` remain omitted until an author enables the stage.
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.6`: task authoring omits `executor.model` by default, preserves explicit model overrides only when the user requests one, includes Codex executor selection in the bundled task schema, diagnoses new `executor_result.json` run evidence, and keeps setup/install guidance provider-neutral for fresh worktrees.
 
 ## v0.3.5 - 2026-05-13
 

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Bump the packaged Claude and Codex Galley plugin manifests to 0.1.6.
- Align the Claude marketplace entry version with the plugin manifest.
- Move the current Unreleased changelog entries into v0.4.0 while leaving the Unreleased section in place.

## Validation
- claude plugin validate plugins/galley/.claude-plugin/plugin.json
- claude plugin validate .claude-plugin/marketplace.json
- python3 -m json.tool plugins/galley/.codex-plugin/plugin.json
- python3 -m json.tool .agents/plugins/marketplace.json
- go run ./cmd/galley schema check
- go run ./cmd/galley task validate examples/afk-task-codex.yaml
- git diff --check