### PR TITLE
Bump Galley plugin patch version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.6.1 - 2026-05-25
+
+### Changed
+
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.11`: task-authoring guidance now drafts acceptance criteria value-first and enables acceptance skeleton preflight only when pre-created integration, cross-layer, or E2E skeletons add value, while Windows profile guidance and the bundled environment schema now document `required_checks.shell_path` for explicit non-standard shell executables and keep `auto` limited to standard Git for Windows Bash discovery.
+
 ### Fixed
 
 - Windows required-check shell auto-discovery now ignores WSL launchers, WindowsApps shims, and non-standard Bash installs. Galley only auto-selects standard Git for Windows Bash, or Bash inferred from Git for Windows, and falls back to `cmd.exe` when no supported Git Bash is found.

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Bump the packaged Claude and Codex Galley plugin manifests to 0.1.11
- Update the Claude plugin marketplace entry to 0.1.11
- Add the v0.6.1 changelog entry for the plugin guidance updates

## Validation
- claude plugin validate plugins/galley
- claude plugin validate .claude-plugin/marketplace.json