### PR TITLE
Prepare v0.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.5.0 - 2026-05-15
+
 ### Changed
 
 - Repository `environment.yaml` profiles now support an optional `executor.default_cli` for new task authoring. The task skeleton generator uses that repository default when present and now falls back to Codex when it is unset, while explicit task YAML `executor.cli` remains authoritative for existing tasks. Setup and task-authoring guidance now make the implementation executor choice explicit because Claude Code print-mode usage moved to Agent SDK billing, which changes the cost profile of the previous Claude-oriented default.


### PR DESCRIPTION
## Summary
- Keep the Unreleased section in place for future changes.
- Move the current released changes under a new v0.5.0 changelog heading dated 2026-05-15.

## Validation
- Not run; changelog-only change.