### PR TITLE
Keep verification and setup excerpts as valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows semantic versioning.
 
 - Claude and Codex subprocesses now inherit the parent environment directly, fixing Windows runs where Galley's previous allowlist dropped required system and toolchain variables.
 - Galley-owned git invocations now enable `core.longpaths=true`, avoiding Windows MAX_PATH failures during worktree cleanup, staging, and related git operations.
+- Verification and setup output excerpts are now scrubbed to valid UTF-8 and truncated on rune boundaries, so accepted tasks with non-ASCII subprocess output no longer fail finalization with `cannot marshal invalid UTF-8 data as !!str`.
 
 ## v0.7.1 - 2026-05-26
 

--- a/internal/preflight/setup/setup_test.go
+++ b/internal/preflight/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/profile"
 )
@@ -163,6 +164,25 @@ func TestNormalizeResultBoundsLargeFields(t *testing.T) {
 	}
 	if strings.HasPrefix(res.Commands[0].StdoutExcerpt, " ") || len(res.Commands[0].StdoutExcerpt) != maxResultExcerptLength {
 		t.Fatalf("stdout excerpt not normalized: %q", res.Commands[0].StdoutExcerpt)
+	}
+}
+
+func TestTruncateStringKeepsValidUTF8(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"cuts inside multi-byte rune": strings.Repeat("あ", 200),
+		"leading orphan byte":         "\x81" + strings.Repeat("a", 200),
+	}
+	for name, in := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := truncateString(in, 101)
+			if !utf8.ValidString(got) {
+				t.Fatalf("truncated string is not valid UTF-8: %q", got)
+			}
+			if len(got) > 101 {
+				t.Fatalf("truncated string exceeds budget: len=%d", len(got))
+			}
+		})
 	}
 }
 

--- a/internal/preflight/setup/util.go
+++ b/internal/preflight/setup/util.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/profile"
 	"github.com/shinpr/galley/internal/task"
@@ -50,20 +51,49 @@ func truncateExcerpt(s string) string {
 }
 
 func truncateString(s string, max int) string {
+	// runner.tailBuffer may start mid-rune.
+	s = strings.ToValidUTF8(s, "\uFFFD")
 	if len(s) <= max {
 		return s
 	}
 	if max <= 1 {
-		return s[:max]
+		return truncateHead(s, max)
 	}
 	const marker = "..."
 	if max <= len(marker) {
-		return s[:max]
+		return truncateHead(s, max)
 	}
 	remaining := max - len(marker)
 	head := remaining / 2
 	tail := remaining - head
-	return s[:head] + marker + s[len(s)-tail:]
+	return truncateHead(s, head) + marker + truncateTail(s, tail)
+}
+
+func truncateHead(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n >= len(s) {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}
+
+func truncateTail(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n >= len(s) {
+		return s
+	}
+	start := len(s) - n
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+	return s[start:]
 }
 
 // DiscoverRepositorySignals returns a small set of repository setup signal

--- a/internal/result/result.go
+++ b/internal/result/result.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/jsonio"
 	"github.com/shinpr/galley/internal/profile"
@@ -269,11 +270,17 @@ func looksPOSIXCommand(command string) bool {
 }
 
 func (r verificationRun) outputExcerpt() string {
-	output := strings.TrimSpace(strings.Join([]string{r.stdout, r.stderr}, "\n"))
-	if len(output) > 2048 {
-		return output[:2048]
+	// runner.tailBuffer may start mid-rune; the excerpt is emitted as an
+	// !!str-tagged YAML scalar that fails marshal on invalid UTF-8.
+	output := strings.ToValidUTF8(strings.TrimSpace(strings.Join([]string{r.stdout, r.stderr}, "\n")), "\uFFFD")
+	if len(output) <= 2048 {
+		return output
 	}
-	return output
+	cut := 2048
+	for cut > 0 && !utf8.RuneStart(output[cut]) {
+		cut--
+	}
+	return output[:cut]
 }
 
 func gitChangedFiles(ctx context.Context, workDir, gitBin string) ([]string, error) {

--- a/internal/result/result_test.go
+++ b/internal/result/result_test.go
@@ -7,8 +7,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/profile"
 )
@@ -265,6 +267,25 @@ func slowCommand() string {
 		return "ping -n 3 127.0.0.1 > NUL"
 	}
 	return "sleep 2"
+}
+
+func TestOutputExcerptKeepsValidUTF8(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"trailing cut inside rune":      strings.Repeat("a", 2047) + "あ" + strings.Repeat("a", 100),
+		"leading orphan byte in budget": "\x81" + strings.Repeat("a", 2047),
+	}
+	for name, stdout := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := verificationRun{stdout: stdout}.outputExcerpt()
+			if !utf8.ValidString(got) {
+				t.Fatalf("excerpt is not valid UTF-8: %q", got[:min(32, len(got))])
+			}
+			if len(got) > 2048 {
+				t.Fatalf("excerpt exceeds byte budget: len=%d", len(got))
+			}
+		})
+	}
 }
 
 func runGit(t *testing.T, dir string, args ...string) {


### PR DESCRIPTION
## Summary

- Accepted tasks whose subprocess output contained non-ASCII bytes were dying in finalization with `cannot marshal invalid UTF-8 data as !!str`, before commit/push/PR creation, and the task was stuck in `tasks/running`.
- Root cause: `runner.tailBuffer` keeps the trailing N bytes regardless of UTF-8 boundaries, so the head can be an orphan continuation byte. The excerpt that flows into `task.verification.commands[].output_excerpt` is emitted as an explicitly `!!str`-tagged YAML scalar (`internal/task/types.go` `VerificationCommand.MarshalYAML`), which makes `yaml.v3` fail the marshal on invalid UTF-8 instead of falling back to base64. A previous 2048-byte hard slice in `outputExcerpt` could also cut mid-rune.
- Fix: scrub excerpts to valid UTF-8 at the consumers (`internal/result/result.go`, `internal/preflight/setup/util.go`) and round byte-budget truncation down to a rune boundary.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/result/... ./internal/preflight/setup/...`
- [x] New regression tests cover (a) a multi-byte rune straddling the byte budget and (b) an orphan leading continuation byte within budget for both excerpt paths.