### PR TITLE
Prepare v0.7.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.7.2 - 2026-05-27
+
 ### Fixed
 
 - Claude and Codex subprocesses now inherit the parent environment directly, fixing Windows runs where Galley's previous allowlist dropped required system and toolchain variables.


### PR DESCRIPTION
## Summary
- Move the current Unreleased fixes under the v0.7.2 changelog heading dated 2026-05-27.

## Testing
- Not run; changelog-only change.