### PR TITLE
Make Galley worktree cleanup avoid unnecessary GitHub API calls for already-final done tasks, so historical cleanup state no longer creates recurring maintenance failures when no worktree action is needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This project follows semantic versioning.
 
 ## Unreleased
 
-### Changed
+## v0.8.1 - 2026-06-24
 
-- Daemon worktree cleanup no longer queries GitHub for done tasks that already record a final `pr.status` of `merged` or `closed`: it acts on the persisted final status to remove a still-present managed worktree or reconcile an already-absent one, so already-final historical tasks no longer turn a GitHub read failure into a recurring maintenance error. Tasks that still record `pr.status: open` continue to fetch live PR state, keeping open-PR worktrees and removing PRs that closed or merged after Galley last persisted the task. Per-task cleanup failures now carry the task file or id plus the PR URL and resolved worktree path, and the sweep continues past a failing task before returning the first contextualized failure.
+### Fixed
+
+- Daemon worktree cleanup now uses persisted final `pr.status` for already-final done tasks instead of refreshing PR state from GitHub, preventing historical tasks from causing recurring maintenance failures. Open PR tasks still refresh live state, and cleanup failures now include task, PR, and worktree context while the sweep continues to later tasks.
 
 ## v0.8.0 - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Daemon worktree cleanup no longer queries GitHub for done tasks that already record a final `pr.status` of `merged` or `closed`: it acts on the persisted final status to remove a still-present managed worktree or reconcile an already-absent one, so already-final historical tasks no longer turn a GitHub read failure into a recurring maintenance error. Tasks that still record `pr.status: open` continue to fetch live PR state, keeping open-PR worktrees and removing PRs that closed or merged after Galley last persisted the task. Per-task cleanup failures now carry the task file or id plus the PR URL and resolved worktree path, and the sweep continues past a failing task before returning the first contextualized failure.
+
 ## v0.8.0 - 2026-06-23
 
 ### Added

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -88,6 +88,8 @@ galley daemon run --once
 
 `galley daemon run --once` drains queued tasks once and exits. Background `galley daemon start` also performs daemon maintenance such as PR comment polling and closed or merged PR worktree cleanup according to `environment.yaml`. In normal (non `--once`) mode this maintenance runs on its own poll-interval schedule, independent of queued task execution, so PR comment polling and cleanup continue on the configured interval even while a long executor attempt is still running.
 
+When a done task already records a final `pr.status` of `merged` or `closed`, worktree cleanup acts on that persisted status directly and does not query GitHub for live PR state, so already-final historical tasks no longer turn a GitHub read failure into a recurring maintenance error. Tasks that still record `pr.status: open` are refreshed from GitHub so a PR that closed or merged after Galley last persisted it is still cleaned up. Per-task cleanup failures are reported with the task file or id plus the PR URL and resolved worktree path, and the sweep continues to the remaining done tasks before surfacing the first such failure.
+
 `--root` points at the daemon root and defaults to `~/.galley`. Use `--root .agent-workflow` only for repo-local or test workflows.
 
 `galley daemon start` launches the daemon in the background. It writes a PID file and appends stdout and stderr to a log file. By default those files are under `~/.galley`; override them with `--pid-file` and `--log-file`.

