### PR TITLE
Avoid Windows installer smoke race on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           "$bin_dir/galley.exe" --help >/dev/null
 
       - name: Smoke install script on Windows PowerShell
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.event_name == 'pull_request'
         shell: powershell
         run: |
           $binDir = Join-Path $env:RUNNER_TEMP "galley-ps-bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,21 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  windows-installer-smoke:
+    name: Windows installer smoke
+    needs: goreleaser
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        # actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Smoke PowerShell installer
+        shell: powershell
+        run: |
+          $binDir = Join-Path $env:RUNNER_TEMP "galley-ps-bin"
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install.ps1 -Version "${{ github.event.release.tag_name }}" -BinDir $binDir
+          & (Join-Path $binDir "galley.exe") --help | Out-Null


### PR DESCRIPTION
## Summary
- Run the Windows PowerShell installer smoke only on pull requests in the main CI workflow.
- Add a release workflow Windows smoke job that runs after GoReleaser and installs the explicit release tag.
- Avoid depending on the mutable latest release while release assets are still being uploaded.

## Testing
- Parsed both workflow YAML files with Ruby.
- Ran git diff --check.
- actionlint could not run locally because the aqua shim was present but the executable was not installed.