### PR TITLE
Add repository environment executor defaults, make unset executor defaults resolve to Codex for new task authoring, and update setup/task guidance plus release notes for the Claude print-mode billing change.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows semantic versioning.
 
 - Repository `environment.yaml` profiles now support an optional `executor.default_cli` for new task authoring. The task skeleton generator uses that repository default when present and now falls back to Codex when it is unset, while explicit task YAML `executor.cli` remains authoritative for existing tasks. Setup and task-authoring guidance now make the implementation executor choice explicit because Claude Code print-mode usage moved to Agent SDK billing, which changes the cost profile of the previous Claude-oriented default.
 - Task YAML `executor.max_budget_usd` is now optional in the schema, and new Codex task skeletons omit it because `codex exec` does not expose a matching budget flag. Explicit values remain valid for existing tasks and continue to drive the Claude CLI budget flag.
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.7`: setup, profile-authoring, task-authoring, and queueing guidance now distinguish implementation executor defaults from daemon supervisor selection, resolve repository executor defaults from `environment.yaml`, and document `/galley` PR comment requeue behavior.
 
 ## v0.4.0 - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Repository `environment.yaml` profiles now support an optional `executor.default_cli` for new task authoring. The task skeleton generator uses that repository default when present and now falls back to Codex when it is unset, while explicit task YAML `executor.cli` remains authoritative for existing tasks. Setup and task-authoring guidance now make the implementation executor choice explicit because Claude Code print-mode usage moved to Agent SDK billing, which changes the cost profile of the previous Claude-oriented default.
+
 ## v0.4.0 - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Repository `environment.yaml` profiles now support an optional `executor.default_cli` for new task authoring. The task skeleton generator uses that repository default when present and now falls back to Codex when it is unset, while explicit task YAML `executor.cli` remains authoritative for existing tasks. Setup and task-authoring guidance now make the implementation executor choice explicit because Claude Code print-mode usage moved to Agent SDK billing, which changes the cost profile of the previous Claude-oriented default.
+- Task YAML `executor.max_budget_usd` is now optional in the schema, and new Codex task skeletons omit it because `codex exec` does not expose a matching budget flag. Explicit values remain valid for existing tasks and continue to drive the Claude CLI budget flag.
 
 ## v0.4.0 - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Galley is a local orchestration runtime for supervised AI-assisted coding task e
 
 It runs locally, keeps work in git-visible changes, and records evidence for review before each acceptance decision.
 
-Galley supports Claude Code and Codex as first-class executor and supervisor backends. New task authoring uses the repository `environment.yaml` executor default when one is set and otherwise starts from Codex; task YAML can still select either backend explicitly, and the daemon can select either backend for supervisor review.
+Galley can use Claude Code or Codex for implementation, and either backend can review the result as supervisor.
+
+When a new task is authored, Galley uses the repository executor default from `environment.yaml` when one is configured; otherwise it defaults to Codex. The generated task records that choice in `executor.cli`, and that task-level setting remains authoritative. Supervisor selection is separate and is controlled by daemon startup.
 
 ## Quick Start
 
@@ -90,8 +92,8 @@ Galley includes a plugin that packages one Agent Skill for Claude Code and Codex
 Profiles are worth setting up early. They tell Galley which commands are available, which quality checks are required, what evidence the supervisor should expect, and which findings should block acceptance. The skill can create these interactively from the target repository.
 
 - **Task authoring**: clarify the user goal, target repo, scope, input files, acceptance criteria, verification, loop budget, supervisor, and PR behavior; write a draft task YAML, validate it, and queue it only after explicit user approval.
-- **Profile authoring**: interactively create `quality.yaml` and `environment.yaml` for repo-specific quality gates, commands, tools, implementation executor defaults, network policy, secrets policy, PR behavior, and cleanup policy.
-- **Setup**: install `galley`, verify `claude`, `codex`, and `gh` availability, configure workflow roots, and prepare daemon/PR automation commands.
+- **Profile authoring**: interactively create `quality.yaml` and `environment.yaml` for repo-specific quality gates, command names, executor defaults, network and secrets policy, PR behavior, and cleanup policy.
+- **Setup**: install `galley`, verify the selected provider CLIs and `gh` when they are needed, configure workflow roots, and prepare daemon/PR automation commands.
 - **Troubleshooting**: inspect failed runs, stale claims, PR automation state, executor output, and recorded evidence.
 
 ```text
@@ -114,9 +116,9 @@ The standalone skill still expects the `galley` CLI on `PATH`. Some workflows al
 
 - **Task YAML**: the trusted local input that defines the goal, acceptance criteria, scope, verification, execution policy, and PR behavior. See [docs/task-yaml.md](docs/task-yaml.md).
 - **Quality profile**: optional repo-specific review gates, required checks, pass policy, and evidence requirements. See [docs/profiles.md](docs/profiles.md).
-- **Environment profile**: optional repo-specific command map, implementation executor default, and execution constraints for network, secrets, and destructive operations. See [docs/profiles.md](docs/profiles.md).
-- **Executor**: the backend that implements the task in the worktree. New task authoring uses the repository executor default when set, otherwise Codex; either backend can be selected per task.
-- **Supervisor**: the backend that reviews executor work against acceptance criteria, required quality checks, and recorded evidence. Claude is the default; Codex can be selected per daemon.
+- **Environment profile**: optional repo-specific profile for command names, executor defaults, network and secrets policy, destructive-operation constraints, PR behavior, and cleanup policy. See [docs/profiles.md](docs/profiles.md).
+- **Executor**: the backend that implements the task in the worktree. Newly authored tasks use `environment.yaml` `executor.default_cli` when it is set, otherwise Codex. An explicit task `executor.cli` selects the backend for that task.
+- **Supervisor**: the backend that reviews executor work against acceptance criteria, required quality checks, and recorded evidence. Supervisor selection is controlled by daemon startup; Claude is the default unless Codex is selected.
 - **AFK task**: an unattended task that can run asynchronously inside a managed worktree.
 - **Acceptance criterion ID**: the `acceptance_criteria[].id` value the executor must report back with evidence, for example `AC1`.
 - **Loop budget**: `execution_policy.loop_budget` is the maximum number of executor attempts before Galley escalates to supervisor review; `0` means unlimited.
@@ -349,7 +351,13 @@ With `pr.comments.reply: true`, Galley posts a concise acknowledgement comment a
 
 ## Executors
 
-New task authoring resolves the executor backend from `environment.yaml` `executor.default_cli` when present and otherwise uses Codex. An explicit task YAML `executor.cli` remains authoritative for that task and may select `claude` or `codex`. Acceptance skeleton preflight, structured executor results, run evidence, and supervisor review use the same contracts across both backends.
+For newly authored tasks, Galley resolves the executor in this order:
+
+1. an explicit executor choice during task authoring
+2. `environment.yaml` `executor.default_cli`
+3. Codex
+
+The generated task records the selected backend in `executor.cli`. After that, the task YAML is authoritative: existing tasks keep their configured executor unless the task file is edited. Acceptance skeleton preflight, structured executor results, run evidence, and supervisor review use the same contracts across both backends.
 
 See [docs/task-yaml.md](docs/task-yaml.md) for the full `executor` block and [examples/afk-task-codex.yaml](examples/afk-task-codex.yaml) for a Codex task example.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Galley is a local orchestration runtime for supervised AI-assisted coding task e
 
 It runs locally, keeps work in git-visible changes, and records evidence for review before each acceptance decision.
 
-Galley supports Claude Code and Codex as first-class executor and supervisor backends. Claude Code is the default; task YAML can select Codex for execution, and the daemon can select Codex for supervisor review.
+Galley supports Claude Code and Codex as first-class executor and supervisor backends. New task authoring uses the repository `environment.yaml` executor default when one is set and otherwise starts from Codex; task YAML can still select either backend explicitly, and the daemon can select either backend for supervisor review.
 
 ## Quick Start
 
@@ -90,7 +90,7 @@ Galley includes a plugin that packages one Agent Skill for Claude Code and Codex
 Profiles are worth setting up early. They tell Galley which commands are available, which quality checks are required, what evidence the supervisor should expect, and which findings should block acceptance. The skill can create these interactively from the target repository.
 
 - **Task authoring**: clarify the user goal, target repo, scope, input files, acceptance criteria, verification, loop budget, supervisor, and PR behavior; write a draft task YAML, validate it, and queue it only after explicit user approval.
-- **Profile authoring**: interactively create `quality.yaml` and `environment.yaml` for repo-specific quality gates, commands, tools, network policy, secrets policy, PR behavior, and cleanup policy.
+- **Profile authoring**: interactively create `quality.yaml` and `environment.yaml` for repo-specific quality gates, commands, tools, implementation executor defaults, network policy, secrets policy, PR behavior, and cleanup policy.
 - **Setup**: install `galley`, verify `claude`, `codex`, and `gh` availability, configure workflow roots, and prepare daemon/PR automation commands.
 - **Troubleshooting**: inspect failed runs, stale claims, PR automation state, executor output, and recorded evidence.
 
@@ -114,8 +114,8 @@ The standalone skill still expects the `galley` CLI on `PATH`. Some workflows al
 
 - **Task YAML**: the trusted local input that defines the goal, acceptance criteria, scope, verification, execution policy, and PR behavior. See [docs/task-yaml.md](docs/task-yaml.md).
 - **Quality profile**: optional repo-specific review gates, required checks, pass policy, and evidence requirements. See [docs/profiles.md](docs/profiles.md).
-- **Environment profile**: optional repo-specific command map and execution constraints for network, secrets, and destructive operations. See [docs/profiles.md](docs/profiles.md).
-- **Executor**: the backend that implements the task in the worktree. Claude Code is the default; Codex can be selected per task.
+- **Environment profile**: optional repo-specific command map, implementation executor default, and execution constraints for network, secrets, and destructive operations. See [docs/profiles.md](docs/profiles.md).
+- **Executor**: the backend that implements the task in the worktree. New task authoring uses the repository executor default when set, otherwise Codex; either backend can be selected per task.
 - **Supervisor**: the backend that reviews executor work against acceptance criteria, required quality checks, and recorded evidence. Claude is the default; Codex can be selected per daemon.
 - **AFK task**: an unattended task that can run asynchronously inside a managed worktree.
 - **Acceptance criterion ID**: the `acceptance_criteria[].id` value the executor must report back with evidence, for example `AC1`.
@@ -349,7 +349,7 @@ With `pr.comments.reply: true`, Galley posts a concise acknowledgement comment a
 
 ## Executors
 
-Executor backends are selected per task in task YAML. Claude Code is the default; set `executor.cli: codex` to run a task with Codex instead. Acceptance skeleton preflight, structured executor results, run evidence, and supervisor review use the same contracts across both backends.
+New task authoring resolves the executor backend from `environment.yaml` `executor.default_cli` when present and otherwise uses Codex. An explicit task YAML `executor.cli` remains authoritative for that task and may select `claude` or `codex`. Acceptance skeleton preflight, structured executor results, run evidence, and supervisor review use the same contracts across both backends.
 
 See [docs/task-yaml.md](docs/task-yaml.md) for the full `executor` block and [examples/afk-task-codex.yaml](examples/afk-task-codex.yaml) for a Codex task example.
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -87,6 +87,8 @@ cwd: "/path/to/repo"
 commands:
   test_unit: "go test ./..."
   build: "go build ./cmd/galley"
+executor:
+  default_cli: "codex"
 constraints:
   network: "approval_required"
   secrets_policy: "never_read_env_files"
@@ -106,6 +108,7 @@ Supported fields:
 - `id`: profile identifier.
 - `cwd`: absolute path to the repository this profile describes.
 - `commands`: named local commands the executor and supervisor can reference.
+- `executor.default_cli`: optional implementation executor default for new task authoring. Values are `claude` and `codex`. When it is unset, new task authoring uses Codex unless the author explicitly chooses another backend. An explicit task YAML `executor.cli` remains authoritative for that task.
 - `constraints.network`: local network policy.
 - `constraints.secrets_policy`: secret handling policy.
 - `constraints.destructive_commands`: destructive command policy.

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -40,11 +40,11 @@ worktree:
 supervisor:
   review_iterations: 0
 executor:
-  cli: "claude"
+  cli: "codex"
   effort: "high"
-  prompt_profile: "codexized-claude-executor-v1"
+  prompt_profile: "codex-executor-v1"
   prompt_mode: "replace"
-  max_budget_usd: 10
+  max_budget_usd: 4
 decisions: []
 risks: []
 attempts: []