--- a/internal/daemon/cleanup.go
+++ b/internal/daemon/cleanup.go
@@ -21,8 +21,12 @@ func cleanupWorktrees(ctx context.Context, opts Options) error {
 	}
 	var firstErr error
 	for _, path := range matches {
-		if err := cleanupTaskWorktree(ctx, opts, path); err != nil && firstErr == nil {
-			firstErr = err
+		if err := cleanupTaskWorktree(ctx, opts, path); err != nil {
+			if firstErr == nil {
+				firstErr = err
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "galley: additional worktree cleanup failure: %v\n", err)
 		}
 	}
 	return firstErr

--- a/internal/daemon/cleanup.go
+++ b/internal/daemon/cleanup.go
@@ -40,7 +40,7 @@ func cleanupTaskWorktree(ctx context.Context, opts Options, path string) error {
 	}
 	_, profiles, err := loadTaskProfiles(opts, loaded.Scope.CWD)
 	if err != nil {
-		return err
+		return cleanupTaskError(path, loaded, err)
 	}
 	effectiveOpts := effectiveOptionsForProfiles(opts, profiles)
 	if !effectiveOpts.CleanupWorktrees {
@@ -49,36 +49,53 @@ func cleanupTaskWorktree(ctx context.Context, opts Options, path string) error {
 	if loaded.PR.URL == "" || loaded.Worktree.Path == "" || !loaded.Worktree.Enabled {
 		return nil
 	}
-	// Retry the PR state lookup. `gh pr view` is a GET-equivalent and
-	// idempotent, so a brief GitHub read flake should not abort worktree
-	// cleanup. The final error is surfaced unchanged.
-	var state vcs.PullRequestState
-	err = retry.Do(ctx, func(ctx context.Context) error {
-		s, fetchErr := vcs.FetchPRState(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL)
-		if fetchErr != nil {
-			return fetchErr
+
+	// Decide the final PR status that authorizes worktree removal.
+	//
+	// A persisted final PR status (merged/closed) is sufficient on its own:
+	// the PR lifecycle has no remaining decision, so cleanup of an already-
+	// final historical task must not depend on GitHub API availability (D1).
+	// Querying GitHub for these tasks is the recurring maintenance failure
+	// this change removes, so the no-GitHub path is gated strictly on the
+	// persisted final status (R1).
+	persistedFinal := loaded.PR.Status == "merged" || loaded.PR.Status == "closed"
+	finalStatus := loaded.PR.Status
+	if !persistedFinal {
+		// The task still records a non-final PR (e.g. open), so the live PR
+		// state may have changed after Galley last persisted the task. Refresh
+		// it from GitHub. `gh pr view` is a GET-equivalent and idempotent, so a
+		// brief GitHub read flake should not abort worktree cleanup.
+		var state vcs.PullRequestState
+		err = retry.Do(ctx, func(ctx context.Context) error {
+			s, fetchErr := vcs.FetchPRState(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			state = s
+			return nil
+		})
+		if err != nil {
+			return cleanupTaskError(path, loaded, err)
 		}
-		state = s
-		return nil
-	})
-	if err != nil {
-		return err
+		if strings.EqualFold(state.State, "open") {
+			return nil
+		}
+		if !strings.EqualFold(state.State, "closed") {
+			return cleanupTaskError(path, loaded, fmt.Errorf("unsupported PR state %q", state.State))
+		}
+		finalStatus = closedPRTaskStatus(state)
 	}
-	if strings.EqualFold(state.State, "open") {
-		return nil
-	}
-	if !strings.EqualFold(state.State, "closed") {
-		return fmt.Errorf("unsupported PR state %q for %s", state.State, loaded.PR.URL)
-	}
-	finalStatus := closedPRTaskStatus(state)
-	alreadyFinal := loaded.PR.Status == "merged" || loaded.PR.Status == "closed"
+
 	cleanupResult, err := workspace.Remove(ctx, loaded.Scope.CWD, loaded.Worktree, workspaceOptions(effectiveOpts))
 	if err != nil {
-		return err
+		return cleanupTaskError(path, loaded, err)
 	}
-	if cleanupResult.AlreadyMissing && alreadyFinal {
+	if cleanupResult.AlreadyMissing && persistedFinal {
 		loaded.Status = finalStatus
-		return task.Save(path, loaded)
+		if err := task.Save(path, loaded); err != nil {
+			return cleanupTaskError(path, loaded, err)
+		}
+		return nil
 	}
 	loaded.Status = finalStatus
 	loaded.PR.Status = finalStatus
@@ -91,7 +108,23 @@ func cleanupTaskWorktree(ctx context.Context, opts Options, path string) error {
 		SupervisorVerdict: "cleanup",
 		Summary:           fmt.Sprintf("Worktree cleanup removed=%t missing=%t path=%s", cleanupResult.Removed, cleanupResult.AlreadyMissing, cleanupResult.Path),
 	})
-	return task.Save(path, loaded)
+	if err := task.Save(path, loaded); err != nil {
+		return cleanupTaskError(path, loaded, err)
+	}
+	return nil
+}
+
+// cleanupTaskError wraps a per-task worktree cleanup failure with enough
+// context for an operator or agent to identify the failing task from daemon
+// logs (R2/AC5): the task YAML path, the task id, the PR URL, and the managed
+// worktree path. cleanupWorktrees scans every done task and returns the first
+// such contextualized failure (AC6), so the context must name which task in
+// the sweep failed rather than only the underlying git or GitHub error.
+func cleanupTaskError(path string, loaded task.Task, err error) error {
+	return fmt.Errorf(
+		"worktree cleanup failed for task %s (id=%s pr=%s worktree=%s): %w",
+		path, loaded.ID, loaded.PR.URL, loaded.Worktree.Path, err,
+	)
 }
 
 func closedPRTaskStatus(state vcs.PullRequestState) string {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1505,6 +1505,44 @@ func TestCleanupWorktreesContinuesAfterTaskFailure(t *testing.T) {
 	}
 }
 
+func TestCleanupWorktreesLogsAdditionalTaskFailures(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+
+	firstFailingPath := filepath.Join(root, "tasks", "done", "a-failing.yaml")
+	writeDaemonTask(t, firstFailingPath, repo)
+	prepareDonePRTask(t, firstFailingPath, repo, "merged")
+	pointWorktreeAtSourceRepo(t, firstFailingPath, repo)
+
+	secondFailingPath := filepath.Join(root, "tasks", "done", "b-failing.yaml")
+	writeDaemonTask(t, secondFailingPath, repo)
+	prepareDonePRTask(t, secondFailingPath, repo, "merged")
+	pointWorktreeAtSourceRepo(t, secondFailingPath, repo)
+
+	ghBin, marker := writeFailIfInvokedGH(t)
+
+	var cleanupErr error
+	stderr := captureStderr(t, func() {
+		cleanupErr = cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults())
+	})
+	if cleanupErr == nil {
+		t.Fatal("expected the first contextualized failure to be returned")
+	}
+	if !strings.Contains(cleanupErr.Error(), firstFailingPath) {
+		t.Fatalf("returned error must keep the first failing task, got %q", cleanupErr)
+	}
+	if !strings.Contains(stderr, "galley: additional worktree cleanup failure:") {
+		t.Fatalf("stderr must log additional cleanup failures, got %q", stderr)
+	}
+	if !strings.Contains(stderr, secondFailingPath) {
+		t.Fatalf("stderr must name the second failing task, got %q", stderr)
+	}
+	assertGHNotInvoked(t, marker)
+}
+
 // pointWorktreeAtSourceRepo rewrites a done task's managed worktree path to the
 // source repository so workspace.Remove refuses to remove it, producing a
 // deterministic actionable cleanup failure for AC5/AC6.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1330,6 +1330,196 @@ func TestCleanupWorktreesRemovesDirtyClosedPRWorktree(t *testing.T) {
 	}
 }
 
+// writeFailIfInvokedGH returns a fake `gh` binary that records every
+// invocation by creating a marker file and exits successfully so a buggy
+// caller does not pay the FetchPRState retry backoff. Tests assert the marker
+// is absent to prove the no-GitHub cleanup path never shelled out to `gh`.
+func writeFailIfInvokedGH(t *testing.T) (ghBin, marker string) {
+	t.Helper()
+	marker = filepath.Join(t.TempDir(), "gh-invoked")
+	ghBin = writeFakeCommand(t, "gh", "printf invoked > "+strconv.Quote(marker)+"\n"+
+		"echo '{\"state\":\"closed\",\"merged\":true}'\n")
+	return ghBin, marker
+}
+
+func assertGHNotInvoked(t *testing.T, marker string) {
+	t.Helper()
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("gh must not be invoked for a persisted-final task, marker err=%v", err)
+	}
+}
+
+// TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI covers
+// AC1: a done task that already records pr.status merged/closed and whose
+// managed worktree path is already absent must complete cleanup without
+// invoking `gh api`.
+func TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI(t *testing.T) {
+	for _, prStatus := range []string{"merged", "closed"} {
+		t.Run(prStatus, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), ".agent-workflow")
+			repo := initDaemonGitRepo(t)
+			if err := queue.EnsureLayout(root); err != nil {
+				t.Fatal(err)
+			}
+			taskPath := filepath.Join(root, "tasks", "done", "task.yaml")
+			writeDaemonTask(t, taskPath, repo)
+			_, worktreePath := prepareDonePRTask(t, taskPath, repo, prStatus)
+			// Simulate an already-final historical task whose worktree was
+			// already removed in a prior sweep.
+			if err := os.RemoveAll(worktreePath); err != nil {
+				t.Fatal(err)
+			}
+			ghBin, marker := writeFailIfInvokedGH(t)
+
+			if err := cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults()); err != nil {
+				t.Fatal(err)
+			}
+			assertGHNotInvoked(t, marker)
+
+			reloaded, err := task.Load(taskPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reloaded.Status != prStatus {
+				t.Fatalf("task status got %q want %q", reloaded.Status, prStatus)
+			}
+			if reloaded.PR.Status != prStatus {
+				t.Fatalf("pr status got %q want %q", reloaded.PR.Status, prStatus)
+			}
+		})
+	}
+}
+
+// TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI covers
+// AC2: a done task that already records pr.status merged/closed and whose
+// managed worktree still exists must be removed using the persisted final PR
+// status, without first refreshing PR state from GitHub.
+func TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI(t *testing.T) {
+	for _, prStatus := range []string{"merged", "closed"} {
+		t.Run(prStatus, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), ".agent-workflow")
+			repo := initDaemonGitRepo(t)
+			if err := queue.EnsureLayout(root); err != nil {
+				t.Fatal(err)
+			}
+			taskPath := filepath.Join(root, "tasks", "done", "task.yaml")
+			writeDaemonTask(t, taskPath, repo)
+			_, worktreePath := prepareDonePRTask(t, taskPath, repo, prStatus)
+			ghBin, marker := writeFailIfInvokedGH(t)
+
+			if err := cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults()); err != nil {
+				t.Fatal(err)
+			}
+			assertGHNotInvoked(t, marker)
+
+			if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+				t.Fatalf("persisted-final worktree should be removed, err=%v", err)
+			}
+			reloaded, err := task.Load(taskPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reloaded.PR.Status != prStatus {
+				t.Fatalf("pr status got %q want %q", reloaded.PR.Status, prStatus)
+			}
+			if reloaded.Status != prStatus {
+				t.Fatalf("task status got %q want %q", reloaded.Status, prStatus)
+			}
+			if len(reloaded.Attempts) == 0 || reloaded.Attempts[len(reloaded.Attempts)-1].SupervisorVerdict != "cleanup" {
+				t.Fatalf("cleanup attempt missing: %#v", reloaded.Attempts)
+			}
+		})
+	}
+}
+
+// TestCleanupWorktreesErrorIncludesTaskContext covers AC5: an actionable
+// cleanup failure must identify the failing task (file or id) plus the PR URL
+// or resolved worktree path. The worktree path is pointed at the source
+// repository so workspace.Remove refuses removal deterministically.
+func TestCleanupWorktreesErrorIncludesTaskContext(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+	taskPath := filepath.Join(root, "tasks", "done", "failing.yaml")
+	writeDaemonTask(t, taskPath, repo)
+	prepareDonePRTask(t, taskPath, repo, "merged")
+	pointWorktreeAtSourceRepo(t, taskPath, repo)
+	ghBin, _ := writeFailIfInvokedGH(t)
+
+	err := cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults())
+	if err == nil {
+		t.Fatal("expected a contextualized cleanup error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, taskPath) && !strings.Contains(msg, "task-daemon-test") {
+		t.Fatalf("error must name the task file or id, got %q", msg)
+	}
+	if !strings.Contains(msg, "https://github.com/example/galley/pull/123") && !strings.Contains(msg, repo) {
+		t.Fatalf("error must name the PR URL or resolved worktree path, got %q", msg)
+	}
+}
+
+// TestCleanupWorktreesContinuesAfterTaskFailure covers AC6: cleanup keeps
+// scanning remaining done tasks after a per-task failure and returns the first
+// contextualized failure once the sweep completes. The failing task sorts
+// before the removable task so the returned error is the contextualized one.
+func TestCleanupWorktreesContinuesAfterTaskFailure(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	if err := queue.EnsureLayout(root); err != nil {
+		t.Fatal(err)
+	}
+
+	failingPath := filepath.Join(root, "tasks", "done", "a-failing.yaml")
+	writeDaemonTask(t, failingPath, repo)
+	prepareDonePRTask(t, failingPath, repo, "merged")
+	pointWorktreeAtSourceRepo(t, failingPath, repo)
+
+	removablePath := filepath.Join(root, "tasks", "done", "b-removable.yaml")
+	writeDaemonTask(t, removablePath, repo)
+	_, removableWorktree := prepareDonePRTask(t, removablePath, repo, "merged")
+
+	ghBin, marker := writeFailIfInvokedGH(t)
+
+	err := cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults())
+	if err == nil {
+		t.Fatal("expected the first contextualized failure to be returned")
+	}
+	if !strings.Contains(err.Error(), failingPath) && !strings.Contains(err.Error(), "a-failing.yaml") {
+		t.Fatalf("returned error must name the failing task, got %q", err)
+	}
+	assertGHNotInvoked(t, marker)
+
+	// The sweep continued past the failure and cleaned the later removable task.
+	if _, statErr := os.Stat(removableWorktree); !os.IsNotExist(statErr) {
+		t.Fatalf("later removable worktree should be cleaned, err=%v", statErr)
+	}
+	reloaded, err := task.Load(removablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Status != "merged" {
+		t.Fatalf("removable task status got %q want merged", reloaded.Status)
+	}
+}
+
+// pointWorktreeAtSourceRepo rewrites a done task's managed worktree path to the
+// source repository so workspace.Remove refuses to remove it, producing a
+// deterministic actionable cleanup failure for AC5/AC6.
+func pointWorktreeAtSourceRepo(t *testing.T, taskPath, repo string) {
+	t.Helper()
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Worktree.Path = repo
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestRunOnceBranchesNewWorktreeFromEnvironmentPRBaseOriginRef covers AC2 +
 // AC4 case (1): when the environment profile's pr.base resolves to an
 // origin/<base> ref, the new task worktree is branched from that ref's SHA


### PR DESCRIPTION
## Goal

Make Galley worktree cleanup avoid unnecessary GitHub API calls for already-final done tasks, so historical cleanup state no longer creates recurring maintenance failures when no worktree action is needed.

## Acceptance Criteria

- `AC1` While a done task records `pr.status: merged` or `pr.status: closed` and its managed worktree path is already absent, worktree cleanup shall complete that task without invoking `gh api`.
  - Verification: go test ./internal/daemon -run TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI; the fake `gh` command fails the test if invoked.
  - Status: satisfied
- `AC2` While a done task records `pr.status: merged` or `pr.status: closed` and its managed worktree path still exists, worktree cleanup shall remove the managed worktree using the persisted final PR status without first refreshing PR state from GitHub.
  - Verification: go test ./internal/daemon -run TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI; assert the worktree is removed, task status remains or updates to the persisted final state, and fake `gh` is not called.
  - Status: satisfied
- `AC3` When a done task records `pr.status: open` with a managed worktree, worktree cleanup shall still fetch the live PR state from GitHub and keep the worktree while the PR state is open.
  - Verification: go test ./internal/daemon -run TestCleanupWorktreesKeepsOpenPRWorktree; assert the fake `gh api` response `{"state":"open","merged":false}` is consumed, the worktree remains, and task YAML is unchanged.
  - Status: satisfied
- `AC4` When a done task records `pr.status: open` and GitHub reports the PR as closed or merged, worktree cleanup shall remove the managed worktree and persist `task.status` and `pr.status` as `closed` or `merged` according to the live PR state.
  - Verification: go test ./internal/daemon -run 'TestCleanupWorktreesRemoves(CleanMergedPRWorktree|DirtyClosedPRWorktree)'; keep coverage for both `{"state":"closed","merged":true}` and `{"state":"closed","merged":false}`.
  - Status: satisfied
- `AC5` If worktree cleanup cannot inspect or remove an actionable task, the maintenance error shall identify the task file or task id and the PR URL or resolved worktree path that caused the failure.
  - Verification: go test ./internal/daemon -run TestCleanupWorktreesErrorIncludesTaskContext; assert the returned error contains the task YAML path or id plus the relevant `pr.url` or resolved worktree path.
  - Status: satisfied
- `AC6` Worktree cleanup shall continue scanning remaining done tasks after a per-task cleanup failure and return the first contextualized failure after the scan completes.
  - Verification: go test ./internal/daemon -run TestCleanupWorktreesContinuesAfterTaskFailure; arrange one failing task followed by one already-final removable task, then assert the later worktree is cleaned and the returned error names the failing task.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go test ./internal/daemon -run 'TestCleanupWorktrees' -count=1`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool <each schema/plugin/marketplace json>`: passed
- `GOOS=windows GOARCH=amd64 go build ./internal/daemon ./internal/workspace`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` What is the cleanup lifecycle boundary? -> Treat persisted final PR states (`merged` and `closed`) as sufficient to skip PR state refresh when the managed worktree is already absent, and as sufficient to remove a still-present managed worktree.
  - Rationale: Cleanup should not make already-final historical task records depend on GitHub API availability when no PR lifecycle decision remains. Live PR state is still required for `open` tasks because the PR may have closed or merged after Galley last persisted the task.
  - Reversibility: high
- `D2` Should missing or stale GitHub PR lookups be hidden as a no-PR case? -> No. Do not rely on swallowing 404s as the primary fix; reduce unnecessary lookups through target selection and keep actionable lookup failures visible with task context.
  - Rationale: The product issue is recurring maintenance failure from querying tasks that do not need remote state. Actionable open-PR cleanup still needs visible errors so operators and agents can identify the task and repair credentials, URL, or external state.
  - Reversibility: high
- `D3` How should sensitive operational evidence be represented? -> Use synthetic tasks, fake `gh`, and local worktrees in tests; do not encode real operator repository names, PR numbers, task ids, or worktree paths from the observed environment.
  - Rationale: The observed failure happened in a real product environment, but the Galley regression is generic and can be proven without leaking customer or product details.
  - Reversibility: high
- `claude-decision-4` How should the AC5/AC6 actionable cleanup failure be triggered deterministically in tests without the slow FetchPRState retry backoff? -> Point the failing task's worktree.path at the source repo so workspace.Remove's validateCleanupPath refuses removal immediately, and keep the failing task persisted-final so no gh retry occurs.
  - Rationale: Produces a fast, deterministic actionable error through a real cleanup refusal path while keeping tests generic and synthetic (D3/R3).
  - Reversibility: high
- `claude-decision-5` Should the persisted-final branch keep appending a cleanup attempt when removing a present worktree (AC2)? -> Yes, append the cleanup attempt as the existing live-state removal path does; the already-absent branch keeps the original no-attempt save.
  - Rationale: Preserves existing observable task-record behavior for worktree removals and matches the prior code path shape.
  - Reversibility: high

## Risks

- `R1` regression: Skipping PR state refresh for the wrong tasks could remove a worktree for an actually open PR.
  - Mitigation: Gate the no-GitHub path only on persisted final `pr.status` values and keep explicit tests proving `pr.status: open` still calls `gh api` and preserves open PR worktrees.
- `R2` evidence_visibility: Existing cleanup errors lack task context, so a future failure can be hard to diagnose from daemon logs.
  - Mitigation: Wrap per-task errors with task id or path and PR URL or resolved worktree path; add tests that assert the context appears in returned errors.
- `R3` privacy: The motivating incident came from a real product environment.
  - Mitigation: Keep tests and documentation generic, with synthetic task names and PR URLs only.
