### PR TITLE
Prepare v0.5.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.5.4 - 2026-05-22
+
 ### Changed
 
 - Acceptance skeleton preflight now follows the task implementation executor backend: `executor.cli: codex` tasks run the built-in skeleton creator through Codex, while `executor.cli: claude` tasks keep the existing Claude creator path. The creator reuses task `executor.model` and `executor.effort`; daemon supervisor selection and persisted preflight evidence shape are unchanged, and no task YAML, profile, or CLI surface changed.


### PR DESCRIPTION
## Summary
- Move the current unreleased changes under a v0.5.4 changelog heading.
- Keep the Unreleased section in place for future entries.

## Testing
- Not run; documentation-only changelog update.