### PR TITLE
Preserve observable contract values in prompts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.7.6 - 2026-06-19
+
+### Changed
+
+- Task-authoring and executor guidance now preserves exact observable contract values when task text, acceptance criteria, input materials, public surfaces, tests, or authoritative existing examples make those values required.
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.16`: bundled task-authoring guidance includes the observable contract value preservation rule.
+
 ## v0.7.5 - 2026-06-07
 
 ### Changed

--- a/internal/runner/codex_prompt_test.go
+++ b/internal/runner/codex_prompt_test.go
@@ -76,6 +76,7 @@ func TestExecutorPromptsContainContractSections(t *testing.T) {
 		"Return exactly one JSON object",
 		"task.files",
 		"requested core mechanism",
+		"exact observable contract values",
 		"Use exactly these enum values:",
 	}
 	for name, prompt := range map[string]string{

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/authoring-quality.md
+++ b/plugins/galley/skills/galley/references/authoring-quality.md
@@ -193,6 +193,8 @@ Runnable verification commands should fail when the checked condition fails. Pre
 
 For observable contracts, choose one expected contract before drafting ACs. CLI text, JSON payloads, files, logs, PR bodies, statuses, titles, and public docs should name the required fields, values, ordering, persistence, or fallback behavior. Record alternatives in `decisions` only after a behavior is chosen.
 
+Carry literal observable values into the AC text, verification, decision, or risk that owns them when any source fixes the value as required: task text, an AC, or an input material names it as required; a public API, CLI, schema, persisted format, or test consumes it; or multiple authoritative existing examples use the same value. Literal values include field and key names, enum/status values, order-sensitive output, fallback or empty-state text, derived display rules, lifecycle negatives such as a value becoming visible only after completion, and config precedence values. Treat these values as part of the contract rather than paraphrasing them into a general description.
+
 Look for:
 
 - existing repo quality profile resolved by `galley profile resolve --cwd <repo> --output json`

--- a/prompts/claude-executor-full.md
+++ b/prompts/claude-executor-full.md
@@ -29,6 +29,8 @@ Before editing, classify each supplied file:
 
 Read every `requirement_basis`, `execution_plan`, and `test_or_quality_basis` file before implementation. Extract obligations from those files into the work contract: product behavior, interface/runtime contracts, evidence contracts, non-scope constraints, quality gates, and explicit anti-goals. Use `context_evidence` when it affects a changed path, local decision, or verification claim.
 
+When extracting an observable contract, preserve exact contract values when any source fixes the value as required: task text, an AC, or an input material names it as required; a public API, CLI, schema, persisted format, or test consumes it; or multiple authoritative existing examples use the same value. Contract values include field and key names, enum/status values, order-sensitive output, fallback or empty-state text, derived display rules, lifecycle negatives such as a value becoming visible only after completion, and config precedence values. Treat a change to a binding contract value as a task semantics change unless a higher-priority source requires or authorizes the new value.
+
 # Completion Contract
 
 Continue until every acceptance criterion is satisfied, or until a hard-stop condition applies. Ambiguity is handled by local investigation first, then by the smallest reversible decision that can make progress.
@@ -152,6 +154,7 @@ Before returning the final JSON, verify:
 - Every `requirement_basis`, `execution_plan`, and `test_or_quality_basis` input material was read, or the final result records why it was irrelevant to the changed behavior.
 - Every extracted work-contract obligation is implemented, explicitly out of scope by higher-priority task text, or reported as `hard_stop`.
 - The final implementation preserves the task's requested core mechanism. Any implementation strategy change keeps the same mechanism and observable contract.
+- Beyond the contract shape, exact observable contract values are preserved or changed only when a higher-priority source requires or authorizes the new value, with the decision recorded in `decisions` or the blocker reported as `hard_stop`.
 - Required quality profile dimensions have concrete implementation evidence. Treat quality profile rules as coding rules during implementation and as supervisor review hints.
 - The implementation is substantive: AC satisfaction comes from real behavior and evidence when the AC requires behavior, rather than fixed templates, metadata shells, placeholder plumbing, TODO-only files, hollow tests, or no-op behavior.
 - Verification evidence exercises the changed behavior. A focused selector that matches zero tests is skipped evidence rather than passed evidence.

--- a/prompts/codex-executor-full.md
+++ b/prompts/codex-executor-full.md
@@ -31,6 +31,8 @@ Classify each supplied file before editing:
 
 Read every `requirement_basis`, `execution_plan`, and `test_or_quality_basis` file before implementation. Extract product behavior, interface/runtime contracts, evidence contracts, non-scope constraints, quality gates, and explicit anti-goals from those files. Use `context_evidence` when it affects a changed path, local decision, or verification claim.
 
+When extracting an observable contract, preserve exact contract values when any source fixes the value as required: task text, an AC, or an input material names it as required; a public API, CLI, schema, persisted format, or test consumes it; or multiple authoritative existing examples use the same value. Contract values include field and key names, enum/status values, order-sensitive output, fallback or empty-state text, derived display rules, lifecycle negatives such as a value becoming visible only after completion, and config precedence values. Treat a change to a binding contract value as a task semantics change unless a higher-priority source requires or authorizes the new value.
+
 # Hard-Stop Conditions
 
 Return `status: "hard_stop"` when the next necessary step is blocked by one of these conditions:
@@ -101,6 +103,7 @@ Before returning the final JSON, verify:
 - Required input materials were read, or the result records why they did not affect the changed behavior.
 - Extracted work-contract obligations are implemented, explicitly out of scope by higher-priority task text, or reported as `hard_stop`.
 - The implementation preserves the requested core mechanism and observable contract.
+- Beyond the contract shape, exact observable contract values are preserved or changed only when a higher-priority source requires or authorizes the new value, with the decision recorded in `decisions` or the blocker reported as `hard_stop`.
 - Required quality profile dimensions have concrete implementation evidence.
 - Acceptance comes from substantive behavior and evidence, not placeholder plumbing, TODO-only files, hollow tests, or no-op behavior.
 - Verification evidence exercises the changed behavior. A focused selector that matches zero tests is recorded as skipped evidence, not passed evidence.


### PR DESCRIPTION
## Summary
- Teach task authoring to carry literal observable values into ACs, verification, decisions, or risks when authoritative sources make those values required.
- Update Claude and Codex executor prompts to preserve exact observable contract values separately from the broader contract shape.
- Bump packaged Claude and Codex Galley plugins to 0.1.16 and document the change in the changelog.

## Validation
- go test ./internal/runner ./internal/task
- go test ./...
- claude plugin validate plugins/galley