### PR TITLE
Decouple normal-daemon PR comment polling and PR cleanup from queued task execution so long executor attempts no longer block PR comment intake, while preserving existing run-once, requeue, authorization, and queue publication behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- The normal daemon now runs PR comment polling and PR worktree cleanup on an independent maintenance schedule, decoupled from queued task execution. A long-running executor attempt no longer blocks PR comment intake, so `/galley` comments on open PRs are picked up on the configured poll interval even while another task is still being implemented. `galley daemon run --once` is unchanged: it still drains eligible queued work and exits without becoming a long-running daemon. PR comment authorization, the actionable task scope (`pr_opened` in `tasks/done`, `needs_supervisor_review` in `tasks/failed`), requeue/`processed_comment_ids` behavior, and the no-overwrite publication/claim boundary are all preserved.
+
 ## v0.7.4 - 2026-06-03
 
 ### Fixed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,7 +86,7 @@ galley daemon stop
 galley daemon run --once
 ```
 
-`galley daemon run --once` drains queued tasks once and exits. Background `galley daemon start` also performs daemon maintenance such as PR comment polling and closed or merged PR worktree cleanup according to `environment.yaml`.
+`galley daemon run --once` drains queued tasks once and exits. Background `galley daemon start` also performs daemon maintenance such as PR comment polling and closed or merged PR worktree cleanup according to `environment.yaml`. In normal (non `--once`) mode this maintenance runs on its own poll-interval schedule, independent of queued task execution, so PR comment polling and cleanup continue on the configured interval even while a long executor attempt is still running.
 
 `--root` points at the daemon root and defaults to `~/.galley`. Use `--root .agent-workflow` only for repo-local or test workflows.
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -161,33 +161,91 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	if opts.Once {
-		var firstErr error
-		for {
-			processed, err := processQueuedTasks(ctx, opts)
-			if err != nil && firstErr == nil {
-				firstErr = err
-			}
-			if processed == 0 {
-				return firstErr
-			}
+		return runExecutionDrain(ctx, opts)
+	}
+	return runNormalDaemon(ctx, opts)
+}
+
+// runExecutionDrain implements `galley daemon run --once`. It drains eligible
+// queued work through the shared execution runner and exits once a pass claims
+// nothing, instead of becoming a long-running daemon. Normal-daemon scheduling
+// routes through the same execution runner so run-once and normal mode share
+// claim/execute behavior.
+func runExecutionDrain(ctx context.Context, opts Options) error {
+	var firstErr error
+	for {
+		processed, err := processQueuedTasks(ctx, opts)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if processed == 0 {
+			return firstErr
 		}
 	}
+}
 
+// runNormalDaemon schedules the maintenance runner (PR comment polling + PR
+// worktree cleanup) and the execution runner (queued task claim + execution)
+// on independent tickers. Decoupling the two means a long executor attempt in
+// the execution runner no longer blocks the next maintenance cycle, so PR
+// comment polling continues on the configured poll interval while an attempt
+// is still running. Both runners share opts.PollInterval and stop when ctx is
+// cancelled; Run returns the context error once both have stopped.
+func runNormalDaemon(ctx context.Context, opts Options) error {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		runMaintenanceRunner(ctx, opts)
+	}()
+	go func() {
+		defer wg.Done()
+		runExecutionRunner(ctx, opts)
+	}()
+	wg.Wait()
+	return ctx.Err()
+}
+
+// runMaintenanceRunner ticks the maintenance cycle on its own schedule,
+// independent of how long any executor attempt in the execution runner takes.
+func runMaintenanceRunner(ctx context.Context, opts Options) {
 	ticker := time.NewTicker(opts.PollInterval)
 	defer ticker.Stop()
 	for {
-		if _, err := runDaemonCycle(ctx, opts); err != nil {
-			fmt.Fprintf(os.Stderr, "galley: iteration failed: %v\n", err)
+		if err := runMaintenanceCycle(ctx, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "galley: maintenance failed: %v\n", err)
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return
 		case <-ticker.C:
 		}
 	}
 }
 
-func runDaemonCycle(ctx context.Context, opts Options) (int, error) {
+// runExecutionRunner ticks queued-task execution on its own schedule. Each
+// pass blocks until its claimed task goroutines finish (see processAvailable),
+// so execution passes stay serialized while maintenance runs independently.
+func runExecutionRunner(ctx context.Context, opts Options) {
+	ticker := time.NewTicker(opts.PollInterval)
+	defer ticker.Stop()
+	for {
+		if _, err := processQueuedTasks(ctx, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "galley: iteration failed: %v\n", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// runMaintenanceCycle runs PR comment polling and PR worktree cleanup. Polling
+// and cleanup stay serialized within the cycle so they do not race each other
+// over the same done/failed task file; the cycle does not touch queued-task
+// execution, which the execution runner owns.
+func runMaintenanceCycle(ctx context.Context, opts Options) error {
 	var errs []error
 	if err := pollPRComments(ctx, opts); err != nil {
 		errs = append(errs, fmt.Errorf("poll PR comments: %w", err))
@@ -195,11 +253,7 @@ func runDaemonCycle(ctx context.Context, opts Options) (int, error) {
 	if err := cleanupWorktrees(ctx, opts); err != nil {
 		errs = append(errs, fmt.Errorf("cleanup worktrees: %w", err))
 	}
-	processed, err := processQueuedTasks(ctx, opts)
-	if err != nil {
-		errs = append(errs, err)
-	}
-	return processed, errors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 func processQueuedTasks(ctx context.Context, opts Options) (int, error) {

--- a/internal/daemon/maintenance_execution_race_test.go
+++ b/internal/daemon/maintenance_execution_race_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+// Acceptance skeleton for issue 70 (decouple PR comment polling from execution).
+//
+// AC6: "While maintenance and execution run concurrently, requeue publication
+// and queued-task claim shall remain race-free so a requeued task is neither
+// lost nor double-claimed under the existing no-overwrite publication and claim
+// boundary."
+//
+// Behavior under test (trigger -> process -> observable result):
+//   - Trigger: the maintenance runner requeues an actionable open-PR task from
+//     tasks/done (or tasks/failed) to tasks/queued at the same time the
+//     execution runner scans/claims queued tasks.
+//   - Process: requeue publishes the queued task via the existing no-overwrite
+//     atomic write, and claim moves tasks/queued/<name>.yaml to
+//     tasks/running/<name>.yaml via a no-overwrite rename.
+//   - Observable result: the requeued task ends up in exactly one terminal
+//     location (still queued, or claimed into running exactly once) and is never
+//     lost or double-claimed, even under concurrent interleaving.
+//
+// @lane: integration
+// @category: contract
+// @dependency: queue (QueuedTasks/ClaimTask), task.Requeue, no-overwrite write/rename
+// @complexity: high
+// @roi: score=80 business_value=8 user_frequency=5 legal=false defect_detection=10
+//   (the design's only new concurrency boundary; existing primitive tests cover
+//   no-overwrite publication and claim in isolation, but not the concurrent
+//   maintenance-requeue vs execution-claim interleaving introduced by the
+//   independent maintenance scheduler.)
+// @timing: implement alongside the daemon scheduler refactor.
+//
+// Implementation notes for the executor:
+//   - This is a focused interleaving regression test, distinct from the existing
+//     TestRequeueDoesNotOverwriteQueuedTask and TestClaimTaskDoesNotOverwriteRunningTask
+//     primitive tests; complete it rather than relying on those.
+//   - Drive requeue and claim from separate goroutines (optionally repeated /
+//     looped or synchronized with a barrier) over the same task name, then make
+//     a deterministic assertion about exactly-once placement.
+//   - A double-claim or lost task must fail the assertion.
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/shinpr/galley/internal/queue"
+	"github.com/shinpr/galley/internal/task"
+)
+
+func TestMaintenanceRequeueAndExecutionClaimStayRaceFree(t *testing.T) {
+	// Arrange: Galley root + source repo + queue layout.
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+
+	// Arrange: an actionable open-PR task in tasks/done that the maintenance
+	// runner will requeue from an authorized /galley comment requeue path.
+	donePath := filepath.Join(root, "tasks", "done", "race.yaml")
+	writeDaemonTask(t, donePath, repo)
+	doneTask, err := task.Load(donePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneTask.Status = "pr_opened"
+	doneTask.PR.URL = "https://github.com/example/galley/pull/123"
+	doneTask.PR.Status = "open"
+	doneTask.PR.AuthorLogin = "author"
+	if err := task.Save(donePath, doneTask); err != nil {
+		t.Fatal(err)
+	}
+
+	// Preserve the original done task bytes so each interleaving round can reset
+	// to the same actionable open-PR state before requeue publication runs again.
+	doneBytes, err := os.ReadFile(donePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queuedGlob := filepath.Join(root, "tasks", "queued", "*.yaml")
+	runningGlob := filepath.Join(root, "tasks", "running", "*.yaml")
+	doneGlob := filepath.Join(root, "tasks", "done", "*.yaml")
+
+	resetRound := func() {
+		// Clear any prior round's queued/running copies and stale claim locks,
+		// then restore the source done task so publication has something to move.
+		for _, pattern := range []string{
+			queuedGlob, runningGlob,
+			filepath.Join(root, "tasks", "queued", "*.lock"),
+			filepath.Join(root, "tasks", "running", "*.lock"),
+		} {
+			matches, globErr := filepath.Glob(pattern)
+			if globErr != nil {
+				t.Fatal(globErr)
+			}
+			for _, m := range matches {
+				if rmErr := os.Remove(m); rmErr != nil && !os.IsNotExist(rmErr) {
+					t.Fatal(rmErr)
+				}
+			}
+		}
+		if writeErr := os.WriteFile(donePath, doneBytes, 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+
+	// Act: drive maintenance requeue publication and execution claim concurrently
+	// over many rounds. A shared start barrier releases both goroutines at once
+	// so the no-overwrite publication (done -> queued) and the no-overwrite claim
+	// (queued -> running) interleave under the race detector.
+	const rounds = 80
+	for round := 0; round < rounds; round++ {
+		resetRound()
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Maintenance publication goroutine: requeue the actionable done task.
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, reqErr := task.Requeue(donePath, task.RequeueOptions{
+				Reason:              "interleave round",
+				ProcessedCommentIDs: []string{"1"},
+			}); reqErr != nil {
+				// A failed publication leaves the done task in place; the
+				// placement assertion below still holds (live copy stays in done
+				// only because queued/running are empty). Record nothing here so
+				// the deterministic assertion catches any real loss.
+				_ = reqErr
+			}
+		}()
+
+		// Execution claim goroutine: scan queued tasks and claim them into running
+		// via the no-overwrite rename, retrying briefly so it overlaps publication.
+		go func() {
+			defer wg.Done()
+			<-start
+			deadline := time.Now().Add(500 * time.Millisecond)
+			for {
+				queued, qErr := queue.QueuedTasks(root)
+				if qErr != nil {
+					t.Errorf("QueuedTasks failed: %v", qErr)
+					return
+				}
+				claimed := false
+				for _, qPath := range queued {
+					if _, claimErr := queue.ClaimTask(root, qPath); claimErr == nil {
+						claimed = true
+					}
+					// ErrClaimConflict or a missing-source rename error means the
+					// task was not claimed this pass; keep scanning/retrying.
+				}
+				if claimed || time.Now().After(deadline) {
+					return
+				}
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+
+		// Assert exactly-once placement: the requeued task lives in exactly one of
+		// queued or running, is never double-claimed (never in both), and is never
+		// lost. The source done task is removed exactly once when publication wins.
+		queuedMatches, gErr := filepath.Glob(queuedGlob)
+		if gErr != nil {
+			t.Fatal(gErr)
+		}
+		runningMatches, gErr := filepath.Glob(runningGlob)
+		if gErr != nil {
+			t.Fatal(gErr)
+		}
+		doneMatches, gErr := filepath.Glob(doneGlob)
+		if gErr != nil {
+			t.Fatal(gErr)
+		}
+		live := len(queuedMatches) + len(runningMatches) + len(doneMatches)
+		if live != 1 {
+			t.Fatalf("round %d: expected exactly one live copy of the task, got %d (queued=%v running=%v done=%v)",
+				round, live, queuedMatches, runningMatches, doneMatches)
+		}
+		if len(runningMatches) > 1 {
+			t.Fatalf("round %d: task was double-claimed into running: %v", round, runningMatches)
+		}
+		if len(queuedMatches) == 1 && len(runningMatches) == 1 {
+			t.Fatalf("round %d: task present in both queued and running (lost no-overwrite boundary)", round)
+		}
+	}
+
+	// Final state assertions over the canonical no-overwrite boundary: after the
+	// last round the task sits in exactly one terminal queue location.
+	finalQueued, err := filepath.Glob(queuedGlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalRunning, err := filepath.Glob(runningGlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalDone, err := filepath.Glob(doneGlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total := len(finalQueued) + len(finalRunning) + len(finalDone); total != 1 {
+		t.Fatalf("final placement: expected exactly one live copy, got %d (queued=%v running=%v done=%v)",
+			total, finalQueued, finalRunning, finalDone)
+	}
+	assertGlobCount(t, runningGlob, len(finalRunning))
+}

--- a/internal/daemon/maintenance_polling_independence_test.go
+++ b/internal/daemon/maintenance_polling_independence_test.go
@@ -1,0 +1,162 @@
+package daemon
+
+// Acceptance skeleton for issue 70 (decouple PR comment polling from execution).
+//
+// AC1: "While a normal daemon is running a long executor attempt, PR comment
+// polling shall continue on the configured poll interval without waiting for
+// that executor attempt to finish."
+//
+// Behavior under test (trigger -> process -> observable result):
+//   - Trigger: a normal (non --once) daemon claims a queued task whose executor
+//     attempt blocks for longer than several poll intervals, while an actionable
+//     open-PR task exists in tasks/done.
+//   - Process: the refactored normal-daemon scheduler runs the maintenance
+//     runner (PR comment polling + cleanup) on its own ticker, independent of
+//     the long-running execution runner.
+//   - Observable result: `gh api .../comments` polling for the done open-PR task
+//     runs (and repeats on the poll interval) while the executor attempt is still
+//     in progress, instead of being blocked until the executor exits.
+//
+// @lane: integration
+// @category: core-functionality
+// @dependency: daemon scheduler, queue, fake executor (claude), fake gh
+// @complexity: high
+// @roi: score=100 business_value=10 user_frequency=10 legal=false defect_detection=10
+//   (primary acceptance behavior of the feature; currently unprotected because the
+//   existing daemon cycle runs polling, cleanup, then execution serially and
+//   processAvailable waits on the executor goroutine before the next cycle.)
+// @timing: implement alongside the daemon scheduler refactor.
+//
+// Implementation notes for the executor:
+//   - There is no existing test that proves polling is independent of execution;
+//     this skeleton must be completed, not deleted.
+//   - Use a cancelable context and a short PollInterval so the maintenance runner
+//     ticks several times during the blocking executor attempt.
+//   - The fake gh appends each comment-poll invocation to pollLog; assert at
+//     least two poll invocations are recorded WHILE executorStarted exists and
+//     before the executor attempt has been allowed to finish.
+//   - Replace the explicit t.Fatal placeholder with the act + assert sequence.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/shinpr/galley/internal/queue"
+	"github.com/shinpr/galley/internal/task"
+)
+
+func TestNormalDaemonPollsPRCommentsWhileExecutorAttemptIsRunning(t *testing.T) {
+	// Arrange: Galley root + source repo.
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+
+	// Arrange: a blocking executor for the queued task. The marker file proves
+	// the executor attempt started; the long sleep keeps it running across
+	// several poll intervals so independent polling is observable.
+	executorStarted := filepath.Join(t.TempDir(), "executor-started")
+	claudeBin := writeFakeClaude(t, "touch "+executorStarted+"\nsleep 5\n"+
+		"echo change > daemon-output.txt\n"+
+		"echo '{\"status\":\"completed\",\"summary\":\"done\",\"files_modified\":[\"daemon-output.txt\"],\"acceptance_criteria\":[{\"id\":\"AC1\",\"status\":\"satisfied\",\"evidence\":[\"diff\"],\"notes\":\"done\"}],\"verification\":[],\"decisions\":[],\"risks\":[]}'\n")
+	writeDaemonTask(t, filepath.Join(root, "tasks", "queued", "blocking.yaml"), repo)
+
+	// Arrange: an actionable open-PR task in tasks/done whose PR comments must be
+	// polled while the executor above is still blocked.
+	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	donePath := filepath.Join(root, "tasks", "done", "open-pr.yaml")
+	writeDaemonTask(t, donePath, repo)
+	doneTask, err := task.Load(donePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doneTask.Status = "pr_opened"
+	doneTask.PR.URL = "https://github.com/example/galley/pull/123"
+	doneTask.PR.Status = "open"
+	doneTask.PR.AuthorLogin = "author"
+	if err := task.Save(donePath, doneTask); err != nil {
+		t.Fatal(err)
+	}
+
+	// Arrange: a fake gh that records each comment-poll invocation so the test
+	// can prove polling runs (and repeats) before the executor exits.
+	pollLog := filepath.Join(t.TempDir(), "gh-poll.log")
+	ghBin := writeFakeCommand(t, "gh", "if [ \"$1\" = \"api\" ]; then echo poll >> "+pollLog+"; echo '[[]]'; else echo unexpected-gh >&2; exit 1; fi\n")
+
+	// Act: start a normal (Once=false) daemon with a short PollInterval so the
+	// maintenance runner ticks several times during the 5s blocking executor
+	// attempt claimed from tasks/queued.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Options{
+			Root:               root,
+			SystemPromptFile:   promptPath,
+			JSONSchemaFile:     schemaPath,
+			Once:               false,
+			MaxConcurrentTasks: 1,
+			PollInterval:       20 * time.Millisecond,
+			ClaimTTL:           time.Hour,
+			ClaudeBin:          claudeBin,
+			GHBin:              ghBin,
+			Supervisor:         "claude",
+		})
+	}()
+
+	// The executor-start marker proves the long executor attempt is in progress.
+	waitForFileOrDone(t, executorStarted, done)
+
+	// Assert: PR comment polling runs and repeats while the executor attempt is
+	// still blocked. countPolls reads the recording fake gh log; the maintenance
+	// runner must record >= 2 poll invocations before the 5s executor attempt is
+	// released, proving polling does not wait for the executor to finish.
+	countPolls := func() int {
+		data, err := os.ReadFile(pollLog)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return 0
+			}
+			t.Fatal(err)
+		}
+		return bytes.Count(data, []byte("poll\n"))
+	}
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for countPolls() < 2 {
+		select {
+		case err := <-done:
+			t.Fatalf("daemon returned before maintenance polled twice (polls=%d): %v", countPolls(), err)
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for >= 2 PR comment polls while executor attempt blocked (polls=%d)", countPolls())
+		case <-tick.C:
+		}
+	}
+	// The executor attempt must still be running: its start marker is present and
+	// the 5s sleep has not been released, so the >= 2 polls above happened
+	// independently of the execution runner rather than after it finished.
+	if _, err := os.Stat(executorStarted); err != nil {
+		t.Fatalf("executor start marker missing; executor attempt may have already finished: %v", err)
+	}
+
+	// Cancel and confirm the daemon shuts down cleanly once the in-flight
+	// executor attempt drains.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("daemon shutdown returned unexpected error: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("daemon did not shut down after context cancel")
+	}
+}

--- a/internal/daemon/maintenance_polling_independence_test.go
+++ b/internal/daemon/maintenance_polling_independence_test.go
@@ -54,6 +54,7 @@ func TestNormalDaemonPollsPRCommentsWhileExecutorAttemptIsRunning(t *testing.T) 
 	// Arrange: Galley root + source repo.
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)
+	runDaemonGit(t, repo, "branch", "-M", "main")
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Close: #70

## Goal

Decouple normal-daemon PR comment polling and PR cleanup from queued task execution so long executor attempts no longer block PR comment intake, while preserving existing run-once, requeue, authorization, and queue publication behavior.

## Acceptance Criteria

- `AC1` While a normal daemon is running a long executor attempt, PR comment polling shall continue on the configured poll interval without waiting for that executor attempt to finish.
  - Verification: Focused daemon test with a blocking executor and an actionable open-PR task in tasks/done or tasks/failed proves gh api comment polling runs before the executor exits.

Acceptance skeleton:
- `internal/daemon/maintenance_polling_independence_test.go`: Prove a normal daemon continues PR comment polling on the poll interval while a long executor attempt is still running, using a blocking fake executor on a queued task and a recording fake gh on an actionable open-PR done task.
  satisfies: AC1 observable behavior: gh api comment polling runs and repeats on the poll interval before the blocking executor attempt exits, instead of waiting for it.
  integration point: Executor wires up the act+assert sequence (start non-once daemon with short PollInterval, wait for executor-start marker, assert >=2 recorded comment polls while the executor is still blocked, then cancel) as part of the daemon scheduler refactor, replacing the t.Fatal placeholder.
  - Status: satisfied
- `AC2` When galley daemon run --once is used, the command shall preserve the existing external behavior: drain eligible queued work and exit without becoming a long-running daemon.
  - Verification: Existing run-once drain tests continue to pass, with a focused regression test if needed for the refactored runner path.
  - Status: satisfied
- `AC3` PR comment polling shall preserve the existing actionable task scope: open-PR pr_opened tasks in tasks/done and open-PR needs_supervisor_review tasks in tasks/failed.
  - Verification: Existing PR comment polling tests continue to pass and show no new running-task comment behavior.
  - Status: satisfied
- `AC4` When an authorized /galley comment is found on an actionable open PR task, Galley shall preserve existing requeue behavior, including revision request creation and processed_comment_ids recording.
  - Verification: Existing authorized PR comment requeue tests pass through the refactored maintenance path.
  - Status: satisfied
- `AC5` When an unauthorized /galley comment is found, Galley shall preserve existing fail-closed behavior by recording the comment as processed without requeueing the task.
  - Verification: Existing unauthorized PR comment tests pass through the refactored maintenance path.
  - Status: satisfied
- `AC6` While maintenance and execution run concurrently, requeue publication and queued-task claim shall remain race-free so a requeued task is neither lost nor double-claimed under the existing no-overwrite publication and claim boundary.
  - Verification: Focused interleaving test covers requeue from done/failed to queued while execution concurrently scans or claims queued tasks; existing no-overwrite publication and claim tests continue to pass.

Acceptance skeleton:
- `internal/daemon/maintenance_execution_race_test.go`: Prove concurrent maintenance requeue publication (done to queued via task.Requeue) and execution claim (queue.QueuedTasks/ClaimTask) stay race-free under the existing no-overwrite write/rename boundary.
  satisfies: AC6 observable behavior: a requeued task is neither lost nor double-claimed when maintenance publication and execution claim interleave; exactly-once placement across queued+running.
  integration point: Executor implements the concurrent goroutine interleaving and the exactly-once placement assertions (assertGlobCount over tasks/queued and tasks/running, single source removal), replacing the t.Fatal placeholder.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go test -race -run 'TestMaintenanceRequeueAndExecutionClaimStayRaceFree|TestNormalDaemonPollsPRCommentsWhileExecutorAttemptIsRunning' ./internal/daemon/ -count=1`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool <each schema/plugin/marketplace json>`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` How should daemon orchestration be refactored for issue 70? -> Split normal daemon scheduling into shared maintenance and execution runners instead of adding a separate top-level once-vs-normal implementation path.
  - Rationale: This preserves run-once behavior while allowing normal-daemon maintenance to run independently from long executor attempts.
  - Reversibility: high
