### PR TITLE
Prevent Galley review staging and accepted-change finalization from failing when an executor has already staged a file deletion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Fixed
+
+- Galley review staging and accepted-change finalization no longer fail when an executor has already staged a file deletion. A staged-only deletion (git status `D `) exists in neither the worktree nor the index, so passing it to `git add` failed with "pathspec did not match any files"; Galley now skips already-staged deletions when building `git add` pathspec lists while keeping them visible in the captured attempt diff and present in the final commit. Unstaged deletions are still staged for review, and the commit:false input exclusion and forbidden-path gate behavior are unchanged.
+
 ## v0.8.2 - 2026-06-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows semantic versioning.
 
 ### Fixed
 
-- Galley review staging and accepted-change finalization no longer fail when an executor has already staged a file deletion. A staged-only deletion (git status `D `) exists in neither the worktree nor the index, so passing it to `git add` failed with "pathspec did not match any files"; Galley now skips already-staged deletions when building `git add` pathspec lists while keeping them visible in the captured attempt diff and present in the final commit. Unstaged deletions are still staged for review, and the commit:false input exclusion and forbidden-path gate behavior are unchanged.
+- Fixed Galley review staging and accepted-task finalization failing when an executor had already staged a file deletion. Staged deletions are now preserved in review evidence and final commits without being re-added.
 
 ## v0.8.2 - 2026-06-27
 

--- a/internal/daemon/finalize_add_paths_test.go
+++ b/internal/daemon/finalize_add_paths_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAddEligiblePorcelainPathsDropsStagedOnlyDeletion pins AC3 at the parsing
+// boundary: the finalization git-add path list must exclude staged-only
+// deletions (porcelain "D ") while keeping every other change kind, including
+// unstaged deletions (" D"), staged adds ("A "), staged modifications ("M "),
+// and renames. Re-adding an already-staged deletion would fail with a pathspec
+// error; the deletion is already in the index, so it still reaches the commit.
+func TestAddEligiblePorcelainPathsDropsStagedOnlyDeletion(t *testing.T) {
+	porcelain := "D  src/staged-deleted.go\n" +
+		" D src/unstaged-deleted.go\n" +
+		"A  src/added.go\n" +
+		"M  src/modified.go\n" +
+		"R  src/old.go -> src/new.go\n"
+
+	got := addEligiblePorcelainPaths(porcelain)
+	want := []string{
+		"src/unstaged-deleted.go",
+		"src/added.go",
+		"src/modified.go",
+		"src/new.go",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("addEligiblePorcelainPaths = %v, want %v", got, want)
+	}
+}
+
+// TestAddEligiblePorcelainPathsEmptyWhenOnlyStagedDeletions pins the
+// empty-list boundary: when every reported change is a staged-only deletion,
+// the add list is empty. finalizeAcceptedChange relies on this so it can skip
+// `git add` (which errors on an empty pathspec list) and commit the
+// already-staged deletion directly.
+func TestAddEligiblePorcelainPathsEmptyWhenOnlyStagedDeletions(t *testing.T) {
+	porcelain := "D  a.txt\nD  b.txt\n"
+	if got := addEligiblePorcelainPaths(porcelain); len(got) != 0 {
+		t.Fatalf("addEligiblePorcelainPaths = %v, want empty", got)
+	}
+}
+
+// TestParsePorcelainPathsStillReportsStagedDeletion pins AC4: the
+// change-visibility parser used by progress detection, the finalize-time
+// forbidden_paths gate, and scope-expansion reporting must keep reporting
+// staged-only deletions. The fix only changes which paths reach git add, not
+// which paths are considered changed/reviewable, so forbidden-path deletions
+// stay visible to the safety gate.
+func TestParsePorcelainPathsStillReportsStagedDeletion(t *testing.T) {
+	porcelain := "D  secret/leak.txt\nA  src/added.go\n"
+	got := parsePorcelainPaths(porcelain)
+	want := []string{"secret/leak.txt", "src/added.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parsePorcelainPaths = %v, want %v (staged deletion must remain visible)", got, want)
+	}
+}

