### PR TITLE
Tighten supervisor finding verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.7.7 - 2026-06-21
+
+### Changed
+
+- Supervisor review prompts now verify candidate findings against supporting and contrary repository evidence before turning them into revision work, while still recording concrete unresolved concerns that another executor attempt can act on.
+
 ## v0.7.6 - 2026-06-19
 
 ### Changed

--- a/prompts/claude-supervisor-review.md
+++ b/prompts/claude-supervisor-review.md
@@ -69,9 +69,15 @@ When `task.files` is present, confirm the implementation reflects relevant sourc
 
 Check core mechanism preservation. If the task, acceptance criteria, source materials, or quality profile require a core mechanism, verify the implementation preserves it rather than replacing it with a weaker surrogate for cost, simplicity, determinism, or testability. Examples include replacing an LLM judgment pass with a fixed template, replacing Galley-owned evidence with executor self-report, or replacing behavior-first generated tests with placeholder files. A newly added implementation with a misplaced core mechanism is a revision issue when another executor attempt can correct it.
 
-Record concrete contradictions, contract mismatches, misplaced requirement boundaries, or missing verification as findings.
+## Step 5. Verify Candidate Findings
 
-## Step 5. Verify Verdict
+For each candidate problem from Steps 2-4, check the evidence before recording it as a finding:
+
+1. Identify the repository evidence that supports the concern.
+2. Check nearby contracts and adjacent cases that share the same changed path, contract, persisted state, or external boundary for contrary evidence.
+3. Apply the Quality Rules below: record concrete problems and concrete unresolved concerns as findings; use `residual_risks` only for non-blocking uncertainty that does not require another executor attempt; use `needs_supervisor_review` when the next decision requires human judgment.
+
+## Step 6. Verify Verdict
 
 Before returning JSON, verify that findings, acceptance gaps, acceptance evidence, residual risks, discussion items, confidence, and `next_work_order` match the active pass policy and schema.
 

--- a/prompts/codex-supervisor-review.md
+++ b/prompts/codex-supervisor-review.md
@@ -52,6 +52,7 @@ Treat executor `hard_stop` as a claim to review, not as an automatic final state
 14. For infra tasks, evaluate idempotency, environment targeting, secrets handling, rollout or rollback risk, and plan or apply evidence when provided.
 15. Apply task-specific quality profile rules, pending revision requests, and any task playbook included in the evidence as boundary contracts.
 16. When a rationale in one changed file depends on a design rule, layering rule, ownership boundary, dependency direction, or compatibility policy, check the other changed files for the same rule before accepting.
+17. Before recording any candidate problem from this checklist as a finding, identify the supporting repository evidence and check nearby contracts plus adjacent cases that share the same changed path, contract, persisted state, or external boundary for contrary evidence. Apply the Finding Policy below: record concrete problems and concrete unresolved concerns as findings; use `residual_risks` only for non-blocking uncertainty that does not require another executor attempt; use `needs_supervisor_review` when the next decision requires human judgment.
 
 # Finding Policy
 


### PR DESCRIPTION
## Summary
- add an explicit Claude supervisor step to verify candidate findings against supporting and contrary repository evidence before recording them
- add the same candidate-finding verification rule to the Codex supervisor checklist
- document the supervisor prompt change in the v0.7.7 changelog

## Testing
- Not run; prompt-only change.