- `D2` Should this task add running-task PR comment recording? -> No; keep PR comment application scoped to existing actionable done/failed states.
  - Rationale: Recording comments on a running task does not deliver the instruction to the already-running executor and would require a separate product decision about live instruction handling.
  - Reversibility: high
- `D3` Should this task add cross-process locks, journals, task versioning, config, or daemon status UI? -> No; rely on existing no-overwrite queued publication and claim behavior, and avoid multi-daemon coordination.
  - Rationale: The requested value is independent maintenance scheduling for the normal daemon, not a storage or coordination redesign.
  - Reversibility: high
- `requeue-4` Why was this task requeued? -> Retry after transient Claude API 529 overload during setup executor
  - Rationale: A reviewer or PR comment requested another executor attempt.
  - Reversibility: high
- `claude-decision-5` How should the normal daemon schedule maintenance independently from execution without adding coordination machinery? -> Run runMaintenanceRunner (pollPRComments + cleanupWorktrees) and runExecutionRunner (processQueuedTasks) as two goroutines, each on its own PollInterval ticker; --once continues to use the shared execution drain. Maintenance polling and cleanup stay serialized within a single maintenance cycle.
  - Rationale: Matches prior decision D1 and the issue-70 design note: the execution runner's load-bearing wg.Wait stays intact (execution passes remain serialized) while maintenance ticks independently, so a long executor attempt no longer blocks PR comment intake. No locks/journals/versioning added (D3).
  - Reversibility: high

## Risks

- `R1` regression: Parallel maintenance and execution could expose a race between PR-comment requeue publication and queued-task claim.
  - Mitigation: Add a focused interleaving regression test and preserve existing no-overwrite publication and claim paths.
- `R2` regression: Refactoring daemon orchestration could accidentally change galley daemon run --once semantics.
  - Mitigation: Keep run-once as execution drain and preserve existing run-once tests.
- `R3` compatibility: PR comment authorization and processed_comment_ids behavior are trust-boundary behavior.
  - Mitigation: Preserve existing authorized and unauthorized PR comment tests, and do not expand actionable states in this task.