@@ -89,7 +89,7 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `execution_policy.stop_on_destructive_operation`: stop when the task would require out-of-scope destructive work.
 - `execution_policy.stop_on_missing_secret`: stop when a required secret is unavailable and cannot be replaced by safe local evidence.
 - `execution_policy.stop_on_external_service_unavailable`: stop when a required external service is unavailable and the task cannot proceed with local substitutes.
-- `executor.cli`: selects the executor backend. Accepts `claude` (Claude Code) or `codex` (`codex exec`). The daemon dispatches the implementation attempt through the matching binary and persists per-attempt evidence under `runs/<run-id>/attempt-N/` for both. The Codex executor uses a Codex-specific executor prompt that preserves the same task/result contract as the Claude executor prompt.
+- `executor.cli`: selects the executor backend. Accepts `claude` (Claude Code) or `codex` (`codex exec`). The daemon dispatches the implementation attempt through the matching binary and persists per-attempt evidence under `runs/<run-id>/attempt-N/` for both. New task authoring resolves this value from `environment.yaml` `executor.default_cli` when present and uses Codex when no environment default is configured; an explicit task YAML value is still authoritative for that task. The Codex executor uses a Codex-specific executor prompt that preserves the same task/result contract as the Claude executor prompt.
 - `executor.model`: optional model override for the executor command. Omit it to use the selected CLI's configured default model; write it only when you want to pin a model name. Available model names depend on the user's account, provider, CLI configuration, and CLI version, so a pinned value should be smoke-tested when in doubt.
 - `executor.effort`: model effort hint for the executor command. Claude accepts `low`, `medium`, `high`, `xhigh`, or `max`; Codex accepts `low`, `medium`, or `high`. For `codex`, effort is delivered via `-c model_reasoning_effort="<value>"` because `codex exec` does not expose a top-level `--effort` flag and `-c` expects TOML-style values.
 - `executor.prompt_profile`: prompt profile name recorded for evidence.

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -44,7 +44,6 @@ executor:
   effort: "high"
   prompt_profile: "codex-executor-v1"
   prompt_mode: "replace"
-  max_budget_usd: 4
 decisions: []
 risks: []
 attempts: []
@@ -94,7 +93,7 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `executor.effort`: model effort hint for the executor command. Claude accepts `low`, `medium`, `high`, `xhigh`, or `max`; Codex accepts `low`, `medium`, or `high`. For `codex`, effort is delivered via `-c model_reasoning_effort="<value>"` because `codex exec` does not expose a top-level `--effort` flag and `-c` expects TOML-style values.
 - `executor.prompt_profile`: prompt profile name recorded for evidence.
 - `executor.prompt_mode`: `replace` or `append`. For `codex`, both modes currently produce the same effective prompt ordering because Galley concatenates the system prompt and work order through `codex exec` stdin; `append` is accepted for schema compatibility and recorded as an informational warning.
-- `executor.max_budget_usd`: non-negative execution budget hint. Claude honors this hint via its CLI flag; `codex exec` has no equivalent flag, so the value is recorded for audit and the runner surfaces an informational warning. See `examples/afk-task-codex.yaml` for a complete Codex example.
+- `executor.max_budget_usd`: optional non-negative execution budget hint. Claude honors this hint via its CLI flag, so explicit Claude tasks may set it when a per-run ceiling is useful. `codex exec` has no equivalent flag; Codex tasks may still carry an explicit value for audit, but new Codex skeletons omit it to avoid implying an enforced cost limit.
 
 ## Permissions
 

--- a/examples/afk-task-codex.yaml
+++ b/examples/afk-task-codex.yaml
@@ -33,7 +33,6 @@ executor:
   effort: "high"
   prompt_profile: "codex-executor-v1"
   prompt_mode: "replace"
-  max_budget_usd: 10
 decisions: []
 risks: []
 attempts: []

--- a/examples/environment-local.yaml
+++ b/examples/environment-local.yaml
@@ -3,6 +3,8 @@ cwd: "/Users/shinpr/Projects/galley"
 commands:
   test_unit: "go test ./..."
   build: "go build ./cmd/galley"
+executor:
+  default_cli: "codex"
 constraints:
   network: "approval_required"
   secrets_policy: "never_read_env_files"

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/shinpr/galley/internal/fileutil"
 	"github.com/shinpr/galley/internal/galleyhome"
@@ -18,6 +19,7 @@ func newProfileCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newProfileValidateCommand())
 	cmd.AddCommand(newProfileResolveCommand())
+	cmd.AddCommand(newProfileExecutorDefaultCommand())
 	return cmd
 }
 
@@ -119,6 +121,40 @@ func newProfileValidateCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&kind, "kind", "", "Profile kind: quality or environment; inferred from fields when omitted")
+	cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format: text or json")
+	return cmd
+}
+
+func newProfileExecutorDefaultCommand() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:    "executor-default ENVIRONMENT.yaml",
+		Short:  "Print the implementation executor default from an environment profile",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			env, err := profile.LoadEnvironment(args[0])
+			if err != nil {
+				return err
+			}
+			result := profile.ValidateEnvironment(env)
+			if !result.Valid() {
+				return fmt.Errorf("invalid environment profile %s: %s", args[0], strings.Join(result.Errors, "; "))
+			}
+			payload := struct {
+				DefaultCLI string `json:"default_cli,omitempty"`
+			}{}
+			if env.Executor != nil {
+				payload.DefaultCLI = env.Executor.DefaultCLI
+			}
+			return renderOutput(cmd, output, payload, func() error {
+				if payload.DefaultCLI != "" {
+					fmt.Fprintln(cmd.OutOrStdout(), payload.DefaultCLI)
+				}
+				return nil
+			})
+		},
+	}
 	cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format: text or json")
 	return cmd
 }

