### PR TITLE
Make RestrictedEnv preserve Windows-required process environment variables so Codex executor, supervisors, and acceptance skeleton creator can start Windows CLI shims reliably without broadening model subprocess env exposure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows semantic versioning.
 
 ### Fixed
 
+- Windows RestrictedEnv inheritance for Codex executor, Codex supervisor, Claude supervisor, and acceptance skeleton creator subprocesses. The restricted environment used by these model subprocesses now preserves the Windows process environment keys that cmd.exe, `.cmd` shims, user-local tool discovery, temp files, and executable resolution require (`SYSTEMROOT`, `WINDIR`, `COMSPEC`, `PATHEXT`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `TEMP`, `TMP`), and matches Windows env keys case-insensitively so parent environments using casings such as `Path`, `SystemRoot`, or `ComSpec` are preserved correctly. macOS and Linux RestrictedEnv behavior is unchanged: the existing Unix-oriented allowlist, `LC_*` preservation, and caller-supplied extra entries continue to work without inheriting unrelated parent environment variables. Claude executor full parent-env inheritance is unchanged. No task YAML, profile, or CLI surface changed.
+
 - Windows command-line length failures in Claude executor/supervisor runs, acceptance skeleton creation, `git add` staging, and required quality checks. On Windows, Galley now routes generated prompts, pathspec lists, and verification command bodies through files or stdin instead of argv. macOS and Linux keep their existing command shapes. No task YAML, profile, or CLI surface changed.
 
 ### Fixed

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -2,9 +2,14 @@ package runner
 
 import (
 	"os"
+	"runtime"
 	"strings"
 )
 
