### PR TITLE
Improve acceptance criteria invariant expansion guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.10`: task-authoring guidance now expands acceptance criteria by invariant before finalizing, checking sibling fields, later lifecycle states, stale or missing values, fallback paths, and publication or visibility boundaries so ACs cover acceptance-relevant edge cases without overloading a single observable obligation.
+
 ## v0.5.4 - 2026-05-22
 
 ### Changed

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/authoring-quality.md
+++ b/plugins/galley/skills/galley/references/authoring-quality.md
@@ -147,6 +147,21 @@ AC traceability checks:
 - Every AC has a verification method or evidence source. Prefer profile required checks for runnable commands that must be enforced by Galley.
 - Every risky boundary crossing has an AC or quality finding target: API/schema, data persistence, authorization, UI state, CLI output, migration, external service, or config.
 - Each AC names one observable obligation. Split one AC when "and" joins independently verifiable obligations or the AC crosses multiple boundaries.
+- Each requirement is expanded by invariant before finalizing ACs; see Invariant Expansion below.
+
+### Invariant Expansion
+
+Before finalizing ACs, expand each requirement by invariant: the changed behavior that must remain true across relevant inputs, states, and lifecycle transitions.
+
+For each changed CLI output, JSON payload, config precedence rule, schema field, task state, queue file, process control path, or run evidence, check whether the same invariant affects:
+
+- sibling fields on the same surface
+- later lifecycle states or retries
+- stale, missing, or empty values
+- failed refreshes, failed lookups, or unavailable fallbacks
+- publication or visibility boundaries, such as when a file, status, or record becomes observable to another command, daemon loop, or user
+
+Cover acceptance-relevant cases in ACs. If a related case is intentionally out of scope, record the reason in `decisions`, `risks`, or the task summary. Verification should force each acceptance-relevant path when practical, or record why direct coverage is out of scope. Split separate obligations into separate ACs; keep multiple verification paths only for the same obligation.
 
 For bug-fix or behavior-correction tasks, define the smallest reproducing state before finalizing ACs. Include the prior state that makes the bug observable, such as stale local or remote state, cached or generated artifacts, persisted records, existing resources, configuration values, previous run state, or saved history. At least one AC or verification item should prove the fix in that reproducing state.
 


### PR DESCRIPTION
## Summary

- Add invariant expansion guidance to Galley task-authoring AC traceability checks.
- Clarify that AC authors should check sibling fields, lifecycle states, stale or missing values, fallback paths, and publication/visibility boundaries before finalizing ACs.
- Bump packaged Claude and Codex Galley plugin metadata to 0.1.10 and document the change in CHANGELOG.

## Verification

- claude plugin validate plugins/galley
- claude plugin validate .
- python3 -m json.tool plugins/galley/.claude-plugin/plugin.json
- python3 -m json.tool .claude-plugin/marketplace.json
- git diff --check