### PR TITLE
Improve AC authoring guidance: obligation-first classification and concurrency invariant

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.15`: task-authoring acceptance-criteria guidance now classifies each item by obligation before keeping it as an AC, routing implementation-shape and out-of-scope items to `decisions` or `risks`, keeping a required outcome as an AC with strengthened verification instead of demoting it for weak verification text, and stating ACs as required outcomes rather than prohibitions on internal mechanisms; invariant expansion now also checks concurrent or reordered execution paths for new interleavings, races, double-processing, or lost updates.
+
 ## v0.7.4 - 2026-06-03
 
 ### Fixed

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/authoring-quality.md
+++ b/plugins/galley/skills/galley/references/authoring-quality.md
@@ -94,6 +94,8 @@ Use ACs for:
 
 Write ACs as observable behavior. Include implementation-shape ACs only when the implementation itself is the requirement.
 
+Classify each item by obligation before keeping it as an AC. An AC states a required observable outcome; route how-the-code-is-built choices and out-of-scope items to `decisions` or `risks` instead. When an item is a required outcome but its verification is weak, keep it as an AC and strengthen the verification — replace text like "tests pass" with the specific command, review evidence, or profile check that proves it — rather than demoting it. State each AC as the outcome required, not as a prohibition on an internal mechanism.
+
 Prefer EARS-style wording when it fits the behavior. EARS means "Easy Approach to Requirements Syntax" and makes trigger, condition, and expected behavior explicit.
 
 | Pattern | Use For | Shape |
@@ -166,6 +168,7 @@ For each changed CLI output, JSON payload, config precedence rule, schema field,
 - stale, missing, or empty values
 - failed refreshes, failed lookups, or unavailable fallbacks
 - publication or visibility boundaries, such as when a file, status, or record becomes observable to another command, daemon loop, or user
+- concurrent or reordered execution paths, where new interleavings, races, double-processing, or lost updates become possible
 
 Cover acceptance-relevant cases in ACs. If a related case is intentionally out of scope, record the reason in `decisions`, `risks`, or the task summary. Verification should force each acceptance-relevant path when practical, or record why direct coverage is out of scope. Split separate obligations into separate ACs; keep multiple verification paths only for the same obligation.
 


### PR DESCRIPTION
## Summary

Strengthens the task-authoring acceptance-criteria guidance in the bundled Galley skill so it steers agents away from three recurring AC defects, and so invariant expansion accounts for newly concurrent execution paths.

These edits came out of a design review where a competent AC draft still produced implementation-shape ACs, negative/non-goal ACs, code-review-only verification, and missed a concurrency invariant — despite the relevant principles already existing in the skill. The skill stated the principles but lacked a write-time discriminator and a concurrency trigger, so the rules did not bite.

## Changes

`plugins/galley/skills/galley/references/authoring-quality.md`:

- **Obligation-first classification.** Classify each item by obligation before keeping it as an AC. Route how-the-code-is-built choices and out-of-scope items to `decisions`/`risks` (schema-valid destinations) instead of writing them as ACs.
- **Weak verification → strengthen, not demote.** When an item is a required outcome but its verification is weak, keep it as an AC and replace text like "tests pass" with the specific command, review evidence, or profile check that proves it.
- **No prohibition-style ACs.** State each AC as the required outcome, not as a ban on an internal mechanism.
- **Concurrency invariant.** Add a "concurrent or reordered execution paths" bullet to invariant expansion so race, double-processing, and lost-update conditions are considered before queueing.

Packaging:

- Bump packaged Claude and Codex Galley plugins to `0.1.15` (`marketplace.json`, both `plugin.json`).
- Record the change in `CHANGELOG.md` under Unreleased, matching the existing plugin-bump entry style.

## Validation

- `claude plugin validate` passes for both the plugin manifest and the marketplace manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)