--- a/internal/daemon/path_set.go
+++ b/internal/daemon/path_set.go
@@ -37,13 +37,9 @@ import (
 // drive-letter paths, and any segment that backs out of cwd so the
 // review-staging set cannot widen beyond the executor's working
 // directory regardless of how git status formatted the entry);
-// - staged-only deletions (index status 'D', clean worktree status):
-// the file no longer exists in the worktree or the index, so passing it
-// to `git add` fails with "pathspec did not match any files". The
-// deletion is already staged, so it stays in the captured attempt diff
-// (git diff --cached) without being re-added. Unstaged deletions are
-// intentionally kept so review staging still stages them and the deleted
-// file appears in the submitted diff;
+// - staged-only deletions, which are already visible in the staged diff and
+// would fail if re-added. Unstaged deletions are intentionally kept so review
+// staging still stages them;
 // - destinations in excludeDestinations — these are task.files entries
 // declared with commit:false, which Galley materializes as context-only
 // inputs the executor reads but does not submit.
@@ -57,9 +53,8 @@ func reviewablePathsFromStatus(statusZ string, excludeDestinations []string) []s
 	seen := make(map[string]bool, len(raw))
 	var result []string
 	for _, entry := range raw {
-		// Staged-only deletions are already submitted work; sending the
-		// deleted path to git add fails with a pathspec error. Skip it from
-		// the staging set; the staged deletion remains in the captured diff.
+		// Already-staged deletions remain visible in the staged diff and do
+		// not need another git add.
 		if isStagedOnlyDeletion(entry.X, entry.Y) {
 			continue
 		}
@@ -154,16 +149,9 @@ func isRenameOrCopyStatus(c byte) bool {
 	return c == 'R' || c == 'C'
 }
 
-// isStagedOnlyDeletion reports whether a `git status` porcelain XY pair
-// describes a deletion that is already fully staged: index status 'D' with a
-// clean (space) worktree status. Such a path exists in neither the worktree
-// nor the index, so passing it to `git add` fails with "pathspec did not
-// match any files". The staged deletion is already part of the index and the
-// captured diff, so Galley skips it when building a `git add` pathspec list
-// while still leaving it visible to reviewers and present in the final
-// commit. An unstaged deletion (worktree status 'D', e.g. " D") is
-// intentionally NOT matched: git add must still stage it so the deletion
-// appears in the submitted diff.
+// isStagedOnlyDeletion reports a deletion that is already fully staged
+// (`D `). Unstaged deletions (` D`) are not matched because git add still
+// needs to stage them.
 func isStagedOnlyDeletion(x, y byte) bool {
 	return x == 'D' && y == ' '
 }

--- a/internal/daemon/path_set.go
+++ b/internal/daemon/path_set.go
@@ -37,6 +37,13 @@ import (
 // drive-letter paths, and any segment that backs out of cwd so the
 // review-staging set cannot widen beyond the executor's working
 // directory regardless of how git status formatted the entry);
+// - staged-only deletions (index status 'D', clean worktree status):
+// the file no longer exists in the worktree or the index, so passing it
+// to `git add` fails with "pathspec did not match any files". The
+// deletion is already staged, so it stays in the captured attempt diff
+// (git diff --cached) without being re-added. Unstaged deletions are
+// intentionally kept so review staging still stages them and the deleted
+// file appears in the submitted diff;
 // - destinations in excludeDestinations — these are task.files entries
 // declared with commit:false, which Galley materializes as context-only
 // inputs the executor reads but does not submit.
@@ -49,8 +56,14 @@ func reviewablePathsFromStatus(statusZ string, excludeDestinations []string) []s
 	raw := parseStatusPorcelainZ(statusZ)
 	seen := make(map[string]bool, len(raw))
 	var result []string
-	for _, p := range raw {
-		clean := normalizeReviewablePath(p)
+	for _, entry := range raw {
+		// Staged-only deletions are already submitted work; sending the
+		// deleted path to git add fails with a pathspec error. Skip it from
+		// the staging set; the staged deletion remains in the captured diff.
+		if isStagedOnlyDeletion(entry.X, entry.Y) {
+			continue
+		}
+		clean := normalizeReviewablePath(entry.Path)
 		if clean == "" {
 			continue
 		}
@@ -74,25 +87,36 @@ func reviewablePathsFromStatus(statusZ string, excludeDestinations []string) []s
 	return result
 }
 
+// statusEntry is one parsed `git status --porcelain=v1` change: the two
+// status bytes (X is the index/staged status, Y is the worktree status) and
+// the reviewable path (the new path for renames/copies, the only path
+// otherwise). Retaining X and Y lets the path-set builder distinguish a
+// staged-only deletion from an unstaged deletion without re-parsing.
+type statusEntry struct {
+	X, Y byte
+	Path string
+}
+
 // parseStatusPorcelainZ parses NUL-separated `git status --porcelain=v1 -z`
-// output into the ordered list of paths the executor changed. Each entry has
+// output into the ordered list of changes the executor made. Each entry has
 // the byte layout "XY<sp>path<NUL>" for regular changes; rename/copy entries
 // (X or Y in {R,C}) append a second "<sp>oldpath<NUL>" token after the new
 // path. The parser yields only the new path so the staged review set tracks
-// the post-rename surface git presents to a reviewer.
+// the post-rename surface git presents to a reviewer, and preserves the X/Y
+// status bytes so callers can tell staged-only deletions apart.
 //
 // Malformed tails (a header without its NUL-terminated path) cause the
 // parser to stop where it can no longer be sure of the next path boundary;
 // returning a partial path would risk staging unrelated content.
-func parseStatusPorcelainZ(s string) []string {
-	var paths []string
+func parseStatusPorcelainZ(s string) []statusEntry {
+	var entries []statusEntry
 	rest := s
 	for len(rest) > 0 {
 		// Each entry begins with two status bytes and a separator before the
 		// path. Anything shorter is a malformed tail; stop instead of
 		// returning a partial path.
 		if len(rest) < 4 {
-			return paths
+			return entries
 		}
 		x := rest[0]
 		y := rest[1]
@@ -102,7 +126,7 @@ func parseStatusPorcelainZ(s string) []string {
 		rest = rest[3:]
 		idx := strings.IndexByte(rest, 0)
 		if idx < 0 {
-			return paths
+			return entries
 		}
 		path := rest[:idx]
 		rest = rest[idx+1:]
@@ -113,21 +137,35 @@ func parseStatusPorcelainZ(s string) []string {
 			idx2 := strings.IndexByte(rest, 0)
 			if idx2 < 0 {
 				if path != "" {
-					paths = append(paths, path)
+					entries = append(entries, statusEntry{X: x, Y: y, Path: path})
 				}
-				return paths
+				return entries
 			}
 			rest = rest[idx2+1:]
 		}
 		if path != "" {
-			paths = append(paths, path)
+			entries = append(entries, statusEntry{X: x, Y: y, Path: path})
 		}
 	}
-	return paths
+	return entries
 }
 
 func isRenameOrCopyStatus(c byte) bool {
 	return c == 'R' || c == 'C'
+}
+
+// isStagedOnlyDeletion reports whether a `git status` porcelain XY pair
+// describes a deletion that is already fully staged: index status 'D' with a
+// clean (space) worktree status. Such a path exists in neither the worktree
+// nor the index, so passing it to `git add` fails with "pathspec did not
+// match any files". The staged deletion is already part of the index and the
+// captured diff, so Galley skips it when building a `git add` pathspec list
+// while still leaving it visible to reviewers and present in the final
+// commit. An unstaged deletion (worktree status 'D', e.g. " D") is
+// intentionally NOT matched: git add must still stage it so the deletion
+// appears in the submitted diff.
+func isStagedOnlyDeletion(x, y byte) bool {
+	return x == 'D' && y == ' '
 }
 
 // normalizedPathSet returns the set of worktree-relative paths in `paths`,

--- a/internal/daemon/path_set_test.go
+++ b/internal/daemon/path_set_test.go
@@ -41,6 +41,41 @@ func TestReviewablePathsFromStatusKeepsModifiedAddedDeletedAndUntracked(t *testi
 	}
 }
 
+// TestReviewablePathsFromStatusSkipsStagedOnlyDeletion pins AC1: a staged-only
+// deletion (index status 'D', clean worktree status — porcelain "D ") must not
+// enter the reviewable path set, because `git add` on a path that exists in
+// neither the worktree nor the index fails with "pathspec did not match any
+// files". The deletion is already staged, so it stays visible in the captured
+// diff without being re-added. Other change kinds in the same status output
+// are still staged.
+func TestReviewablePathsFromStatusSkipsStagedOnlyDeletion(t *testing.T) {
+	statusZ := porcelainEntry("D ", "src/staged-deleted.go") +
+		porcelainEntry("A ", "src/added.go") +
+		porcelainEntry(" M", "src/touched.go")
+
+	got := reviewablePathsFromStatus(statusZ, nil)
+	want := []string{"src/added.go", "src/touched.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reviewablePathsFromStatus = %v, want %v (staged-only deletion must be skipped)", got, want)
+	}
+}
+
+// TestReviewablePathsFromStatusKeepsUnstagedDeletion pins AC2: an unstaged
+// deletion (worktree status 'D' with a clean index — porcelain " D") must
+// remain in the reviewable set so review staging stages the deletion and the
+// deleted file appears in the submitted diff. Only the staged-only deletion in
+// the same output is dropped; the unstaged deletion is preserved.
+func TestReviewablePathsFromStatusKeepsUnstagedDeletion(t *testing.T) {
+	statusZ := porcelainEntry(" D", "src/unstaged-deleted.go") +
+		porcelainEntry("D ", "src/staged-deleted.go")
+
+	got := reviewablePathsFromStatus(statusZ, nil)
+	want := []string{"src/unstaged-deleted.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reviewablePathsFromStatus = %v, want %v (unstaged deletion must be kept, staged-only deletion dropped)", got, want)
+	}
+}
+
 // TestReviewablePathsFromStatusDedupesAndDropsEmpty pins the dedupe and
 // trimming behavior. Repeated porcelain entries for the same logical path
 // (which can arise when git reports rename source/destination separately

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -52,11 +52,8 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	}
 	if snapshot.StatusPorcelain != "" {
 		commitMessage := fmt.Sprintf("galley: %s", strutil.FirstNonEmpty(loaded.ID, "accepted task"))
-		// Only pass add-eligible paths to git add. Staged-only deletions are
-		// already in the index, so re-adding them would fail with a pathspec
-		// error; they still reach the commit because they remain staged. When
-		// every change is a staged-only deletion the add list is empty, so
-		// skip git add entirely and commit the already-staged diff.
+		// Skip git add when only already-staged deletions remain; they are
+		// still committed from the index.
 		if addPaths := addEligiblePorcelainPaths(snapshot.StatusPorcelain); len(addPaths) > 0 {
 			if err := vcs.AddPaths(ctx, vcsBinaries(opts), workDir, runDir, addPaths); err != nil {
 				return err

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -52,8 +52,15 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	}
 	if snapshot.StatusPorcelain != "" {
 		commitMessage := fmt.Sprintf("galley: %s", strutil.FirstNonEmpty(loaded.ID, "accepted task"))
-		if err := vcs.AddPaths(ctx, vcsBinaries(opts), workDir, runDir, parsePorcelainPaths(snapshot.StatusPorcelain)); err != nil {
-			return err
+		// Only pass add-eligible paths to git add. Staged-only deletions are
+		// already in the index, so re-adding them would fail with a pathspec
+		// error; they still reach the commit because they remain staged. When
+		// every change is a staged-only deletion the add list is empty, so
+		// skip git add entirely and commit the already-staged diff.
+		if addPaths := addEligiblePorcelainPaths(snapshot.StatusPorcelain); len(addPaths) > 0 {
+			if err := vcs.AddPaths(ctx, vcsBinaries(opts), workDir, runDir, addPaths); err != nil {
+				return err
+			}
 		}
 		if err := vcs.Commit(ctx, vcsBinaries(opts), workDir, runDir, commitMessage); err != nil {
 			return err

--- a/internal/daemon/progress_baseline.go
+++ b/internal/daemon/progress_baseline.go
@@ -121,15 +121,9 @@ func parsePorcelainPaths(porcelain string) []string {
 	return paths
 }
 
-// addEligiblePorcelainPaths parses `git status --porcelain` text output (no
-// -z) and returns the changed paths that finalization should pass to
-// `git add`. It mirrors parsePorcelainPaths but drops staged-only deletions
-// (index status 'D', clean worktree status): such a path exists in neither the
-// worktree nor the index, so `git add <path>` would fail with "pathspec did
-// not match any files". The deletion is already staged, so it stays in the
-// committed diff without being re-added. Every other change kind — including
-// unstaged deletions, which git add must still stage — is returned so the
-// accepted staged diff is committed in full.
+// addEligiblePorcelainPaths returns the changed paths finalization should pass
+// to `git add`, excluding staged-only deletions that are already in the index.
+// Unstaged deletions stay eligible so finalization still stages them.
 func addEligiblePorcelainPaths(porcelain string) []string {
 	if porcelain == "" {
 		return nil

--- a/internal/daemon/progress_baseline.go
+++ b/internal/daemon/progress_baseline.go
@@ -89,6 +89,12 @@ func changedFilesFromSnapshot(snapshot workspace.Snapshot) map[string]struct{} {
 // parsePorcelainPaths parses `git status --porcelain` text output (no -z) and
 // returns the list of paths it reports as changed. Renames are encoded
 // as "old -> new"; only the new path is returned.
+//
+// This is the change-visibility parser: it is consumed by progress detection,
+// the finalize-time forbidden_paths gate, and scope-expansion reporting, so
+// it must keep reporting every changed path (including staged-only deletions).
+// Finalization uses addEligiblePorcelainPaths instead when it needs the subset
+// safe to pass to git add.
 func parsePorcelainPaths(porcelain string) []string {
 	if porcelain == "" {
 		return nil
@@ -97,6 +103,44 @@ func parsePorcelainPaths(porcelain string) []string {
 	for _, raw := range strings.Split(porcelain, "\n") {
 		line := strings.TrimRight(raw, "\r")
 		if len(line) < 4 {
+			continue
+		}
+		// Porcelain format: XY<space>path[ -> renamed]
+		body := line[3:]
+		if idx := strings.Index(body, " -> "); idx >= 0 {
+			body = body[idx+4:]
+		}
+		body = strings.TrimSpace(body)
+		// Quoted paths may appear when filenames contain unusual characters.
+		body = strings.Trim(body, `"`)
+		if body == "" {
+			continue
+		}
+		paths = append(paths, body)
+	}
+	return paths
+}
+
+// addEligiblePorcelainPaths parses `git status --porcelain` text output (no
+// -z) and returns the changed paths that finalization should pass to
+// `git add`. It mirrors parsePorcelainPaths but drops staged-only deletions
+// (index status 'D', clean worktree status): such a path exists in neither the
+// worktree nor the index, so `git add <path>` would fail with "pathspec did
+// not match any files". The deletion is already staged, so it stays in the
+// committed diff without being re-added. Every other change kind — including
+// unstaged deletions, which git add must still stage — is returned so the
+// accepted staged diff is committed in full.
+func addEligiblePorcelainPaths(porcelain string) []string {
+	if porcelain == "" {
+		return nil
+	}
+	var paths []string
+	for _, raw := range strings.Split(porcelain, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if len(line) < 4 {
+			continue
+		}
+		if isStagedOnlyDeletion(line[0], line[1]) {
 			continue
 		}
 		// Porcelain format: XY<space>path[ -> renamed]

--- a/internal/daemon/review_staging_test.go
+++ b/internal/daemon/review_staging_test.go
@@ -111,6 +111,74 @@ func TestRunOnceAcceptedFinalizationCommitsStagedNewFile(t *testing.T) {
 	}
 }
 
+// TestRunOnceAcceptedFinalizationCommitsStagedOnlyDeletion pins AC1+AC3 for a
+// staged-only deletion. The fake executor stages the deletion of a tracked
+// file with `git rm` and submits no other change. Before the fix, review
+// staging ran `git add -A -- <deleted path>` and failed with "pathspec did not
+// match any files", so the attempt never reached the supervisor. After the
+// fix, review staging skips the already-staged deletion (it stays visible in
+// the captured attempt diff), the supervisor accepts the dirty diff, and
+// finalization commits the deletion without re-adding it.
+func TestRunOnceAcceptedFinalizationCommitsStagedOnlyDeletion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runDaemonGit(t, t.TempDir(), "init", "--bare", remote)
+	runDaemonGit(t, repo, "remote", "add", "origin", remote)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	// Executor stages a deletion of the tracked README.md and nothing else.
+	// `git rm` removes it from both the worktree and the index, producing a
+	// "D " staged-only deletion in git status.
+	claudeBin := writeFakeClaude(t, "git rm README.md\necho '{\"status\":\"completed\",\"summary\":\"done\",\"files_modified\":[\"README.md\"],\"acceptance_criteria\":[{\"id\":\"AC1\",\"status\":\"satisfied\",\"evidence\":[\"diff\"],\"notes\":\"done\"}],\"verification\":[],\"decisions\":[],\"risks\":[]}'\n")
+	ghBin := writeFakeCommand(t, "gh", "echo https://github.com/example/galley/pull/999\n")
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+
+	if err := Run(context.Background(), Options{
+		Root:               root,
+		SystemPromptFile:   promptPath,
+		JSONSchemaFile:     schemaPath,
+		Supervisor:         "claude",
+		ClaudeBin:          claudeBin,
+		Once:               true,
+		MaxConcurrentTasks: 1,
+		OpenPR:             true,
+		PRBase:             "main",
+		GHBin:              ghBin,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// AC1: the staged deletion must remain visible in the captured attempt
+	// diff even though review staging did not re-add it.
+	diff := string(mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", "diff.patch")))
+	if !strings.Contains(diff, "README.md") || !strings.Contains(diff, "deleted file mode") {
+		t.Fatalf("attempt diff.patch missing staged deletion of README.md:\n%s", diff)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" {
+		t.Fatalf("status got %q want pr_opened", doneTask.Status)
+	}
+	worktreePath := taskWorktreePath(repo, doneTask.Worktree.Path)
+	// AC3: the final commit must record the deletion and HEAD must no longer
+	// contain README.md.
+	nameStatus := string(mustCommandOutput(t, "git", "-C", worktreePath, "show", "--name-status", "--format=", "HEAD"))
+	if !strings.Contains(nameStatus, "D\tREADME.md") {
+		t.Fatalf("final commit does not record README.md deletion:\n%s", nameStatus)
+	}
+	tree := string(mustCommandOutput(t, "git", "-C", worktreePath, "ls-tree", "-r", "--name-only", "HEAD"))
+	if strings.Contains(tree, "README.md") {
+		t.Fatalf("README.md still present in HEAD tree after staged deletion was finalized:\n%s", tree)
+	}
+}
+
 // TestRunOnceAcceptedFinalizationExcludesNonCommittedInputFile pins AC4:
 // review-time staging must not cause a commit:false input file to be
 // committed. After the executor (without running `git add`) introduces a


### PR DESCRIPTION
## Goal

Prevent Galley review staging and accepted-change finalization from failing when an executor has already staged a file deletion.

## Acceptance Criteria

- `AC1` When git status reports a staged-only deletion, Galley shall not pass that deleted path to git add during review staging, and the staged deletion shall remain visible in the captured attempt diff.
  - Verification: Focused daemon/path-set test; claim: staged-only deletions are already submitted work and do not need another git add; primary failure mode: git add receives a deleted path and fails with pathspec did not match any files; boundary: git status porcelain -> review staging -> attempt diff capture; state: deletion is staged before review staging -> staging runs -> attempt diff still contains the deletion and no pathspec failure occurs; residual: none.
  - Status: satisfied
- `AC2` When git status reports an unstaged deletion, Galley shall still stage that deletion before supervisor review so the deleted file appears in the submitted diff.
  - Verification: Focused daemon/path-set test; claim: unstaged deletions remain reviewable; primary failure mode: avoiding deleted paths hides an unstaged deletion from supervisor evidence; boundary: git status porcelain -> review staging -> attempt diff capture; state: deletion is unstaged before review staging -> staging runs -> submitted diff contains the deletion; residual: none.
  - Status: satisfied
- `AC3` When an accepted task reaches finalization with staged-only added, modified, or deleted paths, Galley shall not re-add those staged-only paths and shall still commit the accepted staged diff.
  - Verification: Focused finalization test; claim: accepted staged-only changes are committed without redundant git add pathspecs; primary failure mode: finalization fails on an already staged deletion or drops accepted staged work; boundary: accepted task finalization -> git add/commit; state: accepted diff contains staged-only deletion -> finalization runs -> commit succeeds and contains the deletion; residual: none.
  - Status: satisfied
- `AC4` The existing commit:false input exclusion and forbidden-path visibility behavior shall remain unchanged.
  - Verification: Existing review staging tests plus any focused regression test needed; claim: the fix only changes which paths are sent to git add, not which paths are considered reviewable or safety-gated; primary failure mode: context-only inputs leak into submitted diffs or forbidden-path changes become hidden; boundary: task input files -> review staging path filtering -> finalization gates; state: commit:false and forbidden-path fixtures run -> existing expectations remain true; residual: none.
  - Status: satisfied
- `AC5` The change shall stay minimal and reuse the existing review-staging/status parsing shape instead of introducing new task YAML fields, profile settings, or user-facing options.
  - Verification: Code review plus tests; claim: this is a lifecycle bug fix, not a new user-configurable feature; primary failure mode: added configuration or broader refactor increases AFK complexity; boundary: public CLI/task/profile/docs surfaces; state: implementation complete -> public contracts inspected -> no new knobs or contract changes except a changelog note if treated as user-visible reliability behavior; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool schemas/claude-result.schema.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Risks

- `R1` regression: The same git status entry can represent staged-only work, unstaged work, or mixed staged and unstaged work; an overly broad filter could hide changes from supervisor evidence or final commits.
  - Mitigation: Add focused tests for staged-only deletion, unstaged deletion, and accepted finalization with staged-only deletion, and keep existing commit:false and forbidden-path tests passing.