+// defaultInheritedEnv lists the cross-platform environment keys that
+// RestrictedEnv preserves from the parent process. Keys are matched
+// case-sensitively on Unix-style hosts and case-insensitively on Windows
+// (see restrictedEnvFromOS).
 var defaultInheritedEnv = map[string]bool{
 	"ANTHROPIC_API_KEY": true,
 	"CODEX_HOME":        true,
@@ -24,12 +29,51 @@ var defaultInheritedEnv = map[string]bool{
 	"XDG_DATA_HOME":   true,
 }
 
+// windowsInheritedEnv lists the additional process environment keys that
+// Windows requires for cmd.exe, .cmd shims, user-local tool discovery,
+// temp files, and executable resolution. These keys are matched
+// case-insensitively because Windows env keys themselves are case-insensitive
+// and the parent process may surface them with any casing (e.g. "Path",
+// "SystemRoot", "ComSpec").
+var windowsInheritedEnv = map[string]bool{
+	"SYSTEMROOT":   true,
+	"WINDIR":       true,
+	"COMSPEC":      true,
+	"PATHEXT":      true,
+	"USERPROFILE":  true,
+	"APPDATA":      true,
+	"LOCALAPPDATA": true,
+	"TEMP":         true,
+	"TMP":          true,
+}
+
 // RestrictedEnv returns a small inherited environment for model subprocesses.
+// On Unix-style hosts it preserves the historical Unix-oriented allowlist
+// (case-sensitive keys, LC_* preservation, and caller-supplied extras). On
+// Windows it additionally preserves Windows process environment keys that
+// cmd.exe, .cmd shims, user-local tool discovery, temp files, and executable
+// resolution require, and matches all keys case-insensitively because Windows
+// env keys are case-insensitive.
 func RestrictedEnv(extra ...string) []string {
-	env := make([]string, 0, len(defaultInheritedEnv)+len(extra))
-	for _, entry := range os.Environ() {
+	return restrictedEnvFromOS(runtime.GOOS, os.Environ(), extra...)
+}
+
+// restrictedEnvFromOS is the platform-parameterized implementation of
+// RestrictedEnv. It is exported within the package so tests can exercise the
+// Windows-specific path without running on a Windows host.
+func restrictedEnvFromOS(goos string, parentEnv []string, extra ...string) []string {
+	isWindows := goos == "windows"
+	env := make([]string, 0, len(parentEnv)+len(extra))
+	for _, entry := range parentEnv {
 		key, _, ok := strings.Cut(entry, "=")
 		if !ok {
+			continue
+		}
+		if isWindows {
+			upper := strings.ToUpper(key)
+			if defaultInheritedEnv[upper] || windowsInheritedEnv[upper] || strings.HasPrefix(upper, "LC_") {
+				env = append(env, entry)
+			}
 			continue
 		}
 		if defaultInheritedEnv[key] || strings.HasPrefix(key, "LC_") {

--- a/internal/runner/env_test.go
+++ b/internal/runner/env_test.go
@@ -1,0 +1,199 @@
+package runner
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestRestrictedEnvUnixDefaults covers AC3: the historical Unix-oriented
+// allowlist (PATH/HOME/LANG/...), LC_* preservation, caller-supplied extras,
+// and omission of unrelated parent environment values.
+func TestRestrictedEnvUnixDefaults(t *testing.T) {
+	parent := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/u",
+		"LANG=en_US.UTF-8",
+		"LC_ALL=en_US.UTF-8",
+		"LC_TIME=POSIX",
+		"FOO=bar",            // unrelated
+		"AWS_SECRET_KEY=xxx", // unrelated
+		"=novalue",           // malformed entry without key
+	}
+	got := restrictedEnvFromOS("linux", parent, "EXTRA=value", "GALLEY_GUARD=on")
+	want := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/u",
+		"LANG=en_US.UTF-8",
+		"LC_ALL=en_US.UTF-8",
+		"LC_TIME=POSIX",
+		"EXTRA=value",
+		"GALLEY_GUARD=on",
+	}
+	assertSameEntries(t, got, want)
+	for _, entry := range got {
+		if strings.HasPrefix(entry, "FOO=") || strings.HasPrefix(entry, "AWS_SECRET_KEY=") {
+			t.Errorf("unrelated env entry leaked into restricted env: %q", entry)
+		}
+	}
+}
+
+// TestRestrictedEnvUnixDoesNotInheritWindowsKeys also covers AC3: the
+// Windows-only allowlist must not widen Unix behavior. A Linux/Darwin process
+// with Windows-shaped environment keys should still see only the documented
+// Unix allowlist (here, PATH).
+func TestRestrictedEnvUnixDoesNotInheritWindowsKeys(t *testing.T) {
+	parent := []string{
+		"PATH=/usr/bin",
+		"PATHEXT=.EXE",
+		"WINDIR=C\\Windows",
+		"USERPROFILE=C\\Users\\u",
+		"APPDATA=C\\Users\\u\\AppData\\Roaming",
+		"LOCALAPPDATA=C\\Users\\u\\AppData\\Local",
+		"TEMP=C\\Temp",
+		"TMP=C\\Tmp",
+		"SYSTEMROOT=C\\Windows",
+		"COMSPEC=C\\Windows\\System32\\cmd.exe",
+	}
+	got := restrictedEnvFromOS("linux", parent)
+	assertSameEntries(t, got, []string{"PATH=/usr/bin"})
+}
+
+// TestRestrictedEnvWindowsPreservesWindowsKeys covers AC1: on Windows the
+// documented Windows process environment keys (SYSTEMROOT, WINDIR, COMSPEC,
+// PATHEXT, USERPROFILE, APPDATA, LOCALAPPDATA, TEMP, TMP) are preserved when
+// present, alongside the historical allowlist (PATH/LANG/...), while unrelated
+// values stay omitted.
+func TestRestrictedEnvWindowsPreservesWindowsKeys(t *testing.T) {
+	parent := []string{
+		"SYSTEMROOT=C:\\Windows",
+		"WINDIR=C:\\Windows",
+		"COMSPEC=C:\\Windows\\System32\\cmd.exe",
+		"PATHEXT=.COM;.EXE;.BAT;.CMD",
+		"USERPROFILE=C:\\Users\\u",
+		"APPDATA=C:\\Users\\u\\AppData\\Roaming",
+		"LOCALAPPDATA=C:\\Users\\u\\AppData\\Local",
+		"TEMP=C:\\Users\\u\\AppData\\Local\\Temp",
+		"TMP=C:\\Users\\u\\AppData\\Local\\Temp",
+		"PATH=C:\\Windows;C:\\Program Files\\Git\\cmd",
+		"LANG=en_US.UTF-8",
+		"FOO=bar",
+		"AWS_SECRET_KEY=xxx",
+	}
+	got := restrictedEnvFromOS("windows", parent, "GALLEY_CLAUDE_GUARD_MODE=supervisor")
+	want := []string{
+		"SYSTEMROOT=C:\\Windows",
+		"WINDIR=C:\\Windows",
+		"COMSPEC=C:\\Windows\\System32\\cmd.exe",
+		"PATHEXT=.COM;.EXE;.BAT;.CMD",
+		"USERPROFILE=C:\\Users\\u",
+		"APPDATA=C:\\Users\\u\\AppData\\Roaming",
+		"LOCALAPPDATA=C:\\Users\\u\\AppData\\Local",
+		"TEMP=C:\\Users\\u\\AppData\\Local\\Temp",
+		"TMP=C:\\Users\\u\\AppData\\Local\\Temp",
+		"PATH=C:\\Windows;C:\\Program Files\\Git\\cmd",
+		"LANG=en_US.UTF-8",
+		"GALLEY_CLAUDE_GUARD_MODE=supervisor",
+	}
+	assertSameEntries(t, got, want)
+	for _, entry := range got {
+		if strings.HasPrefix(entry, "FOO=") || strings.HasPrefix(entry, "AWS_SECRET_KEY=") {
+			t.Errorf("unrelated env entry leaked into restricted env: %q", entry)
+		}
+	}
+}
+
+// TestRestrictedEnvWindowsCaseInsensitiveKeys covers AC2: Windows env keys are
+// case-insensitive, so parent environments using "Path", "SystemRoot",
+// "ComSpec", "PathExt", "UserProfile", "AppData", "LocalAppData", "Temp",
+// "Tmp", or "Windir" casing must be preserved. The original entry (including
+// its original casing) is retained in the resulting environment so downstream
+// processes observe the same key shape they would inherit from the OS.
+func TestRestrictedEnvWindowsCaseInsensitiveKeys(t *testing.T) {
+	parent := []string{
+		"Path=C:\\Windows;C:\\Tools",
+		"SystemRoot=C:\\Windows",
+		"ComSpec=C:\\Windows\\System32\\cmd.exe",
+		"PathExt=.COM;.EXE;.BAT;.CMD",
+		"UserProfile=C:\\Users\\u",
+		"AppData=C:\\Users\\u\\AppData\\Roaming",
+		"LocalAppData=C:\\Users\\u\\AppData\\Local",
+		"Temp=C:\\Tmp",
+		"Tmp=C:\\Tmp2",
+		"Windir=C:\\Windows",
+		"NotAllowed=value",
+	}
+	got := restrictedEnvFromOS("windows", parent)
+	wantContains := []string{
+		"Path=C:\\Windows;C:\\Tools",
+		"SystemRoot=C:\\Windows",
+		"ComSpec=C:\\Windows\\System32\\cmd.exe",
+		"PathExt=.COM;.EXE;.BAT;.CMD",
+		"UserProfile=C:\\Users\\u",
+		"AppData=C:\\Users\\u\\AppData\\Roaming",
+		"LocalAppData=C:\\Users\\u\\AppData\\Local",
+		"Temp=C:\\Tmp",
+		"Tmp=C:\\Tmp2",
+		"Windir=C:\\Windows",
+	}
+	assertSameEntries(t, got, wantContains)
+	for _, entry := range got {
+		if strings.HasPrefix(entry, "NotAllowed=") {
+			t.Errorf("unrelated env entry leaked into restricted env: %q", entry)
+		}
+	}
+}
+
+// TestRestrictedEnvWindowsPreservesLCKeys ensures LC_* preservation still
+// applies on Windows (with case-insensitive matching), supporting AC2/AC3
+// interaction: turning on Windows-specific behavior must not regress LC_*
+// inheritance.
+func TestRestrictedEnvWindowsPreservesLCKeys(t *testing.T) {
+	parent := []string{
+		"LC_ALL=en_US.UTF-8",
+		"Lc_Time=POSIX",
+		"PATH=C:\\Windows",
+		"OTHER=value",
+	}
+	got := restrictedEnvFromOS("windows", parent)
+	assertSameEntries(t, got, []string{
+		"LC_ALL=en_US.UTF-8",
+		"Lc_Time=POSIX",
+		"PATH=C:\\Windows",
+	})
+}
+
+// TestRestrictedEnvExportedAPI is a smoke test ensuring the exported
+// RestrictedEnv signature still produces inherited entries from the live
+// parent environment for the current host, supporting AC4 (call sites
+// continue to receive a usable env without contract changes).
+func TestRestrictedEnvExportedAPI(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	got := RestrictedEnv("EXTRA=ok")
+	foundExtra := false
+	for _, entry := range got {
+		if entry == "EXTRA=ok" {
+			foundExtra = true
+			break
+		}
+	}
+	if !foundExtra {
+		t.Errorf("expected EXTRA=ok in RestrictedEnv output, got %v", got)
+	}
+}
+
+func assertSameEntries(t *testing.T, got, want []string) {
+	t.Helper()
+	gotSorted := append([]string(nil), got...)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(gotSorted)
+	sort.Strings(wantSorted)
+	if len(gotSorted) != len(wantSorted) {
+		t.Fatalf("entry count mismatch:\n  got  (%d): %v\n  want (%d): %v", len(gotSorted), gotSorted, len(wantSorted), wantSorted)
+	}
+	for i := range gotSorted {
+		if gotSorted[i] != wantSorted[i] {
+			t.Errorf("entry %d differs:\n  got:  %q\n  want: %q", i, gotSorted[i], wantSorted[i])
+		}
+	}
+}

--- a/internal/runner/env_test.go
+++ b/internal/runner/env_test.go
@@ -18,7 +18,8 @@ func TestRestrictedEnvUnixDefaults(t *testing.T) {
 		"LC_TIME=POSIX",
 		"FOO=bar",            // unrelated
 		"AWS_SECRET_KEY=xxx", // unrelated
-		"=novalue",           // malformed entry without key
+		"=novalue",           // empty key
+		"NOVAR",              // malformed entry without "="
 	}
 	got := restrictedEnvFromOS("linux", parent, "EXTRA=value", "GALLEY_GUARD=on")
 	want := []string{


### PR DESCRIPTION
## Goal

Make RestrictedEnv preserve Windows-required process environment variables so Codex executor, supervisors, and acceptance skeleton creator can start Windows CLI shims reliably without broadening model subprocess env exposure.

## Acceptance Criteria

- `AC1` On Windows, RestrictedEnv preserves the Windows process environment keys needed for cmd.exe, .cmd shims, user-local tools, temp files, and executable resolution, including SYSTEMROOT, WINDIR, COMSPEC, PATHEXT, USERPROFILE, APPDATA, LOCALAPPDATA, TEMP, and TMP when present.
  - Verification: Focused tests in internal/runner exercise Windows-key preservation without requiring a Windows host.
  - Status: satisfied
- `AC2` Windows environment key matching is case-insensitive, so parent environments using casing such as Path, SystemRoot, or ComSpec are preserved correctly.
  - Verification: Focused tests cover mixed-case Windows env keys and verify the original env entries are retained.
  - Status: satisfied
- `AC3` Non-Windows RestrictedEnv behavior remains narrow and compatible: existing Unix-oriented inherited keys, LC_* handling, and explicit extra entries continue to work without inheriting unrelated variables.
  - Verification: Focused tests cover default allowlist behavior, LC_* preservation, extra env entries, and omission of unrelated env values.
  - Status: satisfied
- `AC4` All RestrictedEnv call sites that previously used the restricted environment continue to do so; Claude executor full parent-env inheritance remains unchanged.
  - Verification: Review evidence covers internal/runner/codex.go, internal/supervisor/adapter.go, and internal/daemon/acceptance_skeleton_creator.go; implementation should avoid broad call-site rewrites unless tests require them.
  - Status: satisfied
- `AC5` The Windows shell-policy problem for required checks remains explicitly out of scope and is not solved by adding shell/profile fields in this task.
  - Verification: Diff review shows no new environment.yaml shell contract, profile schema field, or required-check shell selection behavior.
  - Status: satisfied
- `AC6` A concise CHANGELOG.md entry records the Windows compatibility fix unless the executor provides a specific, reviewable reason that the change is not user-visible.
  - Verification: CHANGELOG.md contains an Unreleased entry for RestrictedEnv Windows compatibility, or task evidence explains the exemption.
  - Status: satisfied

## Final Verification

- `go test ./internal/runner/ -run TestRestrictedEnv -v`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool on schemas/*.json, plugin.json, and marketplace.json files`: passed
- `GOOS=windows GOARCH=amd64 go build ./internal/runner/ ./internal/supervisor/ ./internal/daemon/ ./cmd/galley`: passed
- `GOOS=windows GOARCH=amd64 go vet ./internal/runner/`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Should this task also decide the Windows required-check shell policy? -> No; keep this task focused on RestrictedEnv Windows inheritance only.
  - Rationale: The shell policy issue touches required-check execution semantics and may need design discussion. RestrictedEnv is a localized compatibility fix centered on internal/runner/env.go.
  - Reversibility: high
- `D2` Should Claude executor environment inheritance be changed? -> No; leave Claude executor behavior unchanged unless implementation evidence shows it already uses RestrictedEnv through a shared path.
  - Rationale: The identified failure mode affects RestrictedEnv users: Codex executor, Codex supervisor, Claude supervisor, and acceptance skeleton creator. Claude executor generally inherits the full parent environment and is not the target.
  - Reversibility: high
- `claude-decision-3` How should Windows-specific RestrictedEnv behavior be platform-gated when AC1/AC2 require tests that run without a Windows host? -> Factor a package-internal helper restrictedEnvFromOS(goos, parentEnv, extra...) that takes goos as a parameter, and make the exported RestrictedEnv call it with runtime.GOOS and os.Environ(). Tests pass goos=windows or goos=linux directly.
  - Rationale: AC1 explicitly requires that Windows behavior be verifiable without a Windows host, so a pure build-tag split would defeat the test contract. Parameterizing goos keeps the actual runtime decision driven by runtime.GOOS while letting tests exercise both paths deterministically on any CI host. This is the smallest reversible change that preserves the requested core mechanism (Windows-aware RestrictedEnv) and the existing exported API.
  - Reversibility: high
- `claude-decision-4` Should the Windows allowlist be narrower than the nine keys listed in AC1? -> Include exactly the nine keys named in AC1 (SYSTEMROOT, WINDIR, COMSPEC, PATHEXT, USERPROFILE, APPDATA, LOCALAPPDATA, TEMP, TMP).
  - Rationale: AC1 names these specific keys; widening would weaken the trust boundary the security dimension requires, and omitting any would fail AC1. SYSTEMROOT is included even though Go may inject it on Windows because AC1 lists it explicitly.
  - Reversibility: high

## Discussion Items

- `discussion-1` Source Material Classification: tmp/galley-windows-followup-notes.md is context evidence: it identifies RestrictedEnv as the intended follow-up and keeps Windows required-check shell policy out of this task. The implementation follows that boundary.

## Risks

- `R1` regression: Expanding inherited env too broadly could weaken the restricted subprocess boundary or expose unnecessary user environment values to model subprocesses.
  - Mitigation: Add only Windows process/runtime keys with a focused helper and tests that unrelated variables remain omitted.
- `R2` compatibility: Windows env keys are case-insensitive, but Go maps and string comparisons are case-sensitive by default.
  - Mitigation: Implement and test case-insensitive matching for Windows-specific inheritance while preserving existing non-Windows behavior.
