### PR TITLE
Bump CI action pins to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout@v5.0.0
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
         # actions/setup-go@v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout@v5.0.0
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -32,8 +32,8 @@ jobs:
         run: go test ./...
 
       - name: Run GoReleaser
-        # goreleaser/goreleaser-action@v6.4.0
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
+        # goreleaser/goreleaser-action@v7.2.2
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
         with:
           distribution: goreleaser
           version: v2.12.7
@@ -49,8 +49,8 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout@v5.0.0
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Smoke PowerShell installer
         shell: powershell


### PR DESCRIPTION
## Summary

The SHA pins for two GitHub Actions were a major version behind. The pinned SHAs themselves correctly matched their comment tags (no mislabeling), but newer majors are available. This updates them to the latest releases.

| Action | Before | After | Pinned SHA |
|---|---|---|---|
| `actions/checkout` (×3) | v5.0.0 | **v6.0.3** | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
| `goreleaser/goreleaser-action` | v6.4.0 | **v7.2.2** | `5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89` |
| `actions/setup-go` | v6.4.0 | unchanged (already latest) | — |

- `ci.yml`: 1 checkout step
- `release.yml`: 2 checkout steps + 1 goreleaser-action step
- `checkout` tags are annotated, so the pins resolve to the underlying commit SHA. Comment labels were updated to match the new versions.

## Breaking change review

Both major bumps are effectively Node 24 runtime migrations. The inputs in use stay valid:
- `checkout`: only `fetch-depth` is used.
- `goreleaser-action`: `distribution: goreleaser`, `version: v2.12.7`, and `args` are unchanged; GoReleaser v2 remains supported.

GitHub-hosted runners support Node 24, so no behavioral impact is expected. Verification relies on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)