### PR TITLE
Limit Galley PR comment polling to actionable open PR tasks so historical closed, merged, archived, and PR-less tasks cannot delay /galley revision pickup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows semantic versioning.
 
 - Windows required-check shell auto-discovery now ignores WSL launchers, WindowsApps shims, and non-standard Bash installs. Galley only auto-selects standard Git for Windows Bash, or Bash inferred from Git for Windows, and falls back to `cmd.exe` when no supported Git Bash is found.
 - Acceptance skeleton preflight and task validation now allow multiple AC output entries to share one skeleton file path, preserving each entry's metadata while still enforcing path safety, allowed/forbidden scoping, declared-file checks, undeclared-change detection, and required AC coverage. Baseline hashes are deduplicated by slash-normalized path.
+- PR comment polling now skips closed, merged, archived, PR-less, and non-open PR tasks before profile loading or GitHub calls while preserving requeue handling for open actionable PR tasks.
 
 ### Added
 

--- a/internal/daemon/comments.go
+++ b/internal/daemon/comments.go
@@ -197,11 +197,14 @@ func applyPRCommandToLoadedTask(loaded *task.Task, command prCommand) {
 //  2. The PR status is "open" (case-insensitive). Merged or closed PRs cannot
 //     usefully trigger another Galley implementation pass.
 //  3. The task status is one of "pr_opened" (the primary actionable state used
-//     by the requeue path in tasks/done), "queued", or "running" (preserved so
-//     direct callers of processTaskPRComments still receive the existing
-//     "already queued/running" reply behavior). Other statuses such as
-//     "merged", "closed", "accepted", "needs_supervisor_review", "failed",
-//     "archived", or "draft" are non-actionable and are skipped here.
+//     by the requeue path in tasks/done) or "needs_supervisor_review" (the
+//     actionable failed-review state used in tasks/failed). The production
+//     poller scans only tasks/done and tasks/failed, so "queued" and "running"
+//     are not reached through that path; they remain allowed only so direct
+//     calls to processTaskPRComments preserve the existing "already
+//     queued/running" reply behavior. Other statuses such as "merged",
+//     "closed", "accepted", "failed", "archived", or "draft" are
+//     non-actionable and are skipped here.
 //
 // Keeping this check ahead of loadTaskProfiles and vcs.FetchPRComments is the
 // reason the daemon no longer pays per-task latency or GitHub quota for
@@ -214,7 +217,7 @@ func isActionableForPRCommentPoll(loaded task.Task) bool {
 		return false
 	}
 	switch loaded.Status {
-	case "pr_opened", "queued", "running":
+	case "pr_opened", "needs_supervisor_review", "queued", "running":
 		return true
 	default:
 		return false

--- a/internal/daemon/comments.go
+++ b/internal/daemon/comments.go
@@ -59,15 +59,22 @@ func processTaskPRComments(ctx context.Context, opts Options, path string) error
 		fmt.Fprintf(os.Stderr, "galley: skipping PR comment scan for unreadable task %s: %v\n", path, err)
 		return nil
 	}
+	// Gate the task on the persisted fields before resolving the repository
+	// profile or calling GitHub. A closed, merged, archived, PR-less, or
+	// non-open PR task cannot drive a Galley follow-up run from a /galley
+	// comment, so scanning it would only add polling latency and GitHub API
+	// load without changing observable behavior. Performing the eligibility
+	// check here (rather than after profile load or after FetchPRComments)
+	// also lets historical tasks survive without a usable repository profile.
+	if !isActionableForPRCommentPoll(loaded) {
+		return nil
+	}
 	_, profiles, err := loadTaskProfiles(opts, loaded.Scope.CWD)
 	if err != nil {
 		return err
 	}
 	effectiveOpts := effectiveOptionsForProfiles(opts, profiles)
 	if !effectiveOpts.PollPRComments {
-		return nil
-	}
-	if loaded.PR.URL == "" {
 		return nil
 	}
 	// Retry the PR comment listing. `gh api .../comments` is a GET and
@@ -177,6 +184,40 @@ func applyPRCommandToLoadedTask(loaded *task.Task, command prCommand) {
 	}
 	if !task.ContainsRevisionRequest(loaded.RevisionRequests, request.ID) {
 		loaded.RevisionRequests = append(loaded.RevisionRequests, request)
+	}
+}
+
+// isActionableForPRCommentPoll reports whether the persisted task fields show
+// that the task could accept another /galley follow-up from a PR comment. The
+// gate intentionally consults only the persisted task YAML so the daemon can
+// skip non-actionable historical tasks before resolving the repository profile
+// or calling GitHub. The conditions are:
+//
+//  1. The task records a PR URL. PR-less tasks have no comment thread to scan.
+//  2. The PR status is "open" (case-insensitive). Merged or closed PRs cannot
+//     usefully trigger another Galley implementation pass.
+//  3. The task status is one of "pr_opened" (the primary actionable state used
+//     by the requeue path in tasks/done), "queued", or "running" (preserved so
+//     direct callers of processTaskPRComments still receive the existing
+//     "already queued/running" reply behavior). Other statuses such as
+//     "merged", "closed", "accepted", "needs_supervisor_review", "failed",
+//     "archived", or "draft" are non-actionable and are skipped here.
+//
+// Keeping this check ahead of loadTaskProfiles and vcs.FetchPRComments is the
+// reason the daemon no longer pays per-task latency or GitHub quota for
+// historical tasks during PR comment polling.
+func isActionableForPRCommentPoll(loaded task.Task) bool {
+	if loaded.PR.URL == "" {
+		return false
+	}
+	if !strings.EqualFold(loaded.PR.Status, "open") {
+		return false
+	}
+	switch loaded.Status {
+	case "pr_opened", "queued", "running":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/daemon/comments_test.go
+++ b/internal/daemon/comments_test.go
@@ -742,6 +742,218 @@ func TestPRCommentMatchesPRAuthor(t *testing.T) {
 	}
 }
 
+func TestIsActionableForPRCommentPoll(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		task task.Task
+		want bool
+	}{
+		{
+			name: "pr_opened task with open PR is actionable",
+			task: task.Task{Status: "pr_opened", PR: task.PR{URL: "https://github.com/example/repo/pull/1", Status: "open"}},
+			want: true,
+		},
+		{
+			name: "queued task with open PR is actionable for direct callers",
+			task: task.Task{Status: "queued", PR: task.PR{URL: "https://github.com/example/repo/pull/2", Status: "open"}},
+			want: true,
+		},
+		{
+			name: "running task with open PR is actionable for direct callers",
+			task: task.Task{Status: "running", PR: task.PR{URL: "https://github.com/example/repo/pull/3", Status: "open"}},
+			want: true,
+		},
+		{
+			name: "missing PR URL is non-actionable",
+			task: task.Task{Status: "pr_opened", PR: task.PR{URL: "", Status: "open"}},
+			want: false,
+		},
+		{
+			name: "merged task status is non-actionable even with PR URL",
+			task: task.Task{Status: "merged", PR: task.PR{URL: "https://github.com/example/repo/pull/4", Status: "merged"}},
+			want: false,
+		},
+		{
+			name: "closed task status is non-actionable",
+			task: task.Task{Status: "closed", PR: task.PR{URL: "https://github.com/example/repo/pull/5", Status: "closed"}},
+			want: false,
+		},
+		{
+			name: "archived task status is non-actionable",
+			task: task.Task{Status: "archived", PR: task.PR{URL: "https://github.com/example/repo/pull/6", Status: "open"}},
+			want: false,
+		},
+		{
+			name: "accepted task status without PR open is non-actionable",
+			task: task.Task{Status: "accepted", PR: task.PR{URL: "https://github.com/example/repo/pull/7", Status: ""}},
+			want: false,
+		},
+		{
+			name: "pr_opened task with closed PR is non-actionable",
+			task: task.Task{Status: "pr_opened", PR: task.PR{URL: "https://github.com/example/repo/pull/8", Status: "closed"}},
+			want: false,
+		},
+		{
+			name: "PR status open is matched case-insensitively",
+			task: task.Task{Status: "pr_opened", PR: task.PR{URL: "https://github.com/example/repo/pull/9", Status: "OPEN"}},
+			want: true,
+		},
+		{
+			name: "failed task status is non-actionable",
+			task: task.Task{Status: "failed", PR: task.PR{URL: "https://github.com/example/repo/pull/10", Status: "open"}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isActionableForPRCommentPoll(tc.task); got != tc.want {
+				t.Fatalf("isActionableForPRCommentPoll got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPollPRCommentsSkipsHistoricalNonActionableTasks proves that the daemon
+// skips merged, closed, PR-less, and non-open PR tasks before touching either
+// the repository profile or GitHub. The fake gh binary fails on any
+// invocation, and an intentionally invalid environment profile path forces
+// loadTaskProfiles to fail if it is ever reached, so any regression that
+// re-introduces per-task profile or comment work surfaces as a test error.
+func TestPollPRCommentsSkipsHistoricalNonActionableTasks(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately do not call writeDaemonEnvironmentProfile so the resolved
+	// profile path is empty; combined with a forced bogus EnvironmentProfileFile
+	// below, profile loading would fail if the eligibility gate did not skip
+	// these tasks first.
+	cases := []struct {
+		name     string
+		status   string
+		prStatus string
+		prURL    string
+	}{
+		{name: "merged-task", status: "merged", prStatus: "merged", prURL: "https://github.com/example/galley/pull/100"},
+		{name: "closed-task", status: "closed", prStatus: "closed", prURL: "https://github.com/example/galley/pull/101"},
+		{name: "pr-less-accepted", status: "accepted", prStatus: "", prURL: ""},
+		{name: "pr-opened-but-pr-closed", status: "pr_opened", prStatus: "closed", prURL: "https://github.com/example/galley/pull/102"},
+		{name: "failed-task-open-pr", status: "failed", prStatus: "open", prURL: "https://github.com/example/galley/pull/103"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		donePath := filepath.Join(root, "tasks", "done", "task-"+tc.name+".yaml")
+		writeDaemonTask(t, donePath, repo)
+		loaded, err := task.Load(donePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loaded.Status = tc.status
+		loaded.PR.URL = tc.prURL
+		loaded.PR.Status = tc.prStatus
+		loaded.PR.AuthorLogin = "owner"
+		if err := task.Save(donePath, loaded); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Any gh invocation is a regression: non-actionable tasks must not fetch
+	// PR comments.
+	ghBin := writeFakeCommand(t, "gh", `echo "gh must not be called for non-actionable tasks: $*" >&2
+exit 1
+`)
+	// Pointing EnvironmentProfileFile at a non-existent path makes
+	// loadTaskProfiles fail if the eligibility gate is bypassed. A passing
+	// run proves the gate ran before profile loading.
+	missingProfile := filepath.Join(t.TempDir(), "missing-environment.yaml")
+	opts := Options{
+		Root:                   root,
+		GHBin:                  ghBin,
+		EnvironmentProfileFile: missingProfile,
+	}.withDefaults()
+	if err := pollPRComments(context.Background(), opts); err != nil {
+		t.Fatalf("non-actionable tasks must skip without error: %v", err)
+	}
+}
+
+// TestPollPRCommentsActionableOnlyFetchesOpenPRTasks mixes a non-actionable
+// done/closed task and an actionable done/pr_opened task with PR.Status="open"
+// in the same poll, asserts that gh is called exactly once (for the open PR),
+// and confirms that the closed PR is not contacted.
+func TestPollPRCommentsActionableOnlyFetchesOpenPRTasks(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+
+	closedPath := filepath.Join(root, "tasks", "done", "task-closed.yaml")
+	writeDaemonTask(t, closedPath, repo)
+	closed, err := task.Load(closedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed.Status = "closed"
+	closed.PR.URL = "https://github.com/example/galley/pull/100"
+	closed.PR.Status = "closed"
+	closed.PR.AuthorLogin = "owner"
+	if err := task.Save(closedPath, closed); err != nil {
+		t.Fatal(err)
+	}
+
+	activePath := filepath.Join(root, "tasks", "done", "task-active.yaml")
+	writeDaemonTask(t, activePath, repo)
+	active, err := task.Load(activePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active.Status = "pr_opened"
+	active.PR.URL = "https://github.com/example/galley/pull/200"
+	active.PR.Status = "open"
+	active.PR.AuthorLogin = "owner"
+	if err := task.Save(activePath, active); err != nil {
+		t.Fatal(err)
+	}
+
+	counter := filepath.Join(t.TempDir(), "gh-calls.log")
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "api" ]; then
+echo "$*" >> `+counter+`
+echo '[]'
+else
+echo unexpected-gh >&2
+exit 1
+fi
+`)
+
+	opts := Options{Root: root, GHBin: ghBin}.withDefaults()
+	if err := pollPRComments(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("expected gh to be called for the actionable open PR task: %v", err)
+	}
+	body := string(data)
+	// gh api translates the PR comments endpoint to issues/<n>/comments, so
+	// the PR number is the stable substring to assert against the captured
+	// argv log.
+	if strings.Contains(body, "issues/100/") {
+		t.Fatalf("closed PR must not be fetched: %q", body)
+	}
+	if !strings.Contains(body, "issues/200/") {
+		t.Fatalf("actionable open PR must be fetched: %q", body)
+	}
+	if got := strings.Count(strings.TrimRight(body, "\n"), "\n") + 1; got != 1 {
+		t.Fatalf("expected exactly one gh api invocation, got %d in %q", got, body)
+	}
+}
+
 func writeDaemonEnvironmentProfile(t *testing.T, root, repo string, pollComments, replyComments bool) {
 	t.Helper()
 	_, _, environmentPath, err := galleyhome.RepoProfilePaths(root, repo)

--- a/internal/daemon/comments_test.go
+++ b/internal/daemon/comments_test.go
@@ -188,6 +188,56 @@ fi
 	}
 }
 
+func TestPollPRCommentsRequeuesNeedsSupervisorReviewOpenPR(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	writeDaemonTask(t, failedPath, repo)
+	loaded, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Status = "needs_supervisor_review"
+	loaded.PR.URL = "https://github.com/example/galley/pull/123"
+	loaded.PR.Status = "open"
+	loaded.PR.AuthorLogin = "author"
+	if err := task.Save(failedPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "api" ]; then
+echo '[[{"id":88,"body":"/galley address supervisor feedback","html_url":"https://github.com/example/galley/pull/123#issuecomment-88","user":{"login":"author"}}]]'
+else
+echo unexpected-gh >&2
+exit 1
+fi
+`)
+
+	if err := pollPRComments(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults()); err != nil {
+		t.Fatal(err)
+	}
+	queuedPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	requeued, err := task.Load(queuedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requeued.Status != "queued" {
+		t.Fatalf("status got %q", requeued.Status)
+	}
+	if !slices.Contains(requeued.PR.ProcessedCommentIDs, "88") {
+		t.Fatalf("processed comments got %#v", requeued.PR.ProcessedCommentIDs)
+	}
+	if len(requeued.RevisionRequests) != 1 || requeued.RevisionRequests[0].Text != "address supervisor feedback" {
+		t.Fatalf("revision requests got %#v", requeued.RevisionRequests)
+	}
+	if _, err := os.Stat(failedPath); !os.IsNotExist(err) {
+		t.Fatalf("failed task should be moved to queued, err=%v", err)
+	}
+}
+
 func TestPollPRCommentsPostsReply(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)
@@ -762,6 +812,11 @@ func TestIsActionableForPRCommentPoll(t *testing.T) {
 		{
 			name: "running task with open PR is actionable for direct callers",
 			task: task.Task{Status: "running", PR: task.PR{URL: "https://github.com/example/repo/pull/3", Status: "open"}},
+			want: true,
+		},
+		{
+			name: "needs supervisor review task with open PR is actionable",
+			task: task.Task{Status: "needs_supervisor_review", PR: task.PR{URL: "https://github.com/example/repo/pull/11", Status: "open"}},
 			want: true,
 		},
 		{


### PR DESCRIPTION
## Goal

Limit Galley PR comment polling to actionable open PR tasks so historical closed, merged, archived, and PR-less tasks cannot delay /galley revision pickup.

## Acceptance Criteria

- `AC1` When PR comment polling scans tasks, Galley shall call the GitHub PR comment API only for tasks that have a PR URL, have pr.status set to open, and are in a status where a /galley comment can drive a follow-up run.
  - Verification: go test ./internal/daemon -run 'PollPRComments.*Actionable|PollPRComments.*Skips'
  - Status: satisfied
- `AC2` When a task is done/merged, done/closed, archived, lacks a PR URL, or has pr.status other than open, Galley shall skip that task before loading repository profiles or calling vcs.FetchPRComments.
  - Verification: go test ./internal/daemon -run 'PollPRComments.*Skips'
  - Status: satisfied
- `AC3` When a done/pr_opened task has pr.status open and an unprocessed /galley comment from the recorded PR author, Galley shall preserve the existing requeue behavior: record the comment ID, add a pending revision request, move the task back to queued/running flow, and post the configured acknowledgement reply.
  - Verification: go test ./internal/daemon -run 'PollPRCommentsRequeuesTaskOnce|PollPRCommentsPostsReply'
  - Status: satisfied
- `AC4` When non-author comments or tasks with empty pr.author_login are encountered on an otherwise actionable open PR, Galley shall keep the existing fail-closed authorization behavior.
  - Verification: go test ./internal/daemon -run 'PollPRCommentsRejectsNonAuthor|PollPRCommentsRejectsWhenPRAuthorLoginEmpty'
  - Status: satisfied
- `AC5` The fix shall stay scoped to PR comment polling eligibility and focused tests, without changing PR creation, PR cleanup, task requeue semantics, public task/profile schemas, or daemon startup options.
  - Verification: Review changed files and run go test ./internal/daemon; expected implementation scope is internal/daemon plus optional CHANGELOG.md.
  - Status: satisfied

## Final Verification

- `go test ./internal/daemon -run 'PollPRComments.*Actionable|PollPRComments.*Skips' -count=1`: passed
- `go test ./internal/daemon -run 'PollPRCommentsRequeuesTaskOnce|PollPRCommentsPostsReply|PollPRCommentsRejectsNonAuthor|PollPRCommentsRejectsWhenPRAuthorLoginEmpty' -count=1`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool over schemas and plugin manifests`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Which tasks are actionable for PR comment polling? -> Treat open PR tasks that can accept a /galley follow-up as actionable, primarily tasks with pr.status open and task status pr_opened; skip merged, closed, archived, PR-less, and non-open PR tasks before any GitHub comment fetch.
  - Rationale: A closed or merged PR cannot usefully drive another Galley implementation pass, and scanning historical tasks caused delayed pickup of current /galley comments.
  - Reversibility: high
- `D2` Should the fix reduce work before or after fetching comments? -> Filter tasks before profile loading and before vcs.FetchPRComments whenever the persisted task fields already prove the task is non-actionable.
  - Rationale: The observed failure is polling latency from unnecessary historical task work. Fetching comments first and ignoring them later would not solve the operational delay.
  - Reversibility: high
- `D3` Should this task redesign PR comment command parsing or authorization? -> No. Preserve the existing /galley parsing and PR-author authorization behavior.
  - Rationale: The bug is candidate selection for polling, not the command grammar or trust boundary.
  - Reversibility: high
- `requeue-4` Why was this task requeued? -> accepted during shutdown; requeue for finalization
  - Rationale: A reviewer or PR comment requested another executor attempt.
  - Reversibility: high

## Risks

- `R1` regression: Filtering too aggressively could stop legitimate /galley comments on open PR tasks from requeueing work.
  - Mitigation: Keep focused positive coverage for pr_opened/open requeue and reply behavior.
- `R2` performance: Leaving profile loading or GitHub fetches before the eligibility check would preserve most of the polling latency.
  - Mitigation: Add tests with fake gh/profile-sensitive setup that fail if skipped historical tasks call GitHub or require profile loading.
- `shutdown-finalize-3` partial_verification: Shutdown was requested before accepted work was finalized; Galley skipped commit, push, and PR creation to avoid an interrupted external side effect.
  - Mitigation: Inspect the accepted diff and requeue or finalize manually when ready.
