### PR TITLE
Prepare v0.8.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.8.2 - 2026-06-27
+
 ### Changed
 
 - Restored Claude as the unset default backend for both the implementation executor and the daemon supervisor. New task skeletons emit `executor.cli: claude` when neither `--executor-cli` nor `environment.yaml` `executor.default_cli` is set, and the daemon resolves the built-in supervisor default to `claude` when `--supervisor`, `daemon.yaml`, and repository `supervisor.default_cli` are all unset. Explicit `--executor-cli codex`, `executor.default_cli: codex`, `--supervisor codex`, and existing Codex task examples remain fully supported; schemas still accept both `claude` and `codex`.


### PR DESCRIPTION
## Summary
- Add the v0.8.2 changelog heading for the current unreleased changes

## Validation
- git diff --check