--- a/internal/daemon/acceptance_skeleton_creator.go
+++ b/internal/daemon/acceptance_skeleton_creator.go
@@ -108,7 +108,7 @@ func buildBuiltinCreatorCommandPlan(opts AcceptanceSkeletonPreflightOptions, pay
 		JSONSchema:     schemas.AcceptanceSkeletonManifest,
 		PromptMode:     "replace",
 		PermissionMode: "bypassPermissions",
-		MaxBudgetUSD:   opts.Task.Executor.MaxBudgetUSD,
+		MaxBudgetUSD:   opts.Task.Executor.MaxBudgetUSDValue(),
 		PluginDirs:     []string{guardDir},
 	})
 	if err != nil {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -48,9 +48,14 @@ type Environment struct {
 	ID          string            `yaml:"id" json:"id"`
 	CWD         string            `yaml:"cwd" json:"cwd"`
 	Commands    map[string]string `yaml:"commands" json:"commands"`
+	Executor    *ExecutorDefault  `yaml:"executor,omitempty" json:"executor,omitempty"`
 	Constraints Constraints       `yaml:"constraints" json:"constraints"`
 	PR          PRSettings        `yaml:"pr,omitempty" json:"pr,omitempty"`
 	Worktree    WorktreeSettings  `yaml:"worktree,omitempty" json:"worktree,omitempty"`
+}
+
+type ExecutorDefault struct {
+	DefaultCLI string `yaml:"default_cli,omitempty" json:"default_cli,omitempty"`
 }
 
 type Constraints struct {
@@ -175,10 +180,22 @@ func ValidateEnvironment(env Environment) ValidationResult {
 	require(&result, env.Constraints.Network != "", "constraints.network is required")
 	require(&result, env.Constraints.SecretsPolicy != "", "constraints.secrets_policy is required")
 	require(&result, env.Constraints.DestructiveCommands != "", "constraints.destructive_commands is required")
+	if env.Executor != nil && env.Executor.DefaultCLI != "" {
+		require(&result, validExecutorCLI(env.Executor.DefaultCLI), "executor.default_cli must be one of: claude, codex")
+	}
 	if env.PR.Comments.Reply && !env.PR.Comments.Enabled {
 		result.Warnings = append(result.Warnings, "pr.comments.reply is set while pr.comments.enabled is false")
 	}
 	return result
+}
+
+func validExecutorCLI(value string) bool {
+	switch value {
+	case "claude", "codex":
+		return true
+	default:
+		return false
+	}
 }
 
 func loadYAML(path string, out any) error {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -41,6 +41,9 @@ func TestLoadAndValidateEnvironmentExample(t *testing.T) {
 	if env.Commands["test_unit"] == "" {
 		t.Fatalf("commands got %#v", env.Commands)
 	}
+	if env.Executor == nil || env.Executor.DefaultCLI != "codex" {
+		t.Fatalf("executor default got %#v", env.Executor)
+	}
 }
 
 func TestLoadBundleRejectsInvalidQuality(t *testing.T) {
@@ -101,5 +104,26 @@ constraints:
 	}
 	if !strings.Contains(err.Error(), "constraints.network") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEnvironmentRejectsInvalidExecutorDefault(t *testing.T) {
+	env := Environment{
+		ID:       "local",
+		CWD:      "/tmp/repo",
+		Commands: map[string]string{"test": "go test ./..."},
+		Executor: &ExecutorDefault{DefaultCLI: "other"},
+		Constraints: Constraints{
+			Network:             "approval_required",
+			SecretsPolicy:       "never_read_env_files",
+			DestructiveCommands: "deny",
+		},
+	}
+	result := ValidateEnvironment(env)
+	if result.Valid() {
+		t.Fatal("expected invalid executor default")
+	}
+	if !strings.Contains(strings.Join(result.Errors, "\n"), "executor.default_cli") {
+		t.Fatalf("errors missing executor.default_cli: %#v", result.Errors)
 	}
 }

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -62,6 +62,11 @@ func EnvironmentJSONSchema() ([]byte, error) {
 			"id":       stringSchema("minLength", 1, "description", "Repository environment profile identifier."),
 			"cwd":      stringSchema("minLength", 1, "description", "Absolute path to the target repository."),
 			"commands": map[string]any{"type": "object", "additionalProperties": stringSchema("minLength", 1)},
+			"executor": object(
+				properties(map[string]any{
+					"default_cli": enumSchema([]string{"claude", "codex"}),
+				}),
+			),
 			"constraints": object(
 				required("network", "secrets_policy", "destructive_commands"),
 				properties(map[string]any{

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -59,7 +59,7 @@ func FromTask(t task.Task) ClaudeOptions {
 		Model:          t.Executor.Model,
 		Effort:         t.Executor.Effort,
 		PromptMode:     promptMode,
-		MaxBudgetUSD:   t.Executor.MaxBudgetUSD,
+		MaxBudgetUSD:   t.Executor.MaxBudgetUSDValue(),
 		PermissionMode: permissionMode,
 		WorkDir:        t.Scope.CWD,
 	}

--- a/internal/runner/claude_test.go
+++ b/internal/runner/claude_test.go
@@ -107,6 +107,39 @@ func TestClaudeCommandPlanUsesEmbeddedPromptAndSchemaByDefault(t *testing.T) {
 	}
 }
 
+func TestClaudeFromTaskUsesExplicitExecutorBudget(t *testing.T) {
+	t.Parallel()
+	budget := 6.25
+	tk := task.Task{
+		Scope: task.Scope{
+			CWD:        "/tmp/project",
+			Permission: "edit",
+		},
+		Executor: task.Executor{
+			CLI:           "claude",
+			Effort:        "high",
+			PromptProfile: "codexized-claude-executor-v1",
+			PromptMode:    "replace",
+			MaxBudgetUSD:  &budget,
+		},
+	}
+	opts := FromTask(tk)
+	opts.SystemPrompt = "system"
+	opts.JSONSchema = `{"type":"object"}`
+	opts.Prompt = "do the work"
+
+	argv, err := ClaudeArgv(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == "--max-budget-usd" && argv[i+1] == "6.25" {
+			return
+		}
+	}
+	t.Fatalf("explicit task budget did not reach Claude argv: %#v", argv)
+}
+
 func TestClaudeArgvRejectsUnknownPromptMode(t *testing.T) {
 	t.Parallel()
 	promptPath, _ := writePromptFixtures(t)

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -82,7 +82,7 @@ func CodexFromTask(t task.Task) CodexOptions {
 		Model:        t.Executor.Model,
 		Effort:       t.Executor.Effort,
 		PromptMode:   promptMode,
-		MaxBudgetUSD: t.Executor.MaxBudgetUSD,
+		MaxBudgetUSD: t.Executor.MaxBudgetUSDValue(),
 		Sandbox:      sandbox,
 		WorkDir:      t.Scope.CWD,
 	}

--- a/internal/runner/codex_argv_test.go
+++ b/internal/runner/codex_argv_test.go
@@ -14,7 +14,8 @@ import (
 func TestCodexArgvDoesNotEmitUnsupportedFlags(t *testing.T) {
 	t.Parallel()
 	base := minimalCodexTask()
-	base.Executor.MaxBudgetUSD = 4
+	budget := 4.0
+	base.Executor.MaxBudgetUSD = &budget
 	opts := CodexFromTask(base)
 	opts.Bin = "/usr/local/bin/codex"
 	opts.WorkDir = "/tmp/codex-argv"

--- a/internal/task/load_test.go
+++ b/internal/task/load_test.go
@@ -175,6 +175,70 @@ func TestSaveOmitsEmptyExecutorModel(t *testing.T) {
 	}
 }
 
+func TestSavePreservesOmittedExecutorMaxBudgetUSD(t *testing.T) {
+	t.Parallel()
+	path := writeTaskYAML(t, "loop_budget: 3")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.ReplaceAll(string(data), "  max_budget_usd: 0\n", ""))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Executor.MaxBudgetUSD != nil {
+		t.Fatalf("omitted executor.max_budget_usd loaded as %#v", loaded.Executor.MaxBudgetUSD)
+	}
+	loaded.Executor.CLI = "codex"
+	loaded.Executor.Model = ""
+	loaded.Executor.Effort = "high"
+	loaded.Executor.PromptProfile = "codex-executor-v1"
+
+	if err := Save(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(saved), "max_budget_usd:") {
+		t.Fatalf("omitted executor.max_budget_usd should stay omitted, got:\n%s", string(saved))
+	}
+}
+
+func TestSaveRoundTripsExplicitPositiveExecutorMaxBudgetUSD(t *testing.T) {
+	t.Parallel()
+	path := writeTaskYAML(t, "loop_budget: 3")
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.MaxBudgetUSD = float64Ptr(4.5)
+
+	if err := Save(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+	roundTripped, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roundTripped.Executor.MaxBudgetUSD == nil || *roundTripped.Executor.MaxBudgetUSD != 4.5 {
+		t.Fatalf("explicit executor.max_budget_usd did not round trip: %#v", roundTripped.Executor.MaxBudgetUSD)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "max_budget_usd: 4.5") {
+		t.Fatalf("explicit executor.max_budget_usd should be saved, got:\n%s", string(data))
+	}
+}
+
 func writeTaskYAML(t *testing.T, loopBudgetLine string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/task/preflight_validation_test.go
+++ b/internal/task/preflight_validation_test.go
@@ -42,7 +42,7 @@ func baseValidPreflightTask() Task {
 			Effort:        "high",
 			PromptProfile: "p",
 			PromptMode:    "replace",
-			MaxBudgetUSD:  1,
+			MaxBudgetUSD:  float64Ptr(1),
 		},
 	}
 }

--- a/internal/task/queue_test.go
+++ b/internal/task/queue_test.go
@@ -102,6 +102,54 @@ func TestQueuePreservesOmittedExecutorModel(t *testing.T) {
 	}
 }
 
+func TestQueuePreservesOmittedCodexSkeletonMaxBudgetUSD(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	draftPath := filepath.Join(root, "tasks", "draft", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(draftPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := writeTaskYAML(t, "loop_budget: 3")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.ReplaceAll(string(data), "  model: \"opus\"\n", ""))
+	data = []byte(strings.ReplaceAll(string(data), "  cli: \"claude\"\n", "  cli: \"codex\"\n"))
+	data = []byte(strings.ReplaceAll(string(data), "  prompt_profile: \"codexized-claude-executor-v1\"\n", "  prompt_profile: \"codex-executor-v1\"\n"))
+	data = []byte(strings.ReplaceAll(string(data), "  max_budget_usd: 0\n", ""))
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Status = "draft"
+	if loaded.Executor.MaxBudgetUSD != nil {
+		t.Fatalf("test fixture should omit executor.max_budget_usd, got %#v", loaded.Executor.MaxBudgetUSD)
+	}
+	if err := Save(draftPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Queue(draftPath, QueueOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Task.Executor.MaxBudgetUSD != nil {
+		t.Fatalf("queued Codex skeleton budget got %#v, want omitted", result.Task.Executor.MaxBudgetUSD)
+	}
+	queuedPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	saved, err := os.ReadFile(queuedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(saved), "max_budget_usd:") {
+		t.Fatalf("queued Codex skeleton should omit executor.max_budget_usd, got:\n%s", string(saved))
+	}
+}
+
 func TestQueueCopiesExternalDraftIntoRoot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/task/schema.go
+++ b/internal/task/schema.go
@@ -120,7 +120,7 @@ func supervisorSchema() map[string]any {
 
 func executorSchema() map[string]any {
 	return object(
-		required("cli", "effort", "prompt_profile", "prompt_mode", "max_budget_usd"),
+		required("cli", "effort", "prompt_profile", "prompt_mode"),
 		properties(map[string]any{
 			"cli":            enumSchema(validExecutorCLIs),
 			"model":          stringSchema("minLength", 1),

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -172,12 +172,21 @@ type Supervisor struct {
 
 // Executor configures the implementation worker for a task.
 type Executor struct {
-	CLI           string  `yaml:"cli" json:"cli"`
-	Model         string  `yaml:"model,omitempty" json:"model,omitempty"`
-	Effort        string  `yaml:"effort" json:"effort"`
-	PromptProfile string  `yaml:"prompt_profile" json:"prompt_profile"`
-	PromptMode    string  `yaml:"prompt_mode" json:"prompt_mode"`
-	MaxBudgetUSD  float64 `yaml:"max_budget_usd" json:"max_budget_usd"`
+	CLI           string   `yaml:"cli" json:"cli"`
+	Model         string   `yaml:"model,omitempty" json:"model,omitempty"`
+	Effort        string   `yaml:"effort" json:"effort"`
+	PromptProfile string   `yaml:"prompt_profile" json:"prompt_profile"`
+	PromptMode    string   `yaml:"prompt_mode" json:"prompt_mode"`
+	MaxBudgetUSD  *float64 `yaml:"max_budget_usd,omitempty" json:"max_budget_usd,omitempty"`
+}
+
+// MaxBudgetUSDValue returns the configured executor budget or zero when the
+// task omitted executor.max_budget_usd.
+func (e Executor) MaxBudgetUSDValue() float64 {
+	if e.MaxBudgetUSD == nil {
+		return 0
+	}
+	return *e.MaxBudgetUSD
 }
 
 // Decision records an ambiguity resolved during execution.

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -208,7 +208,9 @@ func validateExecutor(result *ValidationResult, t Task) {
 	} else {
 		require(result, slices.Contains(validPromptModes, t.Executor.PromptMode), "executor.prompt_mode must be one of: %s", strings.Join(validPromptModes, ", "))
 	}
-	require(result, t.Executor.MaxBudgetUSD >= 0, "executor.max_budget_usd cannot be negative")
+	if t.Executor.MaxBudgetUSD != nil {
+		require(result, *t.Executor.MaxBudgetUSD >= 0, "executor.max_budget_usd cannot be negative")
+	}
 }
 
 func validatePreflight(result *ValidationResult, t Task) {

--- a/internal/task/validate_test.go
+++ b/internal/task/validate_test.go
@@ -129,6 +129,13 @@ func TestValidateStructuralRejectsInvalidCases(t *testing.T) {
 			want: "executor.prompt_mode must be one of",
 		},
 		{
+			name: "negative explicit executor budget",
+			mutate: func(task *Task) {
+				task.Executor.MaxBudgetUSD = float64Ptr(-1)
+			},
+			want: "executor.max_budget_usd cannot be negative",
+		},
+		{
 			name: "duplicate ac id",
 			mutate: func(task *Task) {
 				task.AcceptanceCriteria = append(task.AcceptanceCriteria, task.AcceptanceCriteria[0])
@@ -379,4 +386,8 @@ func validTask(t *testing.T) Task {
 			PromptMode:    "replace",
 		},
 	}
+}
+
+func float64Ptr(v float64) *float64 {
+	return &v
 }

--- a/internal/task/workorder.go
+++ b/internal/task/workorder.go
@@ -175,6 +175,9 @@ func renderProfileContext(b *strings.Builder, profiles profile.Bundle) {
 		for name, command := range profiles.Environment.Commands {
 			fmt.Fprintf(b, "- command `%s`: `%s`\n", name, command)
 		}
+		if profiles.Environment.Executor != nil && profiles.Environment.Executor.DefaultCLI != "" {
+			fmt.Fprintf(b, "- executor default: `%s`\n", profiles.Environment.Executor.DefaultCLI)
+		}
 		fmt.Fprintf(b, "- network: `%s`\n", profiles.Environment.Constraints.Network)
 		fmt.Fprintf(b, "- secrets policy: `%s`\n", profiles.Environment.Constraints.SecretsPolicy)
 		fmt.Fprintf(b, "- destructive commands: `%s`\n", profiles.Environment.Constraints.DestructiveCommands)

--- a/internal/task/workorder_test.go
+++ b/internal/task/workorder_test.go
@@ -24,6 +24,7 @@ func TestRenderWorkOrderWithProfiles(t *testing.T) {
 			ID:       "local",
 			CWD:      loaded.Scope.CWD,
 			Commands: map[string]string{"build": "go build ./cmd/galley"},
+			Executor: &profile.ExecutorDefault{DefaultCLI: "codex"},
 			Constraints: profile.Constraints{
 				Network:             "approval_required",
 				SecretsPolicy:       "never_read_env_files",
@@ -31,7 +32,7 @@ func TestRenderWorkOrderWithProfiles(t *testing.T) {
 			},
 		},
 	})
-	for _, want := range []string{"## Quality Profile", "go test ./...", "## Environment Profile", "never_read_env_files"} {
+	for _, want := range []string{"## Quality Profile", "go test ./...", "## Environment Profile", "executor default: `codex`", "never_read_env_files"} {
 		if !strings.Contains(workOrder, want) {
 			t.Fatalf("work order missing %q:\n%s", want, workOrder)
 		}

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/environment.schema.json
+++ b/plugins/galley/skills/galley/references/environment.schema.json
@@ -40,6 +40,19 @@
       "minLength": 1,
       "type": "string"
     },
+    "executor": {
+      "additionalProperties": false,
+      "properties": {
+        "default_cli": {
+          "enum": [
+            "claude",
+            "codex"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "id": {
       "description": "Repository environment profile identifier.",
       "minLength": 1,

--- a/plugins/galley/skills/galley/references/handoff-and-queueing.md
+++ b/plugins/galley/skills/galley/references/handoff-and-queueing.md
@@ -63,6 +63,33 @@ Main path: `galley task queue` targets the running daemon queue, or the default 
 
 Advanced roots: pass `--root <path>` only when the user explicitly chose a non-default root.
 
+## Post-Queue PR Review Loop
+
+Use this section when a Galley-created PR needs another executor pass from a PR comment.
+
+A PR comment is treated as a Galley command when the trimmed comment body starts with `/galley`.
+
+Accepted forms:
+
+- `/galley <free-form revision request>`
+- `/galley rerun <free-form revision request>`
+- `/galley requeue <free-form revision request>`
+- `/galley`
+
+The free-form text becomes a pending revision request and the task is requeued when its state allows requeueing. Use concrete revision instructions with acceptance or verification detail. Use normal GitHub comments for discussion that should not trigger another executor run.
+
+Ignored forms:
+
+- Mid-line mentions such as `Looks good, /galley rerun`
+- `/galley` after another non-whitespace line
+- `/galley:galley ...`
+- `/galleyfoo ...`
+
+Trust boundary:
+
+- Galley accepts PR comment commands only from the recorded PR author.
+- Keep secrets out of PR comments because the parsed request is stored in task YAML as revision request input.
+
 ## Common Validation Fixes
 
 | Validation Message | Fix |

--- a/plugins/galley/skills/galley/references/handoff-and-queueing.md
+++ b/plugins/galley/skills/galley/references/handoff-and-queueing.md
@@ -76,7 +76,9 @@ Accepted forms:
 - `/galley requeue <free-form revision request>`
 - `/galley`
 
-The free-form text becomes a pending revision request and the task is requeued when its state allows requeueing. Use concrete revision instructions with acceptance or verification detail. Use normal GitHub comments for discussion that should not trigger another executor run.
+The parsed text becomes a pending revision request. A bare `/galley` uses the default request text `PR comment requested another Galley run.` Use concrete revision instructions with acceptance or verification detail when the next executor pass needs specific changes.
+
+PR comment polling scans reviewed tasks under `tasks/done` and `tasks/failed`. A command on a task with status `accepted`, `pr_opened`, `needs_supervisor_review`, `failed`, `closed`, or `merged` requeues the task. If the task is already `queued` or `running`, Galley records the pending revision request and does not move the task again. Use normal GitHub comments for discussion that should not trigger another executor run.
 
 Ignored forms:
 
@@ -88,7 +90,7 @@ Ignored forms:
 Trust boundary:
 
 - Galley accepts PR comment commands only from the recorded PR author.
-- Keep secrets out of PR comments because the parsed request is stored in task YAML as revision request input.
+- Treat PR comment text as persistent task input because the parsed request is stored in task YAML as revision request input. Provide secrets through an approved repository-specific channel instead of PR comments.
 
 ## Common Validation Fixes
 

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -15,6 +15,11 @@ Use `references/authoring-quality.md` to decide when to use existing repo standa
 
 The daemon resolves repository profiles from `scope.cwd` and the Galley root.
 
+Backend defaults are intentionally separate:
+
+- Implementation executor default: stored in `environment.yaml` as `executor.default_cli`; unset resolves to Codex when a new task is authored.
+- Review supervisor default: daemon startup state, not an environment profile field; unset resolves to Claude when the daemon starts.
+
 Use the bundled schemas as the profile field contract:
 
 - `references/quality.schema.json`
@@ -36,7 +41,7 @@ galley profile validate --kind environment <profile.yaml>
    - `environment.yaml` defines the repository cwd, runnable commands, implementation executor default, network/secrets policy, services, destructive-operation constraints, PR behavior, and worktree cleanup.
 2. Read `references/quality.schema.json` and `references/environment.schema.json` to establish fields, defaults, and valid shapes.
 3. Ask the user to choose review strictness before repository inspection. This is an operating policy, not repository evidence.
-4. Ask for the implementation executor choice before repository inspection. Ask for a review supervisor choice only when profile authoring is part of setup or daemon startup planning. Each can be `claude` or `codex`; an unset executor resolves to Codex during new task authoring, and an unset supervisor resolves to the daemon's Claude default.
+4. Ask for the implementation executor choice before repository inspection. Ask for a review supervisor choice only when profile authoring is part of setup or daemon startup planning. Use the backend default rule above for unset values.
 5. Ask to inspect the repository for profile candidates. Mention the concrete sources you plan to read, such as README, CI, package scripts, Makefiles, justfiles, test docs, and existing local guidance.
 6. Inspect the approved sources and draft candidate values from discovered evidence plus schema defaults and the chosen review strictness.
 7. Present the proposed profile before writing files: required checks, optional checks, review dimensions, blocking severities, implementation executor default, environment constraints, PR/base/comment/cleanup settings, and the evidence behind each choice. If a supervisor was chosen, present it separately as daemon startup state rather than as an `environment.yaml` field.
@@ -75,7 +80,7 @@ Use this sequence:
 
 1. Read the profile schemas.
 2. Ask one question for review strictness.
-3. Ask the implementation executor choice. Ask the review supervisor choice only when this profile work is part of setup or daemon startup planning. Each can be `claude` or `codex`; if unset, new task authoring resolves the executor to Codex and daemon startup resolves the supervisor to Claude.
+3. Ask the implementation executor choice. Ask the review supervisor choice only when this profile work is part of setup or daemon startup planning. Use the backend default rule above for unset values.
 4. Ask one question for repository inspection approval. Keep PR automation, base branch, and cleanup out of this question.
 5. After inspection, present a single profile proposal using schema defaults, chosen review strictness, executor choice, and discovered repo evidence. Present any supervisor choice outside the profile proposal as daemon startup state.
 6. Ask for profile approval and additional repository-specific standards.

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -11,7 +11,7 @@ Use `references/authoring-quality.md` to decide when to use existing repo standa
 | Profile | Purpose |
 | --- | --- |
 | quality | Defines required checks, review dimensions, evidence requirements, and pass policy. |
-| environment | Defines cwd, available commands, network/secrets/destructive-command constraints, PR behavior, PR comment handling, base branch, and worktree cleanup. |
+| environment | Defines cwd, available commands, the implementation executor default, network/secrets/destructive-command constraints, PR behavior, PR comment handling, base branch, and worktree cleanup. |
 
 The daemon resolves repository profiles from `scope.cwd` and the Galley root.
 
@@ -33,15 +33,16 @@ galley profile validate --kind environment <profile.yaml>
 
 1. Explain the two profiles before reading or writing them:
    - `quality.yaml` defines the checks, review dimensions, evidence, and severities that Galley uses to decide whether work is acceptable.
-   - `environment.yaml` defines the repository cwd, runnable commands, network/secrets policy, services, destructive-operation constraints, PR behavior, and worktree cleanup.
+   - `environment.yaml` defines the repository cwd, runnable commands, implementation executor default, network/secrets policy, services, destructive-operation constraints, PR behavior, and worktree cleanup.
 2. Read `references/quality.schema.json` and `references/environment.schema.json` to establish fields, defaults, and valid shapes.
 3. Ask the user to choose review strictness before repository inspection. This is an operating policy, not repository evidence.
-4. Ask to inspect the repository for profile candidates. Mention the concrete sources you plan to read, such as README, CI, package scripts, Makefiles, justfiles, test docs, and existing local guidance.
-5. Inspect the approved sources and draft candidate values from discovered evidence plus schema defaults and the chosen review strictness.
-6. Present the proposed profile before writing files: required checks, optional checks, review dimensions, blocking severities, environment constraints, PR/base/comment/cleanup settings, and the evidence behind each choice.
-7. Ask for approval and ask whether the user has additional repository-specific standards to enforce.
-8. Write the profile YAML only after approval.
-9. Validate the profile YAML and report the evidence used to choose each required check.
+4. Ask for the implementation executor and review supervisor choices before repository inspection. Each can be `claude` or `codex`; unset executor choices resolve through the documented task-authoring default, and unset supervisor choices resolve through the daemon default.
+5. Ask to inspect the repository for profile candidates. Mention the concrete sources you plan to read, such as README, CI, package scripts, Makefiles, justfiles, test docs, and existing local guidance.
+6. Inspect the approved sources and draft candidate values from discovered evidence plus schema defaults and the chosen review strictness.
+7. Present the proposed profile before writing files: required checks, optional checks, review dimensions, blocking severities, implementation executor default, environment constraints, PR/base/comment/cleanup settings, and the evidence behind each choice.
+8. Ask for approval and ask whether the user has additional repository-specific standards to enforce.
+9. Write the profile YAML only after approval.
+10. Validate the profile YAML and report the evidence used to choose each required check.
 
 ## Repository Discovery
 
@@ -74,10 +75,11 @@ Use this sequence:
 
 1. Read the profile schemas.
 2. Ask one question for review strictness.
-3. Ask one question for repository inspection approval. Keep supervisor selection, PR automation, base branch, and cleanup out of this question.
-4. After inspection, present a single profile proposal using schema defaults, chosen review strictness, and discovered repo evidence.
-5. Ask for profile approval and additional repository-specific standards.
-6. Ask follow-up questions only for choices that affect acceptance, execution safety, unavailable services, or repository-specific policy.
+3. Ask the implementation executor and review supervisor choices. Each can be `claude` or `codex`; if unset, new task authoring resolves the executor through the documented default and daemon startup resolves the supervisor through its documented default.
+4. Ask one question for repository inspection approval. Keep PR automation, base branch, and cleanup out of this question.
+5. After inspection, present a single profile proposal using schema defaults, chosen review strictness, executor choice, and discovered repo evidence.
+6. Ask for profile approval and additional repository-specific standards.
+7. Ask follow-up questions only for choices that affect acceptance, execution safety, unavailable services, or repository-specific policy.
 
 Review strictness question:
 
@@ -104,13 +106,15 @@ Environment profile questions:
 
 1. What is the target repo absolute path?
 2. Which discovered commands are available and safe to run repeatedly?
-3. Does the repo require local services: DB, Docker, Redis, browser, dev server, Figma MCP, Playwright, cloud CLI?
-4. Is network access allowed, approval-gated, or unavailable?
-5. What is the secret policy: never read `.env`, allow named test env vars, use local dummy credentials, or require human setup?
-6. Which destructive operations are denied or approval-gated: DB reset, migrations, docker prune, file deletion, terraform apply?
-7. Should accepted AFK implementation tasks open PRs by default, and what base branch should they target?
-8. Should `/galley rerun` and `/galley requeue` PR comments be polled and acknowledged?
-9. Should Galley clean up its managed clean worktrees after PRs are closed or merged?
+3. Which implementation executor should new tasks use by default: `claude`, `codex`, or unset so authoring resolves through the documented default?
+4. Which review supervisor should the daemon use: `claude`, `codex`, or unset so daemon startup resolves through the documented default?
+5. Does the repo require local services: DB, Docker, Redis, browser, dev server, Figma MCP, Playwright, cloud CLI?
+6. Is network access allowed, approval-gated, or unavailable?
+7. What is the secret policy: never read `.env`, allow named test env vars, use local dummy credentials, or require human setup?
+8. Which destructive operations are denied or approval-gated: DB reset, migrations, docker prune, file deletion, terraform apply?
+9. Should accepted AFK implementation tasks open PRs by default, and what base branch should they target?
+10. Should `/galley rerun` and `/galley requeue` PR comments be polled and acknowledged?
+11. Should Galley clean up its managed clean worktrees after PRs are closed or merged?
 
 ## Quality Profile Template
 
@@ -152,6 +156,8 @@ commands:
   test_unit: "<unit test command>"
   typecheck: "<typecheck command>"
   build: "<build command>"
+executor:
+  default_cli: "codex"
 constraints:
   network: "approval_required"
   secrets_policy: "never_read_env_files"
@@ -241,6 +247,7 @@ Blocking severities:
 - <severity list>
 
 Environment constraints:
+- executor default: <claude|codex|unset>
 - network: <value>
 - secrets: <value>
 - destructive commands: <value>

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -36,10 +36,10 @@ galley profile validate --kind environment <profile.yaml>
    - `environment.yaml` defines the repository cwd, runnable commands, implementation executor default, network/secrets policy, services, destructive-operation constraints, PR behavior, and worktree cleanup.
 2. Read `references/quality.schema.json` and `references/environment.schema.json` to establish fields, defaults, and valid shapes.
 3. Ask the user to choose review strictness before repository inspection. This is an operating policy, not repository evidence.
-4. Ask for the implementation executor and review supervisor choices before repository inspection. Each can be `claude` or `codex`; unset executor choices resolve through the documented task-authoring default, and unset supervisor choices resolve through the daemon default.
+4. Ask for the implementation executor choice before repository inspection. Ask for a review supervisor choice only when profile authoring is part of setup or daemon startup planning. Each can be `claude` or `codex`; an unset executor resolves to Codex during new task authoring, and an unset supervisor resolves to the daemon's Claude default.
 5. Ask to inspect the repository for profile candidates. Mention the concrete sources you plan to read, such as README, CI, package scripts, Makefiles, justfiles, test docs, and existing local guidance.
 6. Inspect the approved sources and draft candidate values from discovered evidence plus schema defaults and the chosen review strictness.
-7. Present the proposed profile before writing files: required checks, optional checks, review dimensions, blocking severities, implementation executor default, environment constraints, PR/base/comment/cleanup settings, and the evidence behind each choice.
+7. Present the proposed profile before writing files: required checks, optional checks, review dimensions, blocking severities, implementation executor default, environment constraints, PR/base/comment/cleanup settings, and the evidence behind each choice. If a supervisor was chosen, present it separately as daemon startup state rather than as an `environment.yaml` field.
 8. Ask for approval and ask whether the user has additional repository-specific standards to enforce.
 9. Write the profile YAML only after approval.
 10. Validate the profile YAML and report the evidence used to choose each required check.
@@ -75,9 +75,9 @@ Use this sequence:
 
 1. Read the profile schemas.
 2. Ask one question for review strictness.
-3. Ask the implementation executor and review supervisor choices. Each can be `claude` or `codex`; if unset, new task authoring resolves the executor through the documented default and daemon startup resolves the supervisor through its documented default.
+3. Ask the implementation executor choice. Ask the review supervisor choice only when this profile work is part of setup or daemon startup planning. Each can be `claude` or `codex`; if unset, new task authoring resolves the executor to Codex and daemon startup resolves the supervisor to Claude.
 4. Ask one question for repository inspection approval. Keep PR automation, base branch, and cleanup out of this question.
-5. After inspection, present a single profile proposal using schema defaults, chosen review strictness, executor choice, and discovered repo evidence.
+5. After inspection, present a single profile proposal using schema defaults, chosen review strictness, executor choice, and discovered repo evidence. Present any supervisor choice outside the profile proposal as daemon startup state.
 6. Ask for profile approval and additional repository-specific standards.
 7. Ask follow-up questions only for choices that affect acceptance, execution safety, unavailable services, or repository-specific policy.
 
@@ -106,14 +106,14 @@ Environment profile questions:
 
 1. What is the target repo absolute path?
 2. Which discovered commands are available and safe to run repeatedly?
-3. Which implementation executor should new tasks use by default: `claude`, `codex`, or unset so authoring resolves through the documented default?
-4. Which review supervisor should the daemon use: `claude`, `codex`, or unset so daemon startup resolves through the documented default?
+3. Which implementation executor should new tasks use by default: `claude`, `codex`, or unset so authoring resolves to Codex?
+4. If this setup will start or restart the daemon, which review supervisor should the daemon use: `claude`, `codex`, or unset so daemon startup resolves to Claude?
 5. Does the repo require local services: DB, Docker, Redis, browser, dev server, Figma MCP, Playwright, cloud CLI?
 6. Is network access allowed, approval-gated, or unavailable?
 7. What is the secret policy: never read `.env`, allow named test env vars, use local dummy credentials, or require human setup?
 8. Which destructive operations are denied or approval-gated: DB reset, migrations, docker prune, file deletion, terraform apply?
 9. Should accepted AFK implementation tasks open PRs by default, and what base branch should they target?
-10. Should `/galley rerun` and `/galley requeue` PR comments be polled and acknowledged?
+10. Should `/galley` PR comments be polled and acknowledged for reruns and revision requests?
 11. Should Galley clean up its managed clean worktrees after PRs are closed or merged?
 
 ## Quality Profile Template
@@ -248,6 +248,7 @@ Blocking severities:
 
 Environment constraints:
 - executor default: <claude|codex|unset>
+- daemon supervisor plan: <claude|codex|unset|not part of profile>
 - network: <value>
 - secrets: <value>
 - destructive commands: <value>

--- a/plugins/galley/skills/galley/references/setup.md
+++ b/plugins/galley/skills/galley/references/setup.md
@@ -90,6 +90,19 @@ Setup includes repository profiles. After resolving the profile paths:
 - Ask for approval and additional repository-specific standards before writing profiles.
 - Validate both profiles before reporting setup complete.
 
+When setup needs to ask for both backend choices, use this shape during profile intake:
+
+```markdown
+Galley can use `claude` or `codex` separately for implementation and review.
+
+- Implementation executor: writes the task changes in the worktree and is stored in `environment.yaml` as `executor.default_cli` for new task authoring.
+- Review supervisor: reviews completed attempts and is applied when starting or restarting the daemon.
+
+Which implementation executor should new tasks use? Which review supervisor should the daemon use?
+
+If the executor is left unset, new task authoring uses Codex. If the supervisor is left unset, the daemon uses Claude.
+```
+
 ```bash
 <galley-bin> profile validate --kind quality <quality-profile-file>
 <galley-bin> profile validate --kind environment <environment-profile-file>
@@ -126,16 +139,3 @@ Explicit Claude supervisor:
 For a single queue drain, use the same command shape with `run --once` instead of `start`.
 
 Repository profiles under the Galley root are loaded automatically from `scope.cwd`.
-
-When setup needs to ask for both backend choices, use this shape:
-
-```markdown
-Galley can use `claude` or `codex` separately for implementation and review.
-
-- Implementation executor: writes the task changes in the worktree and is stored in `environment.yaml` as `executor.default_cli` for new task authoring.
-- Review supervisor: reviews completed attempts and is applied when starting or restarting the daemon.
-
-Which implementation executor should new tasks use? Which review supervisor should the daemon use?
-
-If the executor is left unset, new task authoring uses Codex. If the supervisor is left unset, the daemon uses Claude.
-```

--- a/plugins/galley/skills/galley/references/setup.md
+++ b/plugins/galley/skills/galley/references/setup.md
@@ -12,7 +12,6 @@ Check required commands and repository context:
 
 ```bash
 galley --help
-claude --version
 git status --short
 ```
 
@@ -42,7 +41,7 @@ Use `galley` for later commands when it works on `PATH`; otherwise use the verif
 
 The installer installs the `galley` binary. By default it downloads a prebuilt GitHub Release asset; `--local` builds from the current checkout. Daemon operations are available under `<galley-bin> daemon ...`.
 
-Check `gh auth status` when the accepted profile proposal enables PR automation. Check `codex --version` when the user selects Codex as the implementation executor or daemon supervisor.
+Check provider CLIs after the user chooses execution backends: run `claude --version` when Claude is selected as implementation executor or daemon supervisor, and `codex --version` when Codex is selected as implementation executor or daemon supervisor. Check `gh auth status` when the accepted profile proposal enables PR automation.
 
 ## Repository Layout
 
@@ -84,7 +83,7 @@ Setup includes repository profiles. After resolving the profile paths:
 - Profile creation starts by reading `references/quality.schema.json` and `references/environment.schema.json`; use schema defaults as the proposed values unless repo evidence or user choices point elsewhere.
 - `quality.yaml` proposal includes required checks, review dimensions, evidence requirements, and blocking severities.
 - `environment.yaml` proposal includes cwd, commands, implementation executor default, network/secrets/destructive-command constraints, PR creation, PR comment handling, base branch, and worktree cleanup.
-- The profile intake order is schema review, review strictness, implementation executor and review supervisor choices, then repository inspection approval. PR automation is a profile proposal decision; daemon supervisor changes are applied at daemon start.
+- The profile intake order is schema review, review strictness, implementation executor choice, optional daemon supervisor choice, then repository inspection approval. Store the implementation executor choice in `environment.yaml` as `executor.default_cli`; carry the supervisor choice into the daemon startup plan only, because it is not an environment profile field. PR automation is a profile proposal decision; daemon supervisor changes are applied at daemon start.
 - Profile creation requires repository inspection approval and profile approval before writing files.
 - Inspect the repository after approval, then draft candidate profiles from discovered commands, CI, README, config, and existing local guidance.
 - Present one combined profile proposal after inspection. Include the evidence behind each required check and each environment setting.
@@ -127,3 +126,16 @@ Explicit Claude supervisor:
 For a single queue drain, use the same command shape with `run --once` instead of `start`.
 
 Repository profiles under the Galley root are loaded automatically from `scope.cwd`.
+
+When setup needs to ask for both backend choices, use this shape:
+
+```markdown
+Galley can use `claude` or `codex` separately for implementation and review.
+
+- Implementation executor: writes the task changes in the worktree and is stored in `environment.yaml` as `executor.default_cli` for new task authoring.
+- Review supervisor: reviews completed attempts and is applied when starting or restarting the daemon.
+
+Which implementation executor should new tasks use? Which review supervisor should the daemon use?
+
+If the executor is left unset, new task authoring uses Codex. If the supervisor is left unset, the daemon uses Claude.
+```

--- a/plugins/galley/skills/galley/references/setup.md
+++ b/plugins/galley/skills/galley/references/setup.md
@@ -42,7 +42,7 @@ Use `galley` for later commands when it works on `PATH`; otherwise use the verif
 
 The installer installs the `galley` binary. By default it downloads a prebuilt GitHub Release asset; `--local` builds from the current checkout. Daemon operations are available under `<galley-bin> daemon ...`.
 
-Check `gh auth status` when the accepted profile proposal enables PR automation. Check `codex --version` when the user selects Codex as the daemon supervisor.
+Check `gh auth status` when the accepted profile proposal enables PR automation. Check `codex --version` when the user selects Codex as the implementation executor or daemon supervisor.
 
 ## Repository Layout
 
@@ -83,8 +83,8 @@ Setup includes repository profiles. After resolving the profile paths:
 - If `quality.yaml` or `environment.yaml` is missing, explain profiles and create them from this flow. Use `references/profile-authoring.md` and `references/authoring-quality.md` for deeper guidance when available.
 - Profile creation starts by reading `references/quality.schema.json` and `references/environment.schema.json`; use schema defaults as the proposed values unless repo evidence or user choices point elsewhere.
 - `quality.yaml` proposal includes required checks, review dimensions, evidence requirements, and blocking severities.
-- `environment.yaml` proposal includes cwd, commands, network/secrets/destructive-command constraints, PR creation, PR comment handling, base branch, and worktree cleanup.
-- The profile intake order is schema review, review strictness, then repository inspection approval. Supervisor selection and PR automation are profile proposal or daemon-start decisions.
+- `environment.yaml` proposal includes cwd, commands, implementation executor default, network/secrets/destructive-command constraints, PR creation, PR comment handling, base branch, and worktree cleanup.
+- The profile intake order is schema review, review strictness, implementation executor and review supervisor choices, then repository inspection approval. PR automation is a profile proposal decision; daemon supervisor changes are applied at daemon start.
 - Profile creation requires repository inspection approval and profile approval before writing files.
 - Inspect the repository after approval, then draft candidate profiles from discovered commands, CI, README, config, and existing local guidance.
 - Present one combined profile proposal after inspection. Include the evidence behind each required check and each environment setting.
@@ -100,7 +100,8 @@ Setup includes repository profiles. After resolving the profile paths:
 
 Choose daemon settings before startup. Explain the defaults and ask for changes when the user has not already chosen:
 
-- supervisor: Claude is the default; Codex can be selected for Codex review.
+- implementation executor: use `environment.yaml` `executor.default_cli` for new task authoring when it is set; if it is unset, task authoring resolves to Codex. Claude and Codex are both supported.
+- supervisor: Claude is the daemon default when unset; Codex can be selected for Codex review. Claude and Codex are both supported.
 - PR automation, PR comment handling, base branch, and worktree cleanup: use the resolved `environment.yaml`.
 - run mode: `daemon start` keeps working in the background; `daemon run --once` drains the current queue once.
 - concurrency: keep defaults unless the user asks for parallel task execution.

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -128,6 +128,7 @@ Interpret daemon-dependent settings before asking:
 
 - If a verified daemon is already running, use its current daemon settings as the execution condition. Present supervisor, concurrency, polling interval, claim TTL, heartbeat interval, and shutdown timeout as current daemon state, not user-selectable task options.
 - Repository operation settings come from `environment.yaml`: PR creation, PR base branch, PR comment polling/replies, and worktree cleanup.
+- Repository executor defaults also come from `environment.yaml`: when `executor.default_cli` is set, confirm that the task will run with that backend and ask for an override only when the user wants a different model/backend. When no executor default is set, ask for both the implementation executor (`claude` or `codex`) and the review supervisor (`claude` or `codex`); if the user leaves the executor unset, new task authoring resolves to Codex.
 - If no daemon is running, ask the user to approve the planned daemon startup settings because they will be applied when starting the daemon.
 - If daemon status is unclear, report that uncertainty and ask whether to inspect or start a fresh daemon before queueing.
 
@@ -137,7 +138,7 @@ Execution-setting content requirements:
 
 - Task YAML settings: executor backend, optional executor model override, edit authority, retry budget, per-attempt timeout, AC test skeleton preflight, and blocking severity policy.
 - Environment profile operation settings: PR behavior, PR base branch, PR comments, and worktree cleanup from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work.
-- Executor backend (`executor.cli`): include it as one Task YAML execution setting. Recommend `claude` by default; offer `codex` when the user wants Codex to perform the implementation work. Explain that this controls the implementation executor for this task and is separate from the daemon supervisor.
+- Executor backend (`executor.cli`): include it as one Task YAML execution setting. Use `environment.yaml` `executor.default_cli` when present; if it is absent, ask for `claude` or `codex` and use Codex when the user leaves the setting unset. Explain that this controls the implementation executor for this task and is separate from the daemon supervisor.
 - Executor model override (`executor.model`): omit it by default so the selected CLI uses its configured default model. If the user names a model, record that exact value. If the user is unsure or the model name was inferred, do not guess; offer a small runtime smoke check before queueing because available model names depend on the user's account, provider, CLI configuration, and CLI version.
 - Supervisor: present the planned or current supervisor. Use `claude` as the default review gate and offer `codex` when the user wants Codex review.
 - Daemon concurrency: present planned or current `max_concurrent_tasks` and `max_concurrent_per_repo`. Explain that default or low concurrency fits a single heavy task, while higher values are available for parallel execution.
@@ -167,6 +168,8 @@ python3 <this-skill-directory>/scripts/create_task_skeleton.py "<short task titl
   --permission sandbox-full-access \
   --loop-budget 10
 ```
+
+The skeleton script resolves `executor.cli` from the explicit `--executor-cli` argument first, then `environment.yaml` `executor.default_cli`, then Codex when no environment setting exists.
 
 With a context-only specification, work plan, log, screenshot note, issue export, or review note supplied by the user:
 
@@ -225,7 +228,7 @@ Use `decisions: []`, `risks: []`, and `verification.commands: []` when those ent
 - `status`: write new tasks as `draft`; `galley task queue` writes the queued copy with `status: queued`.
 - `scope.permission`: prefer broad operations inside the isolated worktree (`sandbox-full-access`) for AFK implementation tasks; use investigation only (`read-only`) for review tasks; use normal edits (`edit`) when broad sandbox authority is unnecessary or unavailable.
 - `allowed_paths`: choose the narrowest paths that cover approved edits and any reference-file destinations.
-- `executor.cli`: use `claude` by default. Use `codex` when the user selects Codex as the implementation executor. This is a task YAML setting and is separate from the daemon supervisor.
+- `executor.cli`: use the resolved environment executor default when `environment.yaml` has `executor.default_cli`; otherwise use Codex when no environment default or explicit user choice exists. Preserve an explicit `executor.cli` already present in existing task YAML. This is a task YAML setting and is separate from the daemon supervisor.
 - `executor.model`: omit by default. Write it only when the user explicitly selects a model name or asks to pin one; otherwise the executor CLI default is used. Do not invent likely model names. When a model is pinned and the user wants confidence before queueing, run a minimal smoke check with that CLI/model and record the result or limitation.
 - `executor.effort`: set the approved effort for the selected executor. Claude accepts `low`, `medium`, `high`, `xhigh`, or `max`; Codex accepts `low`, `medium`, or `high`. Use `high` for ordinary implementation work unless the user asks for lower cost or higher Claude-only effort.
 - `execution_policy.timeout_ms`: set the approved per-attempt timeout in milliseconds. Use `30min` (`1800000`) as the ordinary-task baseline and increase it for broader, slower, or more uncertain tasks.

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -83,6 +83,14 @@ galley profile resolve --cwd <absolute-target-repo> --output json
 
 Use the same absolute target repository path for `galley profile resolve --cwd` and task `scope.cwd`. If the resolved `quality.yaml` or `environment.yaml` does not exist, create profiles with `references/profile-authoring.md` before task drafting continues.
 
+When `environment_exists` is true, inspect the returned `environment_profile_file` before Step 5. Use the profile's `executor.default_cli` value as the repository executor default when present. If the current `galley` binary supports it, the focused lookup is:
+
+```bash
+galley profile executor-default --output json <environment-profile-file>
+```
+
+If that command is unavailable, read the profile YAML directly and use only the top-level `executor.default_cli` value. Treat an absent value as unset.
+
 ## Step 4: Confirm Task Direction
 
 Before discussing Galley runtime settings or writing task YAML, present the proposed task direction and ask for approval. Include:
@@ -128,7 +136,8 @@ Interpret daemon-dependent settings before asking:
 
 - If a verified daemon is already running, use its current daemon settings as the execution condition. Present supervisor, concurrency, polling interval, claim TTL, heartbeat interval, and shutdown timeout as current daemon state, not user-selectable task options.
 - Repository operation settings come from `environment.yaml`: PR creation, PR base branch, PR comment polling/replies, and worktree cleanup.
-- Repository executor defaults also come from `environment.yaml`: when `executor.default_cli` is set, confirm that the task will run with that backend and ask for an override only when the user wants a different model/backend. When no executor default is set, ask for both the implementation executor (`claude` or `codex`) and the review supervisor (`claude` or `codex`); if the user leaves the executor unset, new task authoring resolves to Codex.
+- Repository executor defaults also come from `environment.yaml`: when `executor.default_cli` is set, confirm that the task will run with that backend and ask for an override only when the user wants a different model/backend. When no executor default is set, ask for the implementation executor (`claude` or `codex`); if the user leaves the executor unset, new task authoring resolves to Codex.
+- Ask for the review supervisor (`claude` or `codex`) only when no verified daemon is running or when the user wants to stop/restart the daemon before queueing. A running verified daemon's supervisor is current state, not a task setting.
 - If no daemon is running, ask the user to approve the planned daemon startup settings because they will be applied when starting the daemon.
 - If daemon status is unclear, report that uncertainty and ask whether to inspect or start a fresh daemon before queueing.
 
@@ -140,7 +149,7 @@ Execution-setting content requirements:
 - Environment profile operation settings: PR behavior, PR base branch, PR comments, and worktree cleanup from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work.
 - Executor backend (`executor.cli`): include it as one Task YAML execution setting. Use `environment.yaml` `executor.default_cli` when present; if it is absent, ask for `claude` or `codex` and use Codex when the user leaves the setting unset. Explain that this controls the implementation executor for this task and is separate from the daemon supervisor.
 - Executor model override (`executor.model`): omit it by default so the selected CLI uses its configured default model. If the user names a model, record that exact value. If the user is unsure or the model name was inferred, do not guess; offer a small runtime smoke check before queueing because available model names depend on the user's account, provider, CLI configuration, and CLI version.
-- Supervisor: present the planned or current supervisor. Use `claude` as the default review gate and offer `codex` when the user wants Codex review.
+- Supervisor: present the current daemon supervisor when a verified daemon is running. When no verified daemon is running, present the planned supervisor; the daemon default is `claude`, and `codex` can be selected for Codex review.
 - Daemon concurrency: present planned or current `max_concurrent_tasks` and `max_concurrent_per_repo`. Explain that default or low concurrency fits a single heavy task, while higher values are available for parallel execution.
 - AC test skeleton preflight (`preflight.acceptance_skeleton.enabled`): include it as one Task YAML execution setting with only `enabled` or `disabled`; recommend `enabled` when AC complexity, regression risk, or task size makes pre-created test skeletons worth the preflight cost, and recommend `disabled` for small, local, low-risk tasks where existing verification commands are enough. Let the skeleton creator derive test kind, path, and content.
 - For each user-changeable setting, include the recommended or current value, why it fits the current task, and practical alternatives.

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -83,6 +83,8 @@ galley profile resolve --cwd <absolute-target-repo> --output json
 
 Use the same absolute target repository path for `galley profile resolve --cwd` and task `scope.cwd`. If the resolved `quality.yaml` or `environment.yaml` does not exist, create profiles with `references/profile-authoring.md` before task drafting continues.
 
+Before Step 4, resolve the repository executor default:
+
 When `environment_exists` is true, inspect the returned `environment_profile_file` before Step 5. Use the profile's `executor.default_cli` value as the repository executor default when present. If the current `galley` binary supports it, the focused lookup is:
 
 ```bash

--- a/plugins/galley/skills/galley/references/task.schema.json
+++ b/plugins/galley/skills/galley/references/task.schema.json
@@ -292,8 +292,7 @@
         "cli",
         "effort",
         "prompt_profile",
-        "prompt_mode",
-        "max_budget_usd"
+        "prompt_mode"
       ],
       "type": "object"
     },

--- a/plugins/galley/skills/galley/scripts/create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/create_task_skeleton.py
@@ -5,16 +5,22 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
+import os
 import pathlib
 import re
 import secrets
+import shutil
+import subprocess
 import sys
 from typing import Any
 
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 SCHEMA_PATH = SCRIPT_DIR.parent / "references" / "task.schema.json"
+PROFILE_LOADER_DIR = SCRIPT_DIR / "profile_loader"
+VALID_EXECUTOR_CLIS = {"claude", "codex"}
 ROOT_ORDER = [
     "id",
     "mode",
@@ -48,6 +54,262 @@ def task_id_for(title: str) -> str:
     timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
     random_suffix = secrets.token_hex(3)
     return f"task-{timestamp}-{random_suffix}-{slugify(title)}"
+
+
+def repo_key_for(cwd: pathlib.Path) -> str:
+    absolute = cwd.expanduser().resolve(strict=False)
+    try:
+        absolute = absolute.resolve(strict=True)
+    except FileNotFoundError:
+        pass
+    base = re.sub(r"[^A-Za-z0-9._-]+", "-", absolute.name).strip("-._") or "repo"
+    digest = hashlib.sha256(str(absolute).encode("utf-8")).hexdigest()[:8]
+    return f"{base}-{digest}"
+
+
+def default_galley_root() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("GALLEY_ROOT", pathlib.Path.home() / ".galley")).expanduser()
+
+
+def environment_profile_path(root: pathlib.Path, cwd: pathlib.Path) -> pathlib.Path:
+    return root / "profiles" / repo_key_for(cwd) / "environment.yaml"
+
+
+def repository_root() -> pathlib.Path | None:
+    for candidate in [SCRIPT_DIR, *SCRIPT_DIR.parents]:
+        go_mod = candidate / "go.mod"
+        if go_mod.is_file() and 'module github.com/shinpr/galley' in go_mod.read_text(encoding="utf-8"):
+            return candidate
+    return None
+
+
+def parse_executor_default_payload(stdout: str, path: pathlib.Path) -> str | None:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"profile loader returned invalid JSON: {exc}") from exc
+    parsed = str(payload.get("default_cli") or "").strip()
+    if parsed and parsed not in VALID_EXECUTOR_CLIS:
+        raise ValueError(f"{path}: executor.default_cli must be one of: claude, codex")
+    return parsed or None
+
+
+def galley_binary() -> str | None:
+    configured = os.environ.get("GALLEY_BIN", "").strip()
+    if configured:
+        return configured
+    return shutil.which("galley")
+
+
+def executor_default_from_profile_command(path: pathlib.Path) -> str | None:
+    binary = galley_binary()
+    if not binary:
+        return None
+    absolute_path = path.expanduser().resolve(strict=False)
+    try:
+        proc = subprocess.run(
+            [binary, "profile", "executor-default", "--output", "json", str(absolute_path)],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        message = proc.stderr.strip() or proc.stdout.strip() or "profile executor-default failed"
+        if "unknown command" in message:
+            return None
+        raise ValueError(message)
+    return parse_executor_default_payload(proc.stdout, path)
+
+
+def executor_default_from_profile_loader(path: pathlib.Path) -> str | None:
+    if shutil.which("go") is None or not PROFILE_LOADER_DIR.is_dir():
+        return None
+    root = repository_root()
+    if root is None:
+        return None
+    absolute_path = path.expanduser().resolve(strict=False)
+    proc = subprocess.run(
+        ["go", "run", "./plugins/galley/skills/galley/scripts/profile_loader", str(absolute_path)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        message = proc.stderr.strip() or proc.stdout.strip() or "profile loader failed"
+        raise ValueError(message)
+    return parse_executor_default_payload(proc.stdout, path)
+
+
+def strip_yaml_comment(value: str) -> str:
+    quote: str | None = None
+    escaped = False
+    for i, char in enumerate(value):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if quote == "'":
+            if char == quote:
+                if i + 1 < len(value) and value[i + 1] == quote:
+                    continue
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == "#" and (i == 0 or value[i - 1].isspace()):
+            return value[:i].rstrip()
+    return value.strip()
+
+
+def unquote_yaml_scalar(value: str) -> str:
+    value = strip_yaml_comment(value).strip()
+    if not value:
+        return ""
+    if value[0] in {"'", '"'} and value[-1:] == value[0]:
+        try:
+            return json.loads(value) if value[0] == '"' else value[1:-1].replace("''", "'")
+        except json.JSONDecodeError:
+            return value[1:-1]
+    return value.strip()
+
+
+def split_yaml_key_value(value: str) -> tuple[str, str, str]:
+    quote: str | None = None
+    escaped = False
+    for i, char in enumerate(value):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if quote == "'":
+            if char == quote:
+                if i + 1 < len(value) and value[i + 1] == quote:
+                    continue
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == ":":
+            return value[:i].strip(), ":", value[i + 1 :].strip()
+    return value, "", ""
+
+
+def parse_executor_flow_mapping(value: str, path: pathlib.Path) -> str | None:
+    value = strip_yaml_comment(value)
+    anchor_match = re.match(r"^&[A-Za-z0-9_.-]+\s+(.*)$", value)
+    if anchor_match:
+        value = anchor_match.group(1).strip()
+    if value in {"", "{}", "null", "~"}:
+        return None
+    if not (value.startswith("{") and value.endswith("}")):
+        return None
+    body = value[1:-1].strip()
+    if not body:
+        return None
+    parts: list[str] = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    for i, char in enumerate(body):
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if quote == "'":
+            if char == quote:
+                if i + 1 < len(body) and body[i + 1] == quote:
+                    continue
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char == ",":
+            parts.append(body[start:i].strip())
+            start = i + 1
+    parts.append(body[start:].strip())
+    for part in parts:
+        key, sep, raw_value = split_yaml_key_value(part)
+        if sep and unquote_yaml_scalar(key) == "default_cli":
+            parsed = unquote_yaml_scalar(raw_value)
+            if parsed in VALID_EXECUTOR_CLIS:
+                return parsed
+            raise ValueError(f"{path}: executor.default_cli must be one of: claude, codex")
+    return None
+
+
+def executor_default_from_environment(path: pathlib.Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+    loaded = executor_default_from_profile_loader(path) or executor_default_from_profile_command(path)
+    if loaded:
+        return loaded
+
+    in_executor = False
+    executor_indent = 0
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        stripped = raw.strip()
+        if not raw.startswith(" "):
+            key, sep, value = split_yaml_key_value(stripped)
+            if sep and unquote_yaml_scalar(key) == "executor":
+                flow_value = parse_executor_flow_mapping(value, path)
+                if flow_value:
+                    return flow_value
+                in_executor = strip_yaml_comment(value) == ""
+                executor_indent = indent
+                continue
+        if in_executor and indent <= executor_indent:
+            in_executor = False
+        if in_executor:
+            key, sep, value = split_yaml_key_value(stripped)
+            if sep and unquote_yaml_scalar(key) == "default_cli":
+                parsed = unquote_yaml_scalar(value)
+                if parsed in VALID_EXECUTOR_CLIS:
+                    return parsed
+                raise ValueError(f"{path}: executor.default_cli must be one of: claude, codex")
+    return None
+
+
+def resolved_executor_cli(explicit_cli: str | None, root: pathlib.Path, cwd: pathlib.Path) -> str:
+    if explicit_cli:
+        return explicit_cli
+    return executor_default_from_environment(environment_profile_path(root, cwd)) or "codex"
+
+
+def executor_defaults(cli: str) -> dict[str, Any]:
+    if cli == "codex":
+        return {
+            "cli": "codex",
+            "effort": "high",
+            "prompt_profile": "codex-executor-v1",
+            "prompt_mode": "replace",
+            "max_budget_usd": 4,
+        }
+    return {
+        "cli": "claude",
+        "effort": "high",
+        "prompt_profile": "codexized-claude-executor-v1",
+        "prompt_mode": "replace",
+        "max_budget_usd": 4,
+    }
 
 
 def parse_file_mapping(value: str) -> tuple[str, str]:
@@ -166,6 +428,11 @@ def main() -> int:
     parser.add_argument("--cwd", required=True, help="Absolute target repository path.")
     parser.add_argument("--output-dir", default=".", help="Directory for the draft task YAML.")
     parser.add_argument("--root", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--executor-cli",
+        choices=sorted(VALID_EXECUTOR_CLIS),
+        help="Implementation executor backend for this task. Defaults to environment.executor.default_cli, then codex.",
+    )
     parser.add_argument("--loop-budget", default=10, type=parse_nonnegative_int, help="Integer >= 0; 0 means unlimited.")
     parser.add_argument("--allowed-path", action="append", default=None, help="Relative path allowed for edits. Repeatable.")
     parser.add_argument(
@@ -200,8 +467,9 @@ def main() -> int:
         return 2
 
     task_id = task_id_for(args.title)
+    root = pathlib.Path(args.root).expanduser() if args.root else default_galley_root()
     if args.root:
-        output_dir = pathlib.Path(args.root).expanduser() / "tasks" / "draft"
+        output_dir = root / "tasks" / "draft"
     else:
         output_dir = pathlib.Path(args.output_dir).expanduser()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -245,13 +513,11 @@ def main() -> int:
         "path": f"../{cwd.name}.worktrees/{task_id}",
     }
     task["supervisor"] = {"review_iterations": 0}
-    task["executor"] = {
-        "cli": "claude",
-        "effort": "high",
-        "prompt_profile": "codexized-claude-executor-v1",
-        "prompt_mode": "replace",
-        "max_budget_usd": 4,
-    }
+    try:
+        task["executor"] = executor_defaults(resolved_executor_cli(args.executor_cli, root, cwd))
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     # Emit the AC test skeleton preflight stage explicitly disabled by default so
     # the generated YAML shows the runtime gate. Only `enabled` is written; any
     # enabled-only fields (mode, required, allowed_paths, outputs) stay omitted

--- a/plugins/galley/skills/galley/scripts/create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/create_task_skeleton.py
@@ -78,6 +78,9 @@ def environment_profile_path(root: pathlib.Path, cwd: pathlib.Path) -> pathlib.P
 def repository_root() -> pathlib.Path | None:
     for candidate in [SCRIPT_DIR, *SCRIPT_DIR.parents]:
         go_mod = candidate / "go.mod"
+        # This repo-local helper is only authoritative inside the upstream
+        # Galley module; forks or module renames should fall back to the
+        # installed CLI or the small Python parser below.
         if go_mod.is_file() and 'module github.com/shinpr/galley' in go_mod.read_text(encoding="utf-8"):
             return candidate
     return None
@@ -118,7 +121,9 @@ def executor_default_from_profile_command(path: pathlib.Path) -> str | None:
         message = proc.stderr.strip() or proc.stdout.strip() or "profile executor-default failed"
         if "unknown command" in message:
             return None
-        raise ValueError(message)
+        if "executor.default_cli" in message:
+            raise ValueError(message)
+        return None
     return parse_executor_default_payload(proc.stdout, path)
 
 
@@ -137,7 +142,9 @@ def executor_default_from_profile_loader(path: pathlib.Path) -> str | None:
     )
     if proc.returncode != 0:
         message = proc.stderr.strip() or proc.stdout.strip() or "profile loader failed"
-        raise ValueError(message)
+        if "executor.default_cli" in message:
+            raise ValueError(message)
+        return None
     return parse_executor_default_payload(proc.stdout, path)
 
 
@@ -256,9 +263,15 @@ def executor_default_from_environment(path: pathlib.Path) -> str | None:
     except FileNotFoundError:
         return None
 
-    loaded = executor_default_from_profile_loader(path) or executor_default_from_profile_command(path)
-    if loaded:
-        return loaded
+    for loader in (executor_default_from_profile_command, executor_default_from_profile_loader):
+        try:
+            loaded = loader(path)
+        except ValueError as exc:
+            if "executor.default_cli" in str(exc):
+                raise
+            loaded = None
+        if loaded:
+            return loaded
 
     in_executor = False
     executor_indent = 0
@@ -301,7 +314,6 @@ def executor_defaults(cli: str) -> dict[str, Any]:
             "effort": "high",
             "prompt_profile": "codex-executor-v1",
             "prompt_mode": "replace",
-            "max_budget_usd": 4,
         }
     return {
         "cli": "claude",

--- a/plugins/galley/skills/galley/scripts/profile_loader/main.go
+++ b/plugins/galley/skills/galley/scripts/profile_loader/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/shinpr/galley/internal/profile"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: profile_loader ENVIRONMENT.yaml")
+		os.Exit(2)
+	}
+	env, err := profile.LoadEnvironment(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	result := profile.ValidateEnvironment(env)
+	if !result.Valid() {
+		fmt.Fprintf(os.Stderr, "invalid environment profile %s: %s\n", os.Args[1], strings.Join(result.Errors, "; "))
+		os.Exit(2)
+	}
+	payload := struct {
+		DefaultCLI string `json:"default_cli,omitempty"`
+	}{}
+	if env.Executor != nil {
+		payload.DefaultCLI = env.Executor.DefaultCLI
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(payload); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}

--- a/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
@@ -15,6 +15,7 @@ regressed and the message names the missing or unexpected field.
 
 from __future__ import annotations
 
+import hashlib
 import pathlib
 import re
 import subprocess
@@ -26,27 +27,70 @@ SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 GENERATOR = SCRIPT_DIR / "create_task_skeleton.py"
 
 
-def generate_skeleton(tmpdir: pathlib.Path) -> str:
+def repo_key_for(cwd: pathlib.Path) -> str:
+    absolute = cwd.resolve(strict=False)
+    try:
+        absolute = absolute.resolve(strict=True)
+    except FileNotFoundError:
+        pass
+    base = re.sub(r"[^A-Za-z0-9._-]+", "-", absolute.name).strip("-._") or "repo"
+    return f"{base}-{hashlib.sha256(str(absolute).encode('utf-8')).hexdigest()[:8]}"
+
+
+def generate_skeleton(tmpdir: pathlib.Path, *extra_args: str, root: pathlib.Path | None = None) -> str:
     output_dir = tmpdir / "draft"
     output_dir.mkdir(parents=True, exist_ok=True)
     fake_cwd = tmpdir / "repo"
     fake_cwd.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        str(GENERATOR),
+        "demo-skeleton-preflight",
+        "--cwd",
+        str(fake_cwd),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if root is not None:
+        command.extend(["--root", str(root)])
+    command.extend(extra_args)
     proc = subprocess.run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "demo-skeleton-preflight",
-            "--cwd",
-            str(fake_cwd),
-            "--output-dir",
-            str(output_dir),
-        ],
+        command,
         check=True,
         capture_output=True,
         text=True,
     )
     task_path = pathlib.Path(proc.stdout.strip())
     return task_path.read_text(encoding="utf-8")
+
+
+def write_environment_default(root: pathlib.Path, cwd: pathlib.Path, cli: str, *, inline_executor: bool = False) -> None:
+    env_dir = root / "profiles" / repo_key_for(cwd)
+    env_dir.mkdir(parents=True, exist_ok=True)
+    executor_lines = [f"executor: {{default_cli: {cli}}}"] if inline_executor else ["executor:", f'  default_cli: "{cli}"']
+    (env_dir / "environment.yaml").write_text(
+        "\n".join(
+            [
+                'id: "test"',
+                f'cwd: "{cwd}"',
+                "commands: {}",
+                *executor_lines,
+                "constraints:",
+                '  network: "approval_required"',
+                '  secrets_policy: "never_read_env_files"',
+                '  destructive_commands: "deny"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def generated_executor_cli(yaml_text: str) -> str:
+    match = re.search(r"^executor:\n(?:  .+\n)*?  cli: ([A-Za-z0-9_-]+)$", yaml_text, re.MULTILINE)
+    if not match:
+        raise SystemExit("regression: generated skeleton is missing executor.cli")
+    return match.group(1)
 
 
 def assert_contains(yaml_text: str, needle: str, description: str) -> None:
@@ -67,7 +111,8 @@ def assert_not_matches(yaml_text: str, pattern: str, description: str) -> None:
 
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
-        yaml_text = generate_skeleton(pathlib.Path(tmp))
+        tmpdir = pathlib.Path(tmp)
+        yaml_text = generate_skeleton(tmpdir)
 
     assert_contains(yaml_text, "preflight:\n", "preflight block header")
     assert_contains(
@@ -81,8 +126,40 @@ def main() -> int:
     assert_not_matches(yaml_text, r"^    required:", "required in default skeleton")
     assert_not_matches(yaml_text, r"^    allowed_paths:", "allowed_paths in default skeleton")
     assert_not_matches(yaml_text, r"^    mode:", "mode in default skeleton")
+    if generated_executor_cli(yaml_text) != "codex":
+        raise SystemExit("regression: unset environment executor default should generate executor.cli: codex")
 
-    print("create_task_skeleton.py preflight default-disabled contract holds")
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = pathlib.Path(tmp)
+        fake_cwd = tmpdir / "repo"
+        fake_cwd.mkdir(parents=True, exist_ok=True)
+        root = tmpdir / "galley"
+        write_environment_default(root, fake_cwd, "claude")
+        yaml_text = generate_skeleton(tmpdir, root=root)
+    if generated_executor_cli(yaml_text) != "claude":
+        raise SystemExit("regression: environment executor default should generate executor.cli: claude")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = pathlib.Path(tmp)
+        fake_cwd = tmpdir / "repo"
+        fake_cwd.mkdir(parents=True, exist_ok=True)
+        root = tmpdir / "galley"
+        write_environment_default(root, fake_cwd, "claude", inline_executor=True)
+        yaml_text = generate_skeleton(tmpdir, root=root)
+    if generated_executor_cli(yaml_text) != "claude":
+        raise SystemExit("regression: inline environment executor default should generate executor.cli: claude")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = pathlib.Path(tmp)
+        fake_cwd = tmpdir / "repo"
+        fake_cwd.mkdir(parents=True, exist_ok=True)
+        root = tmpdir / "galley"
+        write_environment_default(root, fake_cwd, "claude")
+        yaml_text = generate_skeleton(tmpdir, "--executor-cli", "codex", root=root)
+    if generated_executor_cli(yaml_text) != "codex":
+        raise SystemExit("regression: explicit --executor-cli should override environment default")
+
+    print("create_task_skeleton.py preflight and executor default contracts hold")
     return 0
 
 

--- a/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
@@ -15,26 +15,23 @@ regressed and the message names the missing or unexpected field.
 
 from __future__ import annotations
 
-import hashlib
+import importlib.util
 import pathlib
 import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Callable
 
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 GENERATOR = SCRIPT_DIR / "create_task_skeleton.py"
 
-
-def repo_key_for(cwd: pathlib.Path) -> str:
-    absolute = cwd.resolve(strict=False)
-    try:
-        absolute = absolute.resolve(strict=True)
-    except FileNotFoundError:
-        pass
-    base = re.sub(r"[^A-Za-z0-9._-]+", "-", absolute.name).strip("-._") or "repo"
-    return f"{base}-{hashlib.sha256(str(absolute).encode('utf-8')).hexdigest()[:8]}"
+spec = importlib.util.spec_from_file_location("create_task_skeleton", GENERATOR)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"unable to load {GENERATOR}")
+create_task_skeleton = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(create_task_skeleton)
 
 
 def generate_skeleton(tmpdir: pathlib.Path, *extra_args: str, root: pathlib.Path | None = None) -> str:
@@ -65,7 +62,9 @@ def generate_skeleton(tmpdir: pathlib.Path, *extra_args: str, root: pathlib.Path
 
 
 def write_environment_default(root: pathlib.Path, cwd: pathlib.Path, cli: str, *, inline_executor: bool = False) -> None:
-    env_dir = root / "profiles" / repo_key_for(cwd)
+    # Share the production repo-key helper so these tests fail if skeleton
+    # resolution drifts from the Galley home profile directory contract.
+    env_dir = root / "profiles" / create_task_skeleton.repo_key_for(cwd)
     env_dir.mkdir(parents=True, exist_ok=True)
     executor_lines = [f"executor: {{default_cli: {cli}}}"] if inline_executor else ["executor:", f'  default_cli: "{cli}"']
     (env_dir / "environment.yaml").write_text(
@@ -109,6 +108,89 @@ def assert_not_matches(yaml_text: str, pattern: str, description: str) -> None:
         )
 
 
+def assert_fallback_parser_executor_default(body: str, want: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "environment.yaml"
+        path.write_text(body, encoding="utf-8")
+
+        original_command: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_command
+        original_loader: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_loader
+        create_task_skeleton.executor_default_from_profile_command = lambda _path: None
+        create_task_skeleton.executor_default_from_profile_loader = lambda _path: None
+        try:
+            got = create_task_skeleton.executor_default_from_environment(path)
+        finally:
+            create_task_skeleton.executor_default_from_profile_command = original_command
+            create_task_skeleton.executor_default_from_profile_loader = original_loader
+
+    if got != want:
+        raise SystemExit(f"regression: fallback parser got {got!r}, want {want!r}")
+
+
+def assert_loader_failure_falls_back_to_parser(body: str, want: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "environment.yaml"
+        path.write_text(body, encoding="utf-8")
+
+        original_command: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_command
+        original_loader: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_loader
+        create_task_skeleton.executor_default_from_profile_command = lambda _path: None
+
+        def failing_loader(_path: pathlib.Path) -> str | None:
+            raise ValueError("go run profile loader failed before emitting JSON")
+
+        create_task_skeleton.executor_default_from_profile_loader = failing_loader
+        try:
+            got = create_task_skeleton.executor_default_from_environment(path)
+        finally:
+            create_task_skeleton.executor_default_from_profile_command = original_command
+            create_task_skeleton.executor_default_from_profile_loader = original_loader
+
+    if got != want:
+        raise SystemExit(f"regression: loader infrastructure failure fallback got {got!r}, want {want!r}")
+
+
+def assert_profile_command_precedes_source_loader() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "environment.yaml"
+        path.write_text("executor:\n  default_cli: codex\n", encoding="utf-8")
+
+        original_command: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_command
+        original_loader: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_loader
+        create_task_skeleton.executor_default_from_profile_command = lambda _path: "claude"
+        create_task_skeleton.executor_default_from_profile_loader = lambda _path: "codex"
+        try:
+            got = create_task_skeleton.executor_default_from_environment(path)
+        finally:
+            create_task_skeleton.executor_default_from_profile_command = original_command
+            create_task_skeleton.executor_default_from_profile_loader = original_loader
+
+    if got != "claude":
+        raise SystemExit(f"regression: installed galley command should precede source loader, got {got!r}")
+
+
+def assert_invalid_executor_default_is_not_masked() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = pathlib.Path(tmp) / "environment.yaml"
+        path.write_text("executor:\n  default_cli: other\n", encoding="utf-8")
+
+        original_command: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_command
+        original_loader: Callable[[pathlib.Path], str | None] = create_task_skeleton.executor_default_from_profile_loader
+        create_task_skeleton.executor_default_from_profile_command = lambda _path: None
+        create_task_skeleton.executor_default_from_profile_loader = lambda _path: None
+        try:
+            try:
+                create_task_skeleton.executor_default_from_environment(path)
+            except ValueError as exc:
+                if "executor.default_cli" in str(exc):
+                    return
+                raise
+            raise SystemExit("regression: invalid executor.default_cli should fail instead of falling back")
+        finally:
+            create_task_skeleton.executor_default_from_profile_command = original_command
+            create_task_skeleton.executor_default_from_profile_loader = original_loader
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = pathlib.Path(tmp)
@@ -128,6 +210,7 @@ def main() -> int:
     assert_not_matches(yaml_text, r"^    mode:", "mode in default skeleton")
     if generated_executor_cli(yaml_text) != "codex":
         raise SystemExit("regression: unset environment executor default should generate executor.cli: codex")
+    assert_not_matches(yaml_text, r"^  max_budget_usd:", "max_budget_usd for Codex skeletons")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = pathlib.Path(tmp)
@@ -158,6 +241,21 @@ def main() -> int:
         yaml_text = generate_skeleton(tmpdir, "--executor-cli", "codex", root=root)
     if generated_executor_cli(yaml_text) != "codex":
         raise SystemExit("regression: explicit --executor-cli should override environment default")
+
+    assert_fallback_parser_executor_default(
+        'id: "test"\ncwd: "/tmp/repo"\ncommands: {}\nexecutor:\n  default_cli: "claude"\n',
+        "claude",
+    )
+    assert_fallback_parser_executor_default(
+        'id: "test"\ncwd: "/tmp/repo"\ncommands: {}\nexecutor: {default_cli: claude}\n',
+        "claude",
+    )
+    assert_loader_failure_falls_back_to_parser(
+        'id: "test"\ncwd: "/tmp/repo"\ncommands: {}\nexecutor:\n  default_cli: "claude"\n',
+        "claude",
+    )
+    assert_profile_command_precedes_source_loader()
+    assert_invalid_executor_default_is_not_masked()
 
     print("create_task_skeleton.py preflight and executor default contracts hold")
     return 0


### PR DESCRIPTION
## Goal

Add repository environment executor defaults, make unset executor defaults resolve to Codex for new task authoring, and update setup/task guidance plus release notes for the Claude print-mode billing change.

## Acceptance Criteria

- `AC1` The environment profile contract supports an optional executor default using the existing executor CLI names, with validation restricted to claude or codex and all generated/bundled profile schemas kept in sync.
  - Verification: Review internal/profile structs, validation, generated schema output, and plugins/galley/skills/galley/references/environment.schema.json; run profile schema generation/check commands.
  - Status: satisfied
- `AC2` Task authoring uses the resolved environment executor default when present, uses Codex when no environment executor default is configured, and still preserves any explicit executor.cli already written in task YAML.
  - Verification: Review the task skeleton script, task authoring reference, examples/tests, and generated task YAML behavior for configured, unset, and explicit executor cases.
  - Status: satisfied
- `AC3` Setup/profile-authoring guidance asks for both implementation executor and review supervisor, stores the executor choice in environment.yaml, and phrases the choice neutrally: executor and supervisor can each be claude or codex, with unset values resolving through the documented default.
  - Verification: Inspect plugins/galley/skills/galley/references/setup.md and profile-authoring.md for the updated flow and wording.
  - Status: satisfied
- `AC4` Task creation guidance says that when environment.yaml has an executor default, the author should confirm running with that backend and ask for an override only if the user wants a different model/backend; when no setting exists, it asks the claude/codex executor and supervisor choice.
  - Verification: Inspect plugins/galley/skills/galley/references/task-authoring.md for the environment-aware wording and the no-setting fallback wording.
  - Status: satisfied
- `AC5` Release notes or CHANGELOG mention the Claude Code print-mode / Agent SDK billing change as the reason Galley is making repository executor defaults explicit and reviewing the new default; README is changed only for durable usage documentation, not transient pricing commentary.
  - Verification: Inspect CHANGELOG.md or release-note surface and confirm README changes, if any, are limited to permanent behavior.
  - Status: satisfied
- `AC6` Required repository checks pass or any skipped check has a concrete environment reason recorded in task evidence.
  - Verification: Run gofmt check, go test ./..., go build ./cmd/galley, go run ./cmd/galley schema check, example task/profile validation, JSON validation for changed schemas, and ./scripts/smoke-local.sh when practical.
  - Status: satisfied

## Final Verification

- `go run ./cmd/galley schema generate`: passed
- `python3 -m py_compile plugins/galley/skills/galley/scripts/create_task_skeleton.py plugins/galley/skills/galley/scripts/test_create_task_skeleton.py`: passed
- `go test ./internal/profile ./internal/task`: passed
- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null && python3 -m json.tool schemas/supervisor-verdict.schema.json >/dev/null && python3 -m json.tool plugins/galley/skills/galley/references/task.schema.json >/dev/null && python3 -m json.tool plugins/galley/skills/galley/references/quality.schema.json >/dev/null && python3 -m json.tool plugins/galley/skills/galley/references/environment.schema.json >/dev/null && python3 -m json.tool plugins/galley/.claude-plugin/plugin.json >/dev/null && python3 -m json.tool plugins/galley/.codex-plugin/plugin.json >/dev/null && python3 -m json.tool .claude-plugin/marketplace.json >/dev/null && python3 -m json.tool .agents/plugins/marketplace.json >/dev/null`: passed
- `generate default task skeleton, validate it, and inspect executor lines`: passed
- `generate task skeleton with environment executor.default_cli=claude, validate it, and inspect executor lines`: passed
- `python3 plugins/galley/skills/galley/scripts/test_create_task_skeleton.py`: passed
- `tmp=$(mktemp); repo=$(mktemp -d); printf '... executor: {default_cli: claude} ...' > "$tmp"; go run ./cmd/galley profile validate --kind environment "$tmp"; go run ./cmd/galley profile executor-default --output json "$tmp"`: passed
- `scripts/smoke-local.sh`: passed
- `codex exec`: passed
- `rg -n "Claude Code is the default" README.md docs examples plugins internal`: passed
- `git diff --check`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` How should Galley treat repositories that do not have an environment executor default yet? -> Use Codex as the fallback for new task authoring, while preserving explicit executor.cli in existing task YAML.
  - Rationale: Galley executor runs are non-interactive, so Claude print-mode billing changes materially affect the old Claude default; this project currently has no broad external user base, so changing the fallback now is acceptable.
  - Reversibility: high
- `D2` Should README include pricing-change rationale? -> No. Put billing-change rationale in CHANGELOG or release notes; keep README limited to durable behavior if it is touched.
  - Rationale: README should not carry time-sensitive pricing commentary.
  - Reversibility: high
- `claude-decision-3` What profile field should represent the repository executor default? -> Use environment.executor.default_cli as the optional repository executor default field.
  - Rationale: It is explicit that the value is a default for new task authoring, avoids overloading task YAML executor.cli semantics, and keeps the accepted values aligned with the existing executor CLI names.
  - Reversibility: medium
- `claude-decision-4` Should environment executor defaults affect existing task YAML execution? -> Keep task YAML executor.cli required and apply environment defaults only in task authoring skeleton generation.
  - Rationale: The work order requires explicit task YAML executor.cli to remain authoritative. Applying defaults only during new task authoring changes the authoring default without changing existing task execution semantics.
  - Reversibility: high
- `claude-decision-5` How should the Python skeleton script read environment.yaml without duplicating the full YAML/profile contract? -> Use the shared Go profile loader through a hidden CLI command and a source-tree helper, with a small fallback parser for standalone skill execution.
  - Rationale: The Go loader is the authoritative structured profile contract and correctly handles inline YAML objects such as `executor: {default_cli: claude}`; the fallback preserves operation when neither an updated galley binary nor the source helper is available.
  - Reversibility: medium

## Risks

- `R1` compatibility: Changing the unset executor fallback from Claude to Codex can surprise existing profile users who create new tasks without an executor default.
  - Mitigation: Document the behavior in CHANGELOG/release notes, make setup write the executor choice to environment.yaml, and keep explicit task YAML executor.cli authoritative.
