### PR TITLE
Add persistent daemon startup defaults and repository-scoped supervisor defaults so Galley resolves supervisor selection from repo config, daemon startup defaults, daemon.yaml, then the built-in Codex default without misleading daemon…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Daemon CLI flags on `galley daemon run` and `galley daemon start` always override the matching `daemon.yaml` field for that run. `--shutdown-timeout` now follows the same explicit-flag tracking as the other startup defaults.
-- `galley daemon status` (text and `--output json`) no longer reports daemon startup-default fields that the `status` command cannot read accurately. The single `supervisor` field is removed because per-repository `supervisor.default_cli` overrides the daemon startup supervisor per task. `max_concurrent_tasks` and `max_concurrent_per_repo` are also removed: `status` only inspects PID argv, so it would not reflect `daemon.yaml`-supplied values. JSON consumers that depended on those fields should read `runs/<run-id>/supervisor.json` (per-task supervisor evidence) or the running daemon's `daemon.yaml` and process argv directly.
+- `galley daemon status` text and JSON output no longer report daemon startup-default fields that can be resolved per task or loaded from `daemon.yaml`. The removed JSON fields are `supervisor`, `max_concurrent_tasks`, and `max_concurrent_per_repo`; per-task supervisor evidence is recorded in `runs/<run-id>/supervisor.json`.
 - Generated environment profile JSON Schema now declares the `supervisor.default_cli` enum (`claude`, `codex`). The bundled `plugins/galley/skills/galley/references/environment.schema.json` is regenerated.
 
 ## v0.5.4 - 2026-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Added
+
+- Persistent daemon startup defaults in `daemon.yaml`. `galley daemon run` and `galley daemon start` now create `daemon.yaml` under the selected daemon root on first use with documented defaults for `supervisor`, `max_concurrent_tasks`, `max_concurrent_per_repo`, `poll_interval`, `claim_ttl`, `heartbeat_interval`, `shutdown_timeout`, and `idle_timeout`. Operators can edit the file to change daemon-wide defaults without re-specifying CLI flags. `galley daemon status` and `galley daemon stop` never create the file.
+- Repository-scoped supervisor selection. `environment.yaml` now accepts `supervisor.default_cli` (`claude` or `codex`). When set, the daemon uses that supervisor for any task whose `scope.cwd` resolves to that environment profile, overriding the daemon startup supervisor for that task only. The resolved supervisor and the layer that selected it (`environment_profile`, `cli`, `daemon_config`, or `default`) are persisted to `runs/<run-id>/supervisor.json` as review evidence.
+
+### Changed
+
+- Daemon CLI flags on `galley daemon run` and `galley daemon start` always override the matching `daemon.yaml` field for that run. `--shutdown-timeout` now follows the same explicit-flag tracking as the other startup defaults.
+- `galley daemon status` (text and `--output json`) no longer reports a single effective `supervisor` field. Because per-repository `supervisor.default_cli` can override the daemon startup supervisor per task, a daemon-wide value would be misleading; the supervisor that actually ran a task is recorded in `runs/<run-id>/supervisor.json`. JSON consumers that depended on the previous `supervisor` field should read run evidence instead.
+- Generated environment profile JSON Schema now declares the `supervisor.default_cli` enum (`claude`, `codex`). The bundled `plugins/galley/skills/galley/references/environment.schema.json` is regenerated.
+
 ## v0.5.4 - 2026-05-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Daemon CLI flags on `galley daemon run` and `galley daemon start` always override the matching `daemon.yaml` field for that run. `--shutdown-timeout` now follows the same explicit-flag tracking as the other startup defaults.
-- `galley daemon status` (text and `--output json`) no longer reports a single effective `supervisor` field. Because per-repository `supervisor.default_cli` can override the daemon startup supervisor per task, a daemon-wide value would be misleading; the supervisor that actually ran a task is recorded in `runs/<run-id>/supervisor.json`. JSON consumers that depended on the previous `supervisor` field should read run evidence instead.
+- `galley daemon status` (text and `--output json`) no longer reports daemon startup-default fields that the `status` command cannot read accurately. The single `supervisor` field is removed because per-repository `supervisor.default_cli` overrides the daemon startup supervisor per task. `max_concurrent_tasks` and `max_concurrent_per_repo` are also removed: `status` only inspects PID argv, so it would not reflect `daemon.yaml`-supplied values. JSON consumers that depended on those fields should read `runs/<run-id>/supervisor.json` (per-task supervisor evidence) or the running daemon's `daemon.yaml` and process argv directly.
 - Generated environment profile JSON Schema now declares the `supervisor.default_cli` enum (`claude`, `codex`). The bundled `plugins/galley/skills/galley/references/environment.schema.json` is regenerated.
 
 ## v0.5.4 - 2026-05-22

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -111,7 +111,7 @@ CLI flags on `galley daemon run` or `galley daemon start` always override the ma
 3. The `supervisor` field in `daemon.yaml`.
 4. The built-in default (`codex`).
 
-`galley daemon status` (text and `--output json`) intentionally does not display a single effective `supervisor` field. Once `environment.yaml` can override the supervisor per task, a daemon-wide value would be misleading. The supervisor that actually ran a task, and the layer that selected it (`environment_profile`, `cli`, `daemon_config`, or `default`), are persisted to `runs/<run-id>/supervisor.json` as review evidence.
+`galley daemon status` (text and `--output json`) intentionally does not display daemon startup-default fields it cannot read accurately. The single `supervisor` field is omitted because `environment.yaml` can override the supervisor per task, and a daemon-wide value would be misleading. `max_concurrent_tasks` and `max_concurrent_per_repo` are omitted because `status` only inspects the daemon's PID argv and cannot see `daemon.yaml`-supplied values. The supervisor that actually ran a task, and the layer that selected it (`environment_profile`, `cli`, `daemon_config`, or `default`), are persisted to `runs/<run-id>/supervisor.json` as review evidence; the running daemon's effective concurrency comes from `daemon.yaml` and CLI argv directly.
 
 On Unix, foreground and background daemons use the same shutdown path. On `SIGINT` or `SIGTERM`, Galley stops claiming new queued tasks, lets active attempts finish until the shutdown timeout, records evidence, and avoids starting another retry attempt after shutdown is requested.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,7 +96,22 @@ galley daemon run --once
 
 Use the installed `galley` binary for `start`, `status`, and `stop`. PID verification records the executable path, so `go run ./cmd/galley ... daemon start` is not suitable for background daemon control because later `go run` invocations use different temporary binaries.
 
-`--supervisor` is a daemon startup flag (accepted on `galley daemon run` and inherited by `daemon start`) and selects the built-in supervisor adapter (`claude` or `codex`). When unset, daemon startup uses Codex. It is not a repository `environment.yaml` field: supervisor selection is daemon startup state, not a per-repo profile setting.
+### Daemon startup defaults (`daemon.yaml`)
+
+Both `galley daemon run` and `galley daemon start` create `daemon.yaml` under the selected daemon root on first use if the file does not already exist. The file holds the durable startup defaults for `supervisor`, `max_concurrent_tasks`, `max_concurrent_per_repo`, `poll_interval`, `claim_ttl`, `heartbeat_interval`, `shutdown_timeout`, and `idle_timeout`. Edit it to change daemon-wide defaults without re-specifying CLI flags. `galley daemon status` and `galley daemon stop` never create `daemon.yaml`; they are read-only.
+
+CLI flags on `galley daemon run` or `galley daemon start` always override the matching `daemon.yaml` field for that run (including `--shutdown-timeout`). Anything you do not set on the CLI falls back to `daemon.yaml`; anything `daemon.yaml` does not set falls back to the built-in default.
+
+### Supervisor resolution
+
+`--supervisor` selects the built-in supervisor adapter (`claude` or `codex`). The daemon resolves the supervisor for each task in this order:
+
+1. The repository `environment.yaml` `supervisor.default_cli` (resolved from `scope.cwd`). This overrides every layer below for that task only.
+2. The daemon CLI `--supervisor` startup flag.
+3. The `supervisor` field in `daemon.yaml`.
+4. The built-in default (`codex`).
+
+`galley daemon status` (text and `--output json`) intentionally does not display a single effective `supervisor` field. Once `environment.yaml` can override the supervisor per task, a daemon-wide value would be misleading. The supervisor that actually ran a task, and the layer that selected it (`environment_profile`, `cli`, `daemon_config`, or `default`), are persisted to `runs/<run-id>/supervisor.json` as review evidence.
 
 On Unix, foreground and background daemons use the same shutdown path. On `SIGINT` or `SIGTERM`, Galley stops claiming new queued tasks, lets active attempts finish until the shutdown timeout, records evidence, and avoids starting another retry attempt after shutdown is requested.
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -89,6 +89,8 @@ commands:
   build: "go build ./cmd/galley"
 executor:
   default_cli: "codex"
+supervisor:
+  default_cli: "codex"
 required_checks:
   shell: "auto"
 constraints:
@@ -111,6 +113,7 @@ Supported fields:
 - `cwd`: absolute path to the repository this profile describes.
 - `commands`: named local commands the executor and supervisor can reference.
 - `executor.default_cli`: optional implementation executor default for new task authoring. Values are `claude` and `codex`. When it is unset, new task authoring uses Codex unless the author explicitly chooses another backend. An explicit task YAML `executor.cli` remains authoritative for that task.
+- `supervisor.default_cli`: optional repository-scoped supervisor adapter. Values are `claude` and `codex`. When this field is set, the daemon uses it as the supervisor for any task whose `scope.cwd` resolves to this environment profile, overriding the daemon CLI `--supervisor` flag, the `supervisor` field in `daemon.yaml`, and the built-in default. When unset, the daemon uses the daemon-startup precedence chain (`--supervisor` → `daemon.yaml` → built-in default). The resolved supervisor and the layer that chose it are persisted to `runs/<run-id>/supervisor.json` as review evidence.
 - `required_checks.shell`: optional shell for Galley-owned `quality.required_checks` execution. Values are `auto`, `sh`, `bash`, `cmd`, `powershell`, and `pwsh`. When unset or `auto`, macOS/Linux use `/bin/sh`; Windows uses Git Bash when `bash.exe` is discoverable and falls back to `cmd.exe`. Galley records the resolved shell in verification evidence. Use `bash` for checks that rely on POSIX tools or syntax such as `grep`, `find`, `xargs`, `test`, `$()`, or single-quoted shell strings. Use `cmd`, `powershell`, or `pwsh` when the profile commands are intentionally Windows-native.
 - `constraints.network`: local network policy.
 - `constraints.secrets_policy`: secret handling policy.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -85,14 +85,20 @@ type Options struct {
 	CleanupWorktrees       bool
 	PRBase                 string
 	Supervisor             string
-	ShutdownTimeout        time.Duration
-	DisableClaudeGuard     bool
-	ClaudeGuardPluginDir   string
-	ClaudeBin              string
-	CodexBin               string
-	GitBin                 string
-	GHBin                  string
-	Explicit               ExplicitOptions
+	// SupervisorSource records where the resolved supervisor value came from
+	// (cli, daemon_config, default, or environment_profile). It is set by
+	// daemon CLI wiring before Preflight and then overridden per task when an
+	// environment.yaml supervisor.default_cli wins for that task. The value is
+	// persisted to runs/<run-id>/supervisor.json as evidence (AC8).
+	SupervisorSource     string
+	ShutdownTimeout      time.Duration
+	DisableClaudeGuard   bool
+	ClaudeGuardPluginDir string
+	ClaudeBin            string
+	CodexBin             string
+	GitBin               string
+	GHBin                string
+	Explicit             ExplicitOptions
 }
 
 type ExplicitOptions struct {
@@ -106,6 +112,7 @@ type ExplicitOptions struct {
 	PollInterval           bool
 	ClaimTTL               bool
 	HeartbeatInterval      bool
+	ShutdownTimeout        bool
 	IdleTimeout            bool
 	CommitOnAccept         bool
 	OpenPR                 bool
@@ -119,6 +126,16 @@ type ExplicitOptions struct {
 // DefaultSupervisor is the built-in supervisor adapter used when daemon
 // startup does not receive an explicit --supervisor value.
 const DefaultSupervisor = "codex"
+
+// Supervisor source labels. Persisted in run evidence (AC8) so reviewers can
+// tell whether the per-task supervisor came from a repository environment
+// profile, a daemon CLI startup flag, daemon.yaml, or the built-in default.
+const (
+	SupervisorSourceRepoProfile  = "environment_profile"
+	SupervisorSourceCLI          = "cli"
+	SupervisorSourceDaemonConfig = "daemon_config"
+	SupervisorSourceDefault      = "default"
+)
 
 // Run starts the daemon loop.
 func Run(ctx context.Context, opts Options) error {
@@ -208,6 +225,12 @@ func (opts Options) withDefaults() Options {
 	}
 	if opts.Supervisor == "" {
 		opts.Supervisor = DefaultSupervisor
+		if opts.SupervisorSource == "" {
+			opts.SupervisorSource = SupervisorSourceDefault
+		}
+	}
+	if opts.SupervisorSource == "" {
+		opts.SupervisorSource = SupervisorSourceDefault
 	}
 	if opts.MaxConcurrentTasks <= 0 {
 		opts.MaxConcurrentTasks = 1

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -60,6 +60,13 @@ func runSupervisorLoop(ctx, shutdownCtx context.Context, opts Options, runningPa
 	// bundle through this function keeps the supervisor loop from
 	// double-loading the environment profile.
 	effectiveOpts := effectiveOptionsForProfiles(opts, profiles)
+	// Persist the resolved supervisor and its source as run evidence (AC8).
+	// Reviewers can then tell whether the per-task supervisor came from the
+	// repository environment profile, daemon CLI startup options, daemon.yaml,
+	// or the built-in default without re-deriving the resolution from logs.
+	if err := writeSupervisorEvidence(runDir, effectiveOpts); err != nil {
+		fmt.Fprintf(os.Stderr, "galley: write supervisor evidence for run %s failed: %v\n", runID, err)
+	}
 	preflightResult, err := LoadPreflightResult(runDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "galley: could not load preflight result for run %s: %v\n", runID, err)
@@ -1210,4 +1217,17 @@ func attemptsLeft(budget, attempt int) int {
 		return 1
 	}
 	return budget - attempt
+}
+
+// writeSupervisorEvidence persists the resolved supervisor and its source for
+// a run so reviewers can verify which precedence layer (repository
+// environment profile, CLI startup flag, daemon.yaml, or built-in default)
+// determined the supervisor adapter Galley used (AC8). The function is
+// extracted from runSupervisorLoop so it can be unit-tested without driving a
+// full task through the daemon loop.
+func writeSupervisorEvidence(runDir string, effectiveOpts Options) error {
+	return writeJSON(filepath.Join(runDir, "supervisor.json"), map[string]string{
+		"resolved": effectiveOpts.Supervisor,
+		"source":   effectiveOpts.SupervisorSource,
+	})
 }

--- a/internal/daemon/options_test.go
+++ b/internal/daemon/options_test.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -77,6 +80,73 @@ func TestEffectiveOptionsForProfilesUsesEnvironmentOperations(t *testing.T) {
 	}
 	if effective.CleanupWorktrees {
 		t.Fatalf("cleanup should follow environment profile: %#v", effective)
+	}
+}
+
+func TestEffectiveOptionsForProfilesAppliesRepoSupervisor(t *testing.T) {
+	t.Parallel()
+	// AC4 / D1: when environment.yaml supervisor.default_cli is set, the
+	// daemon must use that supervisor for the task and record the source
+	// as the repository environment profile so AC8 run evidence reflects
+	// the precedence chain.
+	opts := Options{
+		Root:             t.TempDir(),
+		Supervisor:       "codex",
+		SupervisorSource: SupervisorSourceCLI,
+	}
+	effective := effectiveOptionsForProfiles(opts, profile.Bundle{
+		Environment: &profile.Environment{
+			Supervisor: &profile.SupervisorDefault{DefaultCLI: "claude"},
+		},
+	})
+	if effective.Supervisor != "claude" {
+		t.Fatalf("supervisor got %q, want claude", effective.Supervisor)
+	}
+	if effective.SupervisorSource != SupervisorSourceRepoProfile {
+		t.Fatalf("source got %q, want %s", effective.SupervisorSource, SupervisorSourceRepoProfile)
+	}
+}
+
+func TestEffectiveOptionsForProfilesKeepsCLISupervisorWhenRepoEmpty(t *testing.T) {
+	t.Parallel()
+	// AC5: when no repository supervisor is configured for a task, the
+	// daemon retains the resolution from CLI/daemon.yaml/default.
+	opts := Options{
+		Root:             t.TempDir(),
+		Supervisor:       "claude",
+		SupervisorSource: SupervisorSourceDaemonConfig,
+	}
+	effective := effectiveOptionsForProfiles(opts, profile.Bundle{
+		Environment: &profile.Environment{},
+	})
+	if effective.Supervisor != "claude" || effective.SupervisorSource != SupervisorSourceDaemonConfig {
+		t.Fatalf("unexpected effective opts: supervisor=%q source=%q", effective.Supervisor, effective.SupervisorSource)
+	}
+}
+
+func TestWriteSupervisorEvidenceRecordsResolvedAndSource(t *testing.T) {
+	t.Parallel()
+	// AC8: each daemon-processed task persists the resolved supervisor and
+	// the source that determined it so reviewers can map the precedence
+	// chain (environment_profile / cli / daemon_config / default) without
+	// re-deriving it from daemon logs.
+	runDir := t.TempDir()
+	if err := writeSupervisorEvidence(runDir, Options{
+		Supervisor:       "claude",
+		SupervisorSource: SupervisorSourceRepoProfile,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(runDir, "supervisor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["resolved"] != "claude" || got["source"] != SupervisorSourceRepoProfile {
+		t.Fatalf("supervisor evidence got %#v", got)
 	}
 }
 

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -191,6 +191,15 @@ func effectiveOptionsForProfiles(opts Options, profiles profile.Bundle) Options 
 		if env.Worktree.Cleanup != nil {
 			effective.CleanupWorktrees = *env.Worktree.Cleanup
 		}
+		// Per-task supervisor selection (AC4 / D1): when the resolved
+		// environment.yaml declares supervisor.default_cli, the daemon uses
+		// that adapter for this task even when CLI startup options or
+		// daemon.yaml chose a different supervisor. The override is recorded
+		// as `environment_profile` in run evidence (AC8).
+		if env.Supervisor != nil && env.Supervisor.DefaultCLI != "" {
+			effective.Supervisor = env.Supervisor.DefaultCLI
+			effective.SupervisorSource = SupervisorSourceRepoProfile
+		}
 	}
 	if effective.OpenPR {
 		effective.CommitOnAccept = true

--- a/internal/daemoncmd/command.go
+++ b/internal/daemoncmd/command.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/shinpr/galley/internal/daemon"
+	"github.com/shinpr/galley/internal/daemonconfig"
 	"github.com/shinpr/galley/internal/daemonctl"
 	"github.com/shinpr/galley/internal/galleyhome"
 	"github.com/shinpr/galley/internal/runner"
@@ -62,11 +63,34 @@ func NewCommand(use string) *cobra.Command {
 				switch supervisorProvider {
 				case "codex", "claude":
 					opts.Supervisor = supervisorProvider
+					opts.SupervisorSource = daemon.SupervisorSourceCLI
 				default:
 					return fmt.Errorf("--supervisor must be one of: codex, claude")
 				}
 			}
 			opts.Explicit = explicitOptionsFromFlags(cmd)
+			if pollInterval > 0 {
+				opts.PollInterval = pollInterval
+			}
+			// Daemon startup defaults (AC1/AC2/AC3). This RunE only fires
+			// for `galley daemon run` (via the run subcommand) and for the
+			// background daemon child spawned by `galley daemon start`
+			// (parent cmd name "daemon"). The `status` and `stop`
+			// subcommands install their own RunE and never reach this
+			// branch, so they remain read-only and do not create
+			// daemon.yaml (R2). `galley daemon start` itself also calls
+			// EnsureDefault before spawning the child so the operator sees
+			// the new file as soon as the start command returns. We then
+			// apply daemon.yaml values to any startup option the user did
+			// not explicitly set on the CLI; CLI flags always win (AC3).
+			if _, err := daemonconfig.EnsureDefault(opts.Root); err != nil {
+				return err
+			}
+			if cfg, present, err := daemonconfig.Load(opts.Root); err != nil {
+				return err
+			} else if present {
+				applyDaemonConfig(&opts, &pollInterval, cfg)
+			}
 			if pollInterval > 0 {
 				opts.PollInterval = pollInterval
 			}
@@ -128,6 +152,53 @@ func NewCommand(use string) *cobra.Command {
 	return cmd
 }
 
+// applyDaemonConfig fills daemon startup options whose flag was not explicitly
+// set with values from daemon.yaml. CLI flags always win (AC3). The supervisor
+// source is recorded as `daemon_config` whenever daemon.yaml provided the
+// resolved supervisor value, so run evidence can distinguish a CLI override
+// from a daemon.yaml default (AC8). Per-task environment.yaml
+// supervisor.default_cli overrides this later in the daemon runtime (AC4).
+func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg daemonconfig.File) {
+	if !opts.Explicit.Supervisor && opts.SupervisorSource != daemon.SupervisorSourceCLI && cfg.Supervisor != "" {
+		opts.Supervisor = cfg.Supervisor
+		opts.SupervisorSource = daemon.SupervisorSourceDaemonConfig
+	}
+	if !opts.Explicit.MaxConcurrentTasks && cfg.MaxConcurrentTasks != nil {
+		opts.MaxConcurrentTasks = *cfg.MaxConcurrentTasks
+	}
+	if !opts.Explicit.MaxConcurrentPerRepo && cfg.MaxConcurrentPerRepo != nil {
+		opts.MaxConcurrentPerRepo = *cfg.MaxConcurrentPerRepo
+	}
+	if !opts.Explicit.PollInterval && cfg.PollInterval != "" {
+		if d, ok, _ := daemonconfig.Duration(cfg.PollInterval); ok {
+			*pollInterval = d
+		}
+	}
+	if !opts.Explicit.ClaimTTL && cfg.ClaimTTL != "" {
+		if d, ok, _ := daemonconfig.Duration(cfg.ClaimTTL); ok {
+			opts.ClaimTTL = d
+		}
+	}
+	if !opts.Explicit.HeartbeatInterval && cfg.HeartbeatInterval != "" {
+		if d, ok, _ := daemonconfig.Duration(cfg.HeartbeatInterval); ok {
+			opts.HeartbeatInterval = d
+		}
+	}
+	// ShutdownTimeout follows the same explicit-flag tracking as the other
+	// daemon.yaml-backed startup defaults (AC3): when the CLI flag was not
+	// changed, daemon.yaml wins; otherwise the CLI value is preserved.
+	if !opts.Explicit.ShutdownTimeout && cfg.ShutdownTimeout != "" {
+		if d, ok, _ := daemonconfig.Duration(cfg.ShutdownTimeout); ok {
+			opts.ShutdownTimeout = d
+		}
+	}
+	if !opts.Explicit.IdleTimeout && cfg.IdleTimeout != "" {
+		if d, ok, _ := daemonconfig.Duration(cfg.IdleTimeout); ok {
+			opts.IdleTimeout = d
+		}
+	}
+}
+
 func explicitOptionsFromFlags(cmd *cobra.Command) daemon.ExplicitOptions {
 	changed := cmd.Flags().Changed
 	return daemon.ExplicitOptions{
@@ -137,6 +208,7 @@ func explicitOptionsFromFlags(cmd *cobra.Command) daemon.ExplicitOptions {
 		PollInterval:         changed("poll-interval"),
 		ClaimTTL:             changed("claim-ttl"),
 		HeartbeatInterval:    changed("heartbeat-interval"),
+		ShutdownTimeout:      changed("shutdown-timeout"),
 		IdleTimeout:          changed("idle-timeout"),
 		Supervisor:           changed("supervisor"),
 	}
@@ -161,6 +233,15 @@ func newStartCommand(opts *daemon.Options, pidFile, logFile *string, readinessTi
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Once {
 				return fmt.Errorf("start does not support --once")
+			}
+			// Ensure daemon.yaml exists under the selected root before the
+			// child daemon spawns (AC1). The background child cannot reliably
+			// surface a creation error to the operator, and operators expect
+			// to edit daemon.yaml immediately after `galley daemon start`
+			// returns. The child still re-loads daemon.yaml so any value
+			// written here is what the child resolves on first boot.
+			if _, err := daemonconfig.EnsureDefault(opts.Root); err != nil {
+				return err
 			}
 			paths := daemonctl.ResolvePaths(opts.Root, *pidFile, *logFile)
 			exe, err := os.Executable()
@@ -374,6 +455,11 @@ func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.P
 	if status != nil {
 		runtime = runtime.withArgv(status.Meta.Argv)
 	}
+	// AC7 / D3: daemon status intentionally does not surface a single
+	// "supervisor" field. Per-repository environment.yaml supervisor.default_cli
+	// can override the daemon startup supervisor for individual tasks, so a
+	// daemon-wide supervisor value would be misleading. Supervisor resolution
+	// for an actual task is persisted in runs/<run-id>/supervisor.json (AC8).
 	payload := struct {
 		Running           bool   `json:"running"`
 		Verified          bool   `json:"verified"`
@@ -381,7 +467,6 @@ func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.P
 		Root              string `json:"root"`
 		PIDFile           string `json:"pid_file"`
 		LogFile           string `json:"log_file"`
-		Supervisor        string `json:"supervisor,omitempty"`
 		MaxConcurrent     int    `json:"max_concurrent_tasks,omitempty"`
 		MaxConcurrentRepo int    `json:"max_concurrent_per_repo,omitempty"`
 	}{
@@ -390,7 +475,6 @@ func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.P
 		Root:              opts.Root,
 		PIDFile:           paths.PIDFile,
 		LogFile:           paths.LogFile,
-		Supervisor:        runtime.Supervisor,
 		MaxConcurrent:     runtime.MaxConcurrentTasks,
 		MaxConcurrentRepo: runtime.MaxConcurrentPerRepo,
 	}

--- a/internal/daemoncmd/command.go
+++ b/internal/daemoncmd/command.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -89,7 +88,9 @@ func NewCommand(use string) *cobra.Command {
 			if cfg, present, err := daemonconfig.Load(opts.Root); err != nil {
 				return err
 			} else if present {
-				applyDaemonConfig(&opts, &pollInterval, cfg)
+				if err := applyDaemonConfig(&opts, &pollInterval, cfg); err != nil {
+					return err
+				}
 			}
 			if pollInterval > 0 {
 				opts.PollInterval = pollInterval
@@ -158,29 +159,49 @@ func NewCommand(use string) *cobra.Command {
 // resolved supervisor value, so run evidence can distinguish a CLI override
 // from a daemon.yaml default (AC8). Per-task environment.yaml
 // supervisor.default_cli overrides this later in the daemon runtime (AC4).
-func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg daemonconfig.File) {
-	if !opts.Explicit.Supervisor && opts.SupervisorSource != daemon.SupervisorSourceCLI && cfg.Supervisor != "" {
+//
+// When daemon.yaml supplies an integer concurrency value, the corresponding
+// Explicit flag is set so daemon.Options.withDefaults treats it as an
+// explicitly configured value. This preserves `max_concurrent_per_repo: 0`
+// (disable the per-repo limit) from being silently turned back into 1 by the
+// daemon default fallback.
+func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg daemonconfig.File) error {
+	if !opts.Explicit.Supervisor && cfg.Supervisor != "" {
 		opts.Supervisor = cfg.Supervisor
 		opts.SupervisorSource = daemon.SupervisorSourceDaemonConfig
 	}
 	if !opts.Explicit.MaxConcurrentTasks && cfg.MaxConcurrentTasks != nil {
 		opts.MaxConcurrentTasks = *cfg.MaxConcurrentTasks
+		opts.Explicit.MaxConcurrentTasks = true
 	}
 	if !opts.Explicit.MaxConcurrentPerRepo && cfg.MaxConcurrentPerRepo != nil {
 		opts.MaxConcurrentPerRepo = *cfg.MaxConcurrentPerRepo
+		opts.Explicit.MaxConcurrentPerRepo = true
 	}
 	if !opts.Explicit.PollInterval && cfg.PollInterval != "" {
-		if d, ok, _ := daemonconfig.Duration(cfg.PollInterval); ok {
+		d, ok, err := daemonconfig.Duration(cfg.PollInterval)
+		if err != nil {
+			return fmt.Errorf("daemon.yaml poll_interval: %w", err)
+		}
+		if ok {
 			*pollInterval = d
 		}
 	}
 	if !opts.Explicit.ClaimTTL && cfg.ClaimTTL != "" {
-		if d, ok, _ := daemonconfig.Duration(cfg.ClaimTTL); ok {
+		d, ok, err := daemonconfig.Duration(cfg.ClaimTTL)
+		if err != nil {
+			return fmt.Errorf("daemon.yaml claim_ttl: %w", err)
+		}
+		if ok {
 			opts.ClaimTTL = d
 		}
 	}
 	if !opts.Explicit.HeartbeatInterval && cfg.HeartbeatInterval != "" {
-		if d, ok, _ := daemonconfig.Duration(cfg.HeartbeatInterval); ok {
+		d, ok, err := daemonconfig.Duration(cfg.HeartbeatInterval)
+		if err != nil {
+			return fmt.Errorf("daemon.yaml heartbeat_interval: %w", err)
+		}
+		if ok {
 			opts.HeartbeatInterval = d
 		}
 	}
@@ -188,15 +209,24 @@ func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg da
 	// daemon.yaml-backed startup defaults (AC3): when the CLI flag was not
 	// changed, daemon.yaml wins; otherwise the CLI value is preserved.
 	if !opts.Explicit.ShutdownTimeout && cfg.ShutdownTimeout != "" {
-		if d, ok, _ := daemonconfig.Duration(cfg.ShutdownTimeout); ok {
+		d, ok, err := daemonconfig.Duration(cfg.ShutdownTimeout)
+		if err != nil {
+			return fmt.Errorf("daemon.yaml shutdown_timeout: %w", err)
+		}
+		if ok {
 			opts.ShutdownTimeout = d
 		}
 	}
 	if !opts.Explicit.IdleTimeout && cfg.IdleTimeout != "" {
-		if d, ok, _ := daemonconfig.Duration(cfg.IdleTimeout); ok {
+		d, ok, err := daemonconfig.Duration(cfg.IdleTimeout)
+		if err != nil {
+			return fmt.Errorf("daemon.yaml idle_timeout: %w", err)
+		}
+		if ok {
 			opts.IdleTimeout = d
 		}
 	}
+	return nil
 }
 
 func explicitOptionsFromFlags(cmd *cobra.Command) daemon.ExplicitOptions {
@@ -451,32 +481,27 @@ func newStatusCommand(opts *daemon.Options, pidFile *string) *cobra.Command {
 }
 
 func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.Paths, status *daemonctl.Status, alive, verified bool) error {
-	runtime := statusRuntimeFromOptions(*opts)
-	if status != nil {
-		runtime = runtime.withArgv(status.Meta.Argv)
-	}
-	// AC7 / D3: daemon status intentionally does not surface a single
-	// "supervisor" field. Per-repository environment.yaml supervisor.default_cli
-	// can override the daemon startup supervisor for individual tasks, so a
-	// daemon-wide supervisor value would be misleading. Supervisor resolution
-	// for an actual task is persisted in runs/<run-id>/supervisor.json (AC8).
+	// AC7 / D3: daemon status intentionally does not surface daemon startup
+	// defaults that can be overridden by daemon.yaml or by per-repository
+	// environment.yaml. `supervisor` is omitted because a daemon-wide value
+	// would be misleading once per-task supervisor resolution exists.
+	// `max_concurrent_tasks` and `max_concurrent_per_repo` are omitted for the
+	// same reason: status can only see CLI argv, so daemon.yaml-supplied
+	// values would not be reflected accurately. Resolution evidence for an
+	// actual task is persisted in runs/<run-id>/supervisor.json (AC8).
 	payload := struct {
-		Running           bool   `json:"running"`
-		Verified          bool   `json:"verified"`
-		PID               int    `json:"pid,omitempty"`
-		Root              string `json:"root"`
-		PIDFile           string `json:"pid_file"`
-		LogFile           string `json:"log_file"`
-		MaxConcurrent     int    `json:"max_concurrent_tasks,omitempty"`
-		MaxConcurrentRepo int    `json:"max_concurrent_per_repo,omitempty"`
+		Running  bool   `json:"running"`
+		Verified bool   `json:"verified"`
+		PID      int    `json:"pid,omitempty"`
+		Root     string `json:"root"`
+		PIDFile  string `json:"pid_file"`
+		LogFile  string `json:"log_file"`
 	}{
-		Running:           alive,
-		Verified:          verified,
-		Root:              opts.Root,
-		PIDFile:           paths.PIDFile,
-		LogFile:           paths.LogFile,
-		MaxConcurrent:     runtime.MaxConcurrentTasks,
-		MaxConcurrentRepo: runtime.MaxConcurrentPerRepo,
+		Running:  alive,
+		Verified: verified,
+		Root:     opts.Root,
+		PIDFile:  paths.PIDFile,
+		LogFile:  paths.LogFile,
 	}
 	if status != nil {
 		payload.PID = status.Meta.PID
@@ -484,66 +509,6 @@ func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.P
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(payload)
-}
-
-type statusRuntime struct {
-	Supervisor           string
-	MaxConcurrentTasks   int
-	MaxConcurrentPerRepo int
-}
-
-func statusRuntimeFromOptions(opts daemon.Options) statusRuntime {
-	return statusRuntime{
-		Supervisor:           opts.Supervisor,
-		MaxConcurrentTasks:   opts.MaxConcurrentTasks,
-		MaxConcurrentPerRepo: opts.MaxConcurrentPerRepo,
-	}
-}
-
-func (runtime statusRuntime) withArgv(argv []string) statusRuntime {
-	if len(argv) == 0 {
-		return runtime
-	}
-	if value, ok := flagValue(argv, "--supervisor"); ok {
-		runtime.Supervisor = value
-	} else if runtime.Supervisor == "" {
-		runtime.Supervisor = daemon.DefaultSupervisor
-	}
-	if value, ok := intFlagValue(argv, "--max-concurrent-tasks"); ok {
-		runtime.MaxConcurrentTasks = value
-	}
-	if value, ok := intFlagValue(argv, "--max-concurrent-per-repo"); ok {
-		runtime.MaxConcurrentPerRepo = value
-	}
-	return runtime
-}
-
-func flagValue(argv []string, name string) (string, bool) {
-	for i, arg := range argv {
-		if arg == name {
-			if i+1 < len(argv) {
-				return argv[i+1], true
-			}
-			return "", false
-		}
-		prefix := name + "="
-		if len(arg) > len(prefix) && arg[:len(prefix)] == prefix {
-			return arg[len(prefix):], true
-		}
-	}
-	return "", false
-}
-
-func intFlagValue(argv []string, name string) (int, bool) {
-	value, ok := flagValue(argv, name)
-	if !ok {
-		return 0, false
-	}
-	parsed, err := strconv.Atoi(value)
-	if err != nil {
-		return 0, false
-	}
-	return parsed, true
 }
 
 func waitReady(pidFile, root, executable string, timeout time.Duration) error {

--- a/internal/daemoncmd/command_test.go
+++ b/internal/daemoncmd/command_test.go
@@ -3,11 +3,14 @@ package daemoncmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shinpr/galley/internal/daemon"
+	"github.com/shinpr/galley/internal/daemonconfig"
 )
 
 func TestForegroundArgsRemovesStartCommand(t *testing.T) {
@@ -99,6 +102,116 @@ func TestDaemonHelpReportsCodexSupervisorDefault(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "defaults to "+daemon.DefaultSupervisor) {
 		t.Fatalf("help output missing codex supervisor default: %q", stdout.String())
+	}
+}
+
+func TestStatusJSONOmitsSupervisorField(t *testing.T) {
+	t.Parallel()
+	// AC7 / D3: `galley daemon status --output json` must not include a
+	// single `supervisor` field because per-repository environment.yaml
+	// supervisor.default_cli can override the daemon startup supervisor
+	// for individual tasks; a daemon-wide supervisor field would be
+	// misleading. The resolved supervisor for a real task is persisted
+	// in runs/<run-id>/supervisor.json (AC8).
+	root := t.TempDir()
+	cmd := NewCommand("daemon")
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--root", root, "status", "--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := raw["supervisor"]; present {
+		t.Fatalf("status JSON must not include a supervisor field: %s", stdout.String())
+	}
+}
+
+func TestRunOnceCreatesDaemonYAML(t *testing.T) {
+	t.Parallel()
+	// AC1: when `galley daemon run` is invoked and daemon.yaml does not
+	// exist under the selected daemon root, the system creates it with
+	// documented defaults before running the daemon. With --once and an
+	// empty queue the daemon loop exits immediately and we can inspect
+	// the side effect.
+	root := t.TempDir()
+	cmd := NewCommand("daemon")
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--root", root, "run", "--once"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, daemonconfig.Filename))
+	if err != nil {
+		t.Fatalf("daemon.yaml not created: %v", err)
+	}
+	for _, want := range []string{"supervisor: codex", "poll_interval: 10s", "shutdown_timeout: 5m"} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("daemon.yaml missing %q\ncontent: %s", want, string(data))
+		}
+	}
+}
+
+func TestApplyDaemonConfigFillsAbsentFlagsAndPreservesExplicit(t *testing.T) {
+	t.Parallel()
+	// AC2: when daemon.yaml exists, startup loads its durable defaults
+	// without requiring CLI flags.
+	// AC3: when both daemon.yaml and CLI options define the same setting,
+	// the CLI option overrides daemon.yaml for that run. This test exercises
+	// shutdown-timeout explicitly because the previous implementation
+	// missed it.
+	one := 1
+	cfg := daemonconfig.File{
+		Supervisor:           "claude",
+		MaxConcurrentTasks:   &one,
+		MaxConcurrentPerRepo: &one,
+		PollInterval:         "30s",
+		ClaimTTL:             "1h",
+		HeartbeatInterval:    "15s",
+		ShutdownTimeout:      "2m",
+		IdleTimeout:          "5m",
+	}
+	// Case 1: no flags explicit, daemon.yaml wins.
+	opts := daemon.Options{
+		ShutdownTimeout: 5 * time.Minute,
+	}
+	var poll time.Duration
+	applyDaemonConfig(&opts, &poll, cfg)
+	if opts.Supervisor != "claude" || opts.SupervisorSource != daemon.SupervisorSourceDaemonConfig {
+		t.Fatalf("daemon.yaml supervisor not applied: %#v", opts)
+	}
+	if opts.ShutdownTimeout != 2*time.Minute {
+		t.Fatalf("daemon.yaml shutdown_timeout not applied: %s", opts.ShutdownTimeout)
+	}
+	if opts.ClaimTTL != time.Hour || opts.HeartbeatInterval != 15*time.Second || opts.IdleTimeout != 5*time.Minute {
+		t.Fatalf("daemon.yaml durations not applied: %#v", opts)
+	}
+	if poll != 30*time.Second {
+		t.Fatalf("daemon.yaml poll_interval not applied: %s", poll)
+	}
+
+	// Case 2: CLI flags explicit, CLI wins for shutdown-timeout and supervisor.
+	opts2 := daemon.Options{
+		ShutdownTimeout:  90 * time.Second,
+		Supervisor:       "codex",
+		SupervisorSource: daemon.SupervisorSourceCLI,
+		Explicit: daemon.ExplicitOptions{
+			Supervisor:      true,
+			ShutdownTimeout: true,
+		},
+	}
+	var poll2 time.Duration
+	applyDaemonConfig(&opts2, &poll2, cfg)
+	if opts2.Supervisor != "codex" || opts2.SupervisorSource != daemon.SupervisorSourceCLI {
+		t.Fatalf("CLI supervisor must win: %#v", opts2)
+	}
+	if opts2.ShutdownTimeout != 90*time.Second {
+		t.Fatalf("CLI shutdown_timeout must win: %s", opts2.ShutdownTimeout)
 	}
 }
 

--- a/internal/daemoncmd/command_test.go
+++ b/internal/daemoncmd/command_test.go
@@ -63,33 +63,6 @@ func TestStatusJSONReportsRoot(t *testing.T) {
 	}
 }
 
-func TestStatusRuntimeRestoresDaemonArgs(t *testing.T) {
-	t.Parallel()
-	runtime := statusRuntime{}.withArgv([]string{
-		"/bin/galley",
-		"daemon",
-		"--supervisor",
-		"codex",
-		"--max-concurrent-tasks",
-		"3",
-		"--max-concurrent-per-repo=2",
-	})
-	if runtime.Supervisor != "codex" {
-		t.Fatalf("supervisor got %q", runtime.Supervisor)
-	}
-	if runtime.MaxConcurrentTasks != 3 || runtime.MaxConcurrentPerRepo != 2 {
-		t.Fatalf("parsed values got %#v", runtime)
-	}
-}
-
-func TestStatusRuntimeDefaultsSupervisorForDaemonWithoutFlag(t *testing.T) {
-	t.Parallel()
-	runtime := statusRuntime{}.withArgv([]string{"/bin/galley", "daemon"})
-	if runtime.Supervisor != daemon.DefaultSupervisor {
-		t.Fatalf("supervisor got %q", runtime.Supervisor)
-	}
-}
-
 func TestDaemonHelpReportsCodexSupervisorDefault(t *testing.T) {
 	t.Parallel()
 	cmd := NewCommand("daemon")
@@ -105,14 +78,16 @@ func TestDaemonHelpReportsCodexSupervisorDefault(t *testing.T) {
 	}
 }
 
-func TestStatusJSONOmitsSupervisorField(t *testing.T) {
+func TestStatusJSONOmitsRuntimeDefaultFields(t *testing.T) {
 	t.Parallel()
-	// AC7 / D3: `galley daemon status --output json` must not include a
-	// single `supervisor` field because per-repository environment.yaml
-	// supervisor.default_cli can override the daemon startup supervisor
-	// for individual tasks; a daemon-wide supervisor field would be
-	// misleading. The resolved supervisor for a real task is persisted
-	// in runs/<run-id>/supervisor.json (AC8).
+	// AC7 / D3: `galley daemon status --output json` must not include
+	// daemon startup defaults that can be supplied by either daemon.yaml
+	// or per-repository environment.yaml. The single `supervisor` field is
+	// misleading because per-repository `supervisor.default_cli` overrides
+	// it per task. `max_concurrent_tasks` and `max_concurrent_per_repo`
+	// are misleading because `status` only sees PID argv and cannot read
+	// daemon.yaml-supplied values. Resolution evidence for actual tasks is
+	// persisted in runs/<run-id>/supervisor.json (AC8).
 	root := t.TempDir()
 	cmd := NewCommand("daemon")
 	var stdout bytes.Buffer
@@ -126,8 +101,10 @@ func TestStatusJSONOmitsSupervisorField(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
 		t.Fatal(err)
 	}
-	if _, present := raw["supervisor"]; present {
-		t.Fatalf("status JSON must not include a supervisor field: %s", stdout.String())
+	for _, field := range []string{"supervisor", "max_concurrent_tasks", "max_concurrent_per_repo"} {
+		if _, present := raw[field]; present {
+			t.Fatalf("status JSON must not include %q: %s", field, stdout.String())
+		}
 	}
 }
 
@@ -163,27 +140,37 @@ func TestApplyDaemonConfigFillsAbsentFlagsAndPreservesExplicit(t *testing.T) {
 	// without requiring CLI flags.
 	// AC3: when both daemon.yaml and CLI options define the same setting,
 	// the CLI option overrides daemon.yaml for that run. This test exercises
-	// shutdown-timeout explicitly because the previous implementation
-	// missed it.
-	one := 1
+	// every daemon.yaml-backed startup option, including the integer
+	// concurrency fields, so a future change that drops one or weakens the
+	// CLI-wins contract is caught.
+	four := 4
+	two := 2
 	cfg := daemonconfig.File{
 		Supervisor:           "claude",
-		MaxConcurrentTasks:   &one,
-		MaxConcurrentPerRepo: &one,
+		MaxConcurrentTasks:   &four,
+		MaxConcurrentPerRepo: &two,
 		PollInterval:         "30s",
 		ClaimTTL:             "1h",
 		HeartbeatInterval:    "15s",
 		ShutdownTimeout:      "2m",
 		IdleTimeout:          "5m",
 	}
-	// Case 1: no flags explicit, daemon.yaml wins.
+	// Case 1: no flags explicit, daemon.yaml wins for every field.
 	opts := daemon.Options{
 		ShutdownTimeout: 5 * time.Minute,
 	}
 	var poll time.Duration
-	applyDaemonConfig(&opts, &poll, cfg)
+	if err := applyDaemonConfig(&opts, &poll, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if opts.Supervisor != "claude" || opts.SupervisorSource != daemon.SupervisorSourceDaemonConfig {
 		t.Fatalf("daemon.yaml supervisor not applied: %#v", opts)
+	}
+	if opts.MaxConcurrentTasks != 4 || !opts.Explicit.MaxConcurrentTasks {
+		t.Fatalf("daemon.yaml max_concurrent_tasks not applied or not marked explicit: %#v", opts)
+	}
+	if opts.MaxConcurrentPerRepo != 2 || !opts.Explicit.MaxConcurrentPerRepo {
+		t.Fatalf("daemon.yaml max_concurrent_per_repo not applied or not marked explicit: %#v", opts)
 	}
 	if opts.ShutdownTimeout != 2*time.Minute {
 		t.Fatalf("daemon.yaml shutdown_timeout not applied: %s", opts.ShutdownTimeout)
@@ -195,23 +182,63 @@ func TestApplyDaemonConfigFillsAbsentFlagsAndPreservesExplicit(t *testing.T) {
 		t.Fatalf("daemon.yaml poll_interval not applied: %s", poll)
 	}
 
-	// Case 2: CLI flags explicit, CLI wins for shutdown-timeout and supervisor.
+	// Case 2: CLI flags explicit, CLI wins for every field daemon.yaml also provides.
 	opts2 := daemon.Options{
-		ShutdownTimeout:  90 * time.Second,
-		Supervisor:       "codex",
-		SupervisorSource: daemon.SupervisorSourceCLI,
+		ShutdownTimeout:      90 * time.Second,
+		Supervisor:           "codex",
+		SupervisorSource:     daemon.SupervisorSourceCLI,
+		MaxConcurrentTasks:   8,
+		MaxConcurrentPerRepo: 3,
 		Explicit: daemon.ExplicitOptions{
-			Supervisor:      true,
-			ShutdownTimeout: true,
+			Supervisor:           true,
+			ShutdownTimeout:      true,
+			MaxConcurrentTasks:   true,
+			MaxConcurrentPerRepo: true,
 		},
 	}
 	var poll2 time.Duration
-	applyDaemonConfig(&opts2, &poll2, cfg)
+	if err := applyDaemonConfig(&opts2, &poll2, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if opts2.Supervisor != "codex" || opts2.SupervisorSource != daemon.SupervisorSourceCLI {
 		t.Fatalf("CLI supervisor must win: %#v", opts2)
 	}
+	if opts2.MaxConcurrentTasks != 8 || opts2.MaxConcurrentPerRepo != 3 {
+		t.Fatalf("CLI concurrency must win: %#v", opts2)
+	}
 	if opts2.ShutdownTimeout != 90*time.Second {
 		t.Fatalf("CLI shutdown_timeout must win: %s", opts2.ShutdownTimeout)
+	}
+}
+
+func TestApplyDaemonConfigPreservesZeroPerRepoLimit(t *testing.T) {
+	t.Parallel()
+	// daemon.yaml `max_concurrent_per_repo: 0` means "disable the per-repo
+	// limit", matching the CLI `--max-concurrent-per-repo=0` contract. The
+	// 0 must survive past daemon.Options.withDefaults; if applyDaemonConfig
+	// did not mark the option explicit, withDefaults would silently turn
+	// the user-configured 0 back into 1.
+	zero := 0
+	cfg := daemonconfig.File{MaxConcurrentPerRepo: &zero}
+	opts := daemon.Options{MaxConcurrentPerRepo: 1}
+	var poll time.Duration
+	if err := applyDaemonConfig(&opts, &poll, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if opts.MaxConcurrentPerRepo != 0 || !opts.Explicit.MaxConcurrentPerRepo {
+		t.Fatalf("daemon.yaml 0 must be preserved and marked explicit: %#v", opts)
+	}
+	preflighted, err := daemon.Preflight(daemon.Options{
+		Root:                 t.TempDir(),
+		Supervisor:           "codex",
+		MaxConcurrentPerRepo: 0,
+		Explicit:             daemon.ExplicitOptions{MaxConcurrentPerRepo: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflighted.MaxConcurrentPerRepo != 0 {
+		t.Fatalf("Preflight must preserve max_concurrent_per_repo=0; got %d", preflighted.MaxConcurrentPerRepo)
 	}
 }
 

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -142,9 +142,16 @@ func (f File) Validate() error {
 	if f.Supervisor != "" && f.Supervisor != "claude" && f.Supervisor != "codex" {
 		return fmt.Errorf("supervisor must be one of: claude, codex (got %q)", f.Supervisor)
 	}
-	if f.MaxConcurrentTasks != nil && *f.MaxConcurrentTasks < 0 {
-		return fmt.Errorf("max_concurrent_tasks must be >= 0 (got %d)", *f.MaxConcurrentTasks)
+	// max_concurrent_tasks must be >= 1: the daemon always needs at least
+	// one worker to make progress, and silently accepting 0 here just gets
+	// rewritten by daemon.Options.withDefaults to 1 — leaving operators
+	// unsure whether their daemon.yaml value took effect. This contract
+	// matches the CLI flag, which is documented and defaulted to 1.
+	if f.MaxConcurrentTasks != nil && *f.MaxConcurrentTasks < 1 {
+		return fmt.Errorf("max_concurrent_tasks must be >= 1 (got %d)", *f.MaxConcurrentTasks)
 	}
+	// max_concurrent_per_repo accepts 0 to disable the per-repo limit,
+	// matching the CLI `--max-concurrent-per-repo=0` contract.
 	if f.MaxConcurrentPerRepo != nil && *f.MaxConcurrentPerRepo < 0 {
 		return fmt.Errorf("max_concurrent_per_repo must be >= 0 (got %d)", *f.MaxConcurrentPerRepo)
 	}

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -1,0 +1,200 @@
+// Package daemonconfig owns the durable daemon startup defaults written to
+// daemon.yaml under the selected daemon root. It is intentionally independent
+// from the daemon and daemoncmd packages so daemon CLI wiring and the runtime
+// loop can both consume the same on-disk contract without creating an import
+// cycle.
+//
+// Resolution order, per the daemon startup defaults task contract:
+//
+//  1. Daemon CLI startup options (explicit flags on `galley daemon run` or
+//     `galley daemon start`).
+//  2. daemon.yaml under the selected daemon root.
+//  3. Built-in defaults (Codex supervisor and the other documented daemon
+//     defaults).
+//
+// Repository-level `environment.yaml` supervisor.default_cli is a *task-level*
+// override that takes precedence over all three of the above for that task's
+// supervisor selection only. That precedence is enforced by the daemon
+// runtime, not this package.
+package daemonconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Filename is the daemon configuration filename written under the daemon root.
+const Filename = "daemon.yaml"
+
+// File is the YAML shape persisted under <root>/daemon.yaml. Every field is
+// optional: an absent field defers to the next layer in the resolution chain.
+// Durations are stored as Go duration strings (for example "10s" or "30m") so
+// the file stays human-readable.
+type File struct {
+	Supervisor           string `yaml:"supervisor,omitempty"`
+	MaxConcurrentTasks   *int   `yaml:"max_concurrent_tasks,omitempty"`
+	MaxConcurrentPerRepo *int   `yaml:"max_concurrent_per_repo,omitempty"`
+	PollInterval         string `yaml:"poll_interval,omitempty"`
+	ClaimTTL             string `yaml:"claim_ttl,omitempty"`
+	HeartbeatInterval    string `yaml:"heartbeat_interval,omitempty"`
+	ShutdownTimeout      string `yaml:"shutdown_timeout,omitempty"`
+	IdleTimeout          string `yaml:"idle_timeout,omitempty"`
+}
+
+// Defaults returns the documented daemon startup defaults that are written to
+// daemon.yaml on first creation. They mirror the built-in CLI default values
+// so an operator can edit a single file instead of relying on flag defaults.
+func Defaults() File {
+	one := 1
+	return File{
+		Supervisor:           "codex",
+		MaxConcurrentTasks:   &one,
+		MaxConcurrentPerRepo: &one,
+		PollInterval:         "10s",
+		ClaimTTL:             "30m",
+		HeartbeatInterval:    "1m",
+		ShutdownTimeout:      "5m",
+		IdleTimeout:          "10m",
+	}
+}
+
+// Path returns the daemon configuration path under root.
+func Path(root string) string { return filepath.Join(root, Filename) }
+
+// EnsureDefault creates daemon.yaml under root with the documented defaults
+// when the file does not exist. It is the only function that mutates the
+// daemon configuration file; read-only commands (status, stop) must not call
+// it. Returns true when the file was created.
+func EnsureDefault(root string) (bool, error) {
+	if root == "" {
+		return false, errors.New("daemonconfig: root is required")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return false, fmt.Errorf("create daemon root: %w", err)
+	}
+	path := Path(root)
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return false, fmt.Errorf("inspect %s: %w", path, err)
+	}
+	data, err := marshalDocumentedDefaults()
+	if err != nil {
+		return false, err
+	}
+	// O_CREATE|O_EXCL avoids racing a concurrent daemon start that may also
+	// be creating the same file.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("create %s: %w", path, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return false, fmt.Errorf("close %s: %w", path, err)
+	}
+	return true, nil
+}
+
+// Load reads daemon.yaml under root. The boolean reports whether the file was
+// present. A missing file is not an error; the caller proceeds with built-in
+// defaults.
+func Load(root string) (File, bool, error) {
+	if root == "" {
+		return File{}, false, errors.New("daemonconfig: root is required")
+	}
+	path := Path(root)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return File{}, false, nil
+		}
+		return File{}, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var file File
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&file); err != nil {
+		return File{}, true, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if err := file.Validate(); err != nil {
+		return File{}, true, fmt.Errorf("validate %s: %w", path, err)
+	}
+	return file, true, nil
+}
+
+// Validate checks that the fields present in the file are well-formed. An
+// absent field is always valid because the resolver falls back to the next
+// layer.
+func (f File) Validate() error {
+	if f.Supervisor != "" && f.Supervisor != "claude" && f.Supervisor != "codex" {
+		return fmt.Errorf("supervisor must be one of: claude, codex (got %q)", f.Supervisor)
+	}
+	if f.MaxConcurrentTasks != nil && *f.MaxConcurrentTasks < 0 {
+		return fmt.Errorf("max_concurrent_tasks must be >= 0 (got %d)", *f.MaxConcurrentTasks)
+	}
+	if f.MaxConcurrentPerRepo != nil && *f.MaxConcurrentPerRepo < 0 {
+		return fmt.Errorf("max_concurrent_per_repo must be >= 0 (got %d)", *f.MaxConcurrentPerRepo)
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"poll_interval", f.PollInterval},
+		{"claim_ttl", f.ClaimTTL},
+		{"heartbeat_interval", f.HeartbeatInterval},
+		{"shutdown_timeout", f.ShutdownTimeout},
+		{"idle_timeout", f.IdleTimeout},
+	} {
+		if field.value == "" {
+			continue
+		}
+		if _, err := time.ParseDuration(field.value); err != nil {
+			return fmt.Errorf("%s must be a valid Go duration (got %q): %w", field.name, field.value, err)
+		}
+	}
+	return nil
+}
+
+// Duration parses a duration string field. An empty string returns ok=false so
+// callers can leave the resolved value untouched.
+func Duration(value string) (time.Duration, bool, error) {
+	if value == "" {
+		return 0, false, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, false, err
+	}
+	return d, true, nil
+}
+
+func marshalDocumentedDefaults() ([]byte, error) {
+	defaults := Defaults()
+	var buf bytes.Buffer
+	buf.WriteString("# Galley daemon startup defaults.\n")
+	buf.WriteString("# Edit these values to change daemon-wide defaults without re-specifying CLI flags.\n")
+	buf.WriteString("# CLI flags on `galley daemon run` or `galley daemon start` override the matching field.\n")
+	buf.WriteString("# Repository `environment.yaml` `supervisor.default_cli` overrides supervisor for that task only.\n")
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(defaults); err != nil {
+		return nil, fmt.Errorf("encode defaults: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("close encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/daemonconfig/config_test.go
+++ b/internal/daemonconfig/config_test.go
@@ -134,3 +134,48 @@ func TestLoadRejectsBadDuration(t *testing.T) {
 		t.Fatalf("expected error for invalid duration")
 	}
 }
+
+func TestLoadRejectsZeroMaxConcurrentTasks(t *testing.T) {
+	t.Parallel()
+	// The daemon always needs >= 1 worker. Accepting 0 in daemon.yaml and
+	// silently turning it into 1 inside daemon.Options.withDefaults makes
+	// the configured value invisible to operators; reject it instead.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("max_concurrent_tasks: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Load(root); err == nil {
+		t.Fatalf("expected error for max_concurrent_tasks: 0")
+	}
+}
+
+func TestLoadAcceptsZeroMaxConcurrentPerRepo(t *testing.T) {
+	t.Parallel()
+	// CLI `--max-concurrent-per-repo=0` disables the per-repo limit; the
+	// daemon.yaml field has the same public meaning.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("max_concurrent_per_repo: 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, present, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Fatalf("expected present=true")
+	}
+	if file.MaxConcurrentPerRepo == nil || *file.MaxConcurrentPerRepo != 0 {
+		t.Fatalf("max_concurrent_per_repo got %#v, want pointer to 0", file.MaxConcurrentPerRepo)
+	}
+}
+
+func TestLoadRejectsNegativeMaxConcurrentPerRepo(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("max_concurrent_per_repo: -1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Load(root); err == nil {
+		t.Fatalf("expected error for max_concurrent_per_repo: -1")
+	}
+}

--- a/internal/daemonconfig/config_test.go
+++ b/internal/daemonconfig/config_test.go
@@ -1,0 +1,136 @@
+package daemonconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureDefaultCreatesFileWithDocumentedDefaults(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	created, err := EnsureDefault(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatalf("expected EnsureDefault to create daemon.yaml on first call")
+	}
+	data, err := os.ReadFile(filepath.Join(root, Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"supervisor: codex",
+		"max_concurrent_tasks: 1",
+		"max_concurrent_per_repo: 1",
+		"poll_interval: 10s",
+		"claim_ttl: 30m",
+		"heartbeat_interval: 1m",
+		"shutdown_timeout: 5m",
+		"idle_timeout: 10m",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("daemon.yaml missing %q\ncontent:\n%s", want, content)
+		}
+	}
+}
+
+func TestEnsureDefaultPreservesExistingFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	path := filepath.Join(root, Filename)
+	custom := "supervisor: claude\n"
+	if err := os.WriteFile(path, []byte(custom), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	created, err := EnsureDefault(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatalf("EnsureDefault should not recreate an existing file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != custom {
+		t.Fatalf("existing daemon.yaml was modified: %q", string(data))
+	}
+}
+
+func TestLoadReturnsAbsentWhenMissing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	file, present, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present {
+		t.Fatalf("expected present=false on missing daemon.yaml")
+	}
+	if file != (File{}) {
+		t.Fatalf("expected zero-value File when missing, got %#v", file)
+	}
+}
+
+func TestLoadParsesAllFields(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := `supervisor: claude
+max_concurrent_tasks: 4
+max_concurrent_per_repo: 2
+poll_interval: 30s
+claim_ttl: 1h
+heartbeat_interval: 15s
+shutdown_timeout: 2m
+idle_timeout: 5m
+`
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, present, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present {
+		t.Fatalf("expected present=true")
+	}
+	if file.Supervisor != "claude" {
+		t.Fatalf("supervisor got %q", file.Supervisor)
+	}
+	if file.MaxConcurrentTasks == nil || *file.MaxConcurrentTasks != 4 {
+		t.Fatalf("max_concurrent_tasks got %#v", file.MaxConcurrentTasks)
+	}
+	if file.MaxConcurrentPerRepo == nil || *file.MaxConcurrentPerRepo != 2 {
+		t.Fatalf("max_concurrent_per_repo got %#v", file.MaxConcurrentPerRepo)
+	}
+	if file.PollInterval != "30s" || file.ClaimTTL != "1h" || file.HeartbeatInterval != "15s" || file.ShutdownTimeout != "2m" || file.IdleTimeout != "5m" {
+		t.Fatalf("durations got %#v", file)
+	}
+}
+
+func TestLoadRejectsUnknownSupervisor(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("supervisor: opus\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Load(root); err == nil {
+		t.Fatalf("expected error for unsupported supervisor")
+	}
+}
+
+func TestLoadRejectsBadDuration(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("poll_interval: not-a-duration\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Load(root); err == nil {
+		t.Fatalf("expected error for invalid duration")
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -49,6 +49,7 @@ type Environment struct {
 	CWD            string                   `yaml:"cwd" json:"cwd"`
 	Commands       map[string]string        `yaml:"commands" json:"commands"`
 	Executor       *ExecutorDefault         `yaml:"executor,omitempty" json:"executor,omitempty"`
+	Supervisor     *SupervisorDefault       `yaml:"supervisor,omitempty" json:"supervisor,omitempty"`
 	RequiredChecks RequiredCheckEnvironment `yaml:"required_checks,omitempty" json:"required_checks,omitempty"`
 	Constraints    Constraints              `yaml:"constraints" json:"constraints"`
 	PR             PRSettings               `yaml:"pr,omitempty" json:"pr,omitempty"`
@@ -56,6 +57,15 @@ type Environment struct {
 }
 
 type ExecutorDefault struct {
+	DefaultCLI string `yaml:"default_cli,omitempty" json:"default_cli,omitempty"`
+}
+
+// SupervisorDefault selects the repository-scoped review supervisor for tasks
+// whose `scope.cwd` resolves to this environment profile. When `default_cli`
+// is set, the daemon uses it for that task even when daemon CLI startup
+// options, `daemon.yaml`, or the built-in default would otherwise pick a
+// different supervisor. Allowed values are `claude` and `codex`.
+type SupervisorDefault struct {
 	DefaultCLI string `yaml:"default_cli,omitempty" json:"default_cli,omitempty"`
 }
 
@@ -188,6 +198,9 @@ func ValidateEnvironment(env Environment) ValidationResult {
 	if env.Executor != nil && env.Executor.DefaultCLI != "" {
 		require(&result, validExecutorCLI(env.Executor.DefaultCLI), "executor.default_cli must be one of: claude, codex")
 	}
+	if env.Supervisor != nil && env.Supervisor.DefaultCLI != "" {
+		require(&result, validSupervisorCLI(env.Supervisor.DefaultCLI), "supervisor.default_cli must be one of: claude, codex")
+	}
 	if env.RequiredChecks.Shell != "" {
 		require(&result, validRequiredCheckShell(env.RequiredChecks.Shell), "required_checks.shell must be one of: auto, sh, bash, cmd, powershell, pwsh")
 	}
@@ -198,6 +211,18 @@ func ValidateEnvironment(env Environment) ValidationResult {
 }
 
 func validExecutorCLI(value string) bool {
+	switch value {
+	case "claude", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+// validSupervisorCLI mirrors validExecutorCLI for the repository-scoped
+// supervisor selection. Allowed values are the two built-in supervisor
+// adapters Galley supports.
+func validSupervisorCLI(value string) bool {
 	switch value {
 	case "claude", "codex":
 		return true

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -128,6 +128,32 @@ func TestValidateEnvironmentRejectsInvalidExecutorDefault(t *testing.T) {
 	}
 }
 
+func TestValidateEnvironmentAcceptsSupervisorDefaultCLI(t *testing.T) {
+	for _, value := range []string{"claude", "codex"} {
+		value := value
+		t.Run(value, func(t *testing.T) {
+			env := validEnvironmentForTest()
+			env.Supervisor = &SupervisorDefault{DefaultCLI: value}
+			result := ValidateEnvironment(env)
+			if !result.Valid() {
+				t.Fatalf("errors got %#v", result.Errors)
+			}
+		})
+	}
+}
+
+func TestValidateEnvironmentRejectsInvalidSupervisorDefault(t *testing.T) {
+	env := validEnvironmentForTest()
+	env.Supervisor = &SupervisorDefault{DefaultCLI: "opus"}
+	result := ValidateEnvironment(env)
+	if result.Valid() {
+		t.Fatal("expected invalid supervisor default")
+	}
+	if !strings.Contains(strings.Join(result.Errors, "\n"), "supervisor.default_cli") {
+		t.Fatalf("errors missing supervisor.default_cli: %#v", result.Errors)
+	}
+}
+
 func TestValidateEnvironmentAcceptsRequiredCheckShell(t *testing.T) {
 	env := validEnvironmentForTest()
 	env.RequiredChecks.Shell = "bash"

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -67,6 +67,11 @@ func EnvironmentJSONSchema() ([]byte, error) {
 					"default_cli": enumSchema([]string{"claude", "codex"}),
 				}),
 			),
+			"supervisor": object(
+				properties(map[string]any{
+					"default_cli": enumSchema([]string{"claude", "codex"}),
+				}),
+			),
 			"required_checks": object(
 				properties(map[string]any{
 					"shell": enumSchema([]string{"auto", "sh", "bash", "cmd", "powershell", "pwsh"}),

--- a/plugins/galley/skills/galley/references/environment.schema.json
+++ b/plugins/galley/skills/galley/references/environment.schema.json
@@ -111,6 +111,19 @@
       },
       "type": "object"
     },
+    "supervisor": {
+      "additionalProperties": false,
+      "properties": {
+        "default_cli": {
+          "enum": [
+            "claude",
+            "codex"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "worktree": {
       "additionalProperties": false,
       "default": {


### PR DESCRIPTION
## Goal

Add persistent daemon startup defaults and repository-scoped supervisor defaults so Galley resolves supervisor selection from repo config, daemon startup defaults, daemon.yaml, then the built-in Codex default without misleading daemon status output.

## Acceptance Criteria

- `AC1` When `galley daemon run` or `galley daemon start` is invoked and `daemon.yaml` does not exist under the selected daemon root, the system shall create it with documented default daemon settings before running the daemon.
  - Verification: go test ./internal/daemoncmd ./internal/daemonconfig ./internal/daemon
  - Status: satisfied
- `AC2` When `daemon.yaml` exists under the selected daemon root, daemon startup shall load public durable defaults for supervisor, concurrency, polling, claim, heartbeat, shutdown, and idle-timeout settings without requiring the corresponding CLI flags.
  - Verification: go test ./internal/daemoncmd ./internal/daemonconfig
  - Status: satisfied
- `AC3` When both `daemon.yaml` and daemon CLI options define the same daemon startup setting, the CLI option shall override `daemon.yaml` as the daemon startup default for that run.
  - Verification: go test ./internal/daemoncmd ./internal/daemonconfig
  - Status: satisfied
- `AC4` When a queued task resolves an environment profile containing `supervisor.default_cli`, the daemon shall use that repository supervisor for that task even if daemon CLI options or `daemon.yaml` define a different supervisor.
  - Verification: go test ./internal/daemon ./internal/profile
  - Status: satisfied
- `AC5` If no repository supervisor is configured for a task, then the daemon shall resolve the supervisor from CLI startup option, then `daemon.yaml`, then the built-in Codex default.
  - Verification: go test ./internal/daemon ./internal/daemoncmd
  - Status: satisfied
- `AC6` When `environment.yaml` contains `supervisor.default_cli`, profile validation and generated schemas shall accept only `claude` and `codex`, and reject any other supervisor value.
  - Verification: go test ./internal/profile ./internal/cli && go run ./cmd/galley schema check
  - Status: satisfied
- `AC7` When `galley daemon status` or `galley daemon status --output json` is run, the output shall not report a single effective `supervisor` field that could be confused with per-repository task supervisor resolution.
  - Verification: go test ./internal/daemoncmd
  - Status: satisfied
- `AC8` The system shall persist the resolved supervisor and its source for each daemon-processed task in run evidence so reviewers can tell whether repo config, CLI startup defaults, `daemon.yaml`, or the built-in default determined the supervisor.
  - Verification: go test ./internal/daemon
  - Status: satisfied
- `AC9` Documentation shall describe daemon startup defaults, `daemon.yaml` creation behavior, repo supervisor precedence, CLI override semantics, and the reason daemon status does not display a single supervisor value.
  - Verification: go test ./internal/cli && go run ./cmd/galley schema check
  - Status: satisfied
- `AC10` Existing daemon behavior shall remain backward compatible for users who do not create `daemon.yaml` manually and do not add `supervisor.default_cli` to `environment.yaml`.
  - Verification: go test ./... && ./scripts/smoke-local.sh
  - Status: satisfied

## Final Verification

- `find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l`: passed
- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Where should repository-specific supervisor selection live? -> Add `supervisor.default_cli` to the existing repository `environment.yaml` profile.
  - Rationale: This avoids a new repo-level config file and keeps executor and supervisor repository policy in the existing profile contract.
  - Reversibility: medium
- `D2` How should daemon startup options interact with `daemon.yaml`? -> CLI options override `daemon.yaml` only as daemon startup defaults; repository profile supervisor remains task-level policy and wins for that task.
  - Rationale: This preserves common CLI override behavior while keeping repo policy authoritative for per-task supervisor resolution.
  - Reversibility: high
- `D3` Should daemon status display supervisor? -> Do not display a single supervisor in daemon status.
  - Rationale: Once supervisor can be resolved per repository, a daemon-wide supervisor field is misleading.
  - Reversibility: high
- `claude-decision-4` Where to write the supervisor evidence file so it could be unit-tested? -> Extracted writeSupervisorEvidence as a package-private helper in internal/daemon/loop.go.
  - Rationale: Keeps the side effect inside the daemon package while letting a focused unit test exercise the contract without driving a full task through the supervisor loop.
  - Reversibility: high
- `claude-decision-5` Where should daemon.yaml creation live for `galley daemon start`? -> EnsureDefault is called in both newStartCommand (parent process, before spawning) and the parent RunE (child process / `daemon run`).
  - Rationale: Operators expect the file to be visible as soon as `galley daemon start` returns; a single creation site in the background child cannot reliably surface errors. The double call is idempotent because EnsureDefault is a no-op when the file exists.
  - Reversibility: high

## Discussion Items

- `discussion-1` Status JSON compatibility: Removing status.supervisor is a documented breaking output-shape change, but it is explicitly required by AC7 because supervisor resolution is now per repository/task.

## Risks

- `R1` compatibility: Existing JSON consumers may expect `status --output json` to include `supervisor`.
  - Mitigation: Treat the removal as a documented user-visible output change and add CHANGELOG coverage; tests should assert the new output contract.
- `R2` config: Creating `daemon.yaml` on read-only commands would introduce surprising side effects.
  - Mitigation: Limit auto-creation to `daemon run` and `daemon start`; `status` and `stop` should not create config files.
- `R3` evidence: If resolved supervisor source is not persisted per task, later review cannot explain which config path controlled the run.
  - Mitigation: Add run evidence for resolved supervisor and source.
