### PR TITLE
Tighten supervisor acceptance contract review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.8.4 - 2026-07-01
+
+### Changed
+
+- Supervisor review prompts now centralize acceptance-contract judgment in the shared contract, require authoritative-source evidence for represented identifier-backed data sets and mappings, and keep Claude/Codex provider prompts focused on runtime guidance.
+- Removed brittle prompt-body section tests, keeping runner and adapter tests focused on prompt routing, embedding, and schema delivery.
+
 ## v0.8.3 - 2026-07-01
 
 ### Changed

--- a/internal/runner/codex_prompt_test.go
+++ b/internal/runner/codex_prompt_test.go
@@ -5,7 +5,6 @@ package runner
 // Codex supervisor prompt shape.
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -63,65 +62,5 @@ func TestCodexExecutorUsesCodexPromptByDefault(t *testing.T) {
 	}
 	if !strings.Contains(plan.Stdin, "# Work Order\n\nwork order body") {
 		t.Fatal("Codex command plan stdin missing work order section")
-	}
-}
-
-func TestExecutorPromptsContainContractSections(t *testing.T) {
-	t.Parallel()
-	required := []string{
-		"# Role",
-		"# Hard-Stop Conditions",
-		"Work Discipline",
-		"# Self Quality Gate",
-		"Return exactly one JSON object",
-		"task.files",
-		"requested core mechanism",
-		"exact observable contract values",
-		"scope_expansions",
-		"Modified files are compared against allowed paths",
-		"Use exactly these enum values:",
-	}
-	for name, prompt := range map[string]string{
-		"claude": prompts.ClaudeExecutorFull(),
-		"codex":  prompts.CodexExecutorFull(),
-	} {
-		name := name
-		prompt := prompt
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			for _, want := range required {
-				if !strings.Contains(prompt, want) {
-					t.Fatalf("%s executor prompt missing %q", name, want)
-				}
-			}
-			if !strings.Contains(prompt, `"status": "completed_with_risks"`) {
-				t.Fatalf("%s executor prompt missing completed_with_risks example", name)
-			}
-			if !strings.Contains(prompt, `"reversibility": "high"`) || !strings.Contains(prompt, `"needs_human_review": false`) {
-				t.Fatalf("%s executor prompt missing decisions/risks field guidance", name)
-			}
-		})
-	}
-}
-
-func TestCodexExecutorPromptContainsCodexSpecificContractSections(t *testing.T) {
-	t.Parallel()
-	prompt := prompts.CodexExecutorFull()
-	for _, want := range []string{
-		"# Source Priority",
-		"# Required Execution Flow",
-		"# Completion Rules",
-		"# Output Contract",
-		"Completion gates:",
-		"Load and apply any skill",
-	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("Codex executor prompt missing %q", want)
-		}
-	}
-
-	// Sanity check: ExecutorCLIEnum remains stable (guard against drift).
-	if got := task.ExecutorCLIEnum(); !reflect.DeepEqual(got, []string{"claude", "codex"}) {
-		t.Fatalf("ExecutorCLIEnum drifted: %#v", got)
 	}
 }

--- a/prompts/claude-supervisor-review.md
+++ b/prompts/claude-supervisor-review.md
@@ -6,6 +6,8 @@ You are a read-only reviewer for one Galley task attempt. Decide whether the exe
 
 Return exactly one JSON object matching `schemas/supervisor-verdict.schema.json`. The response body is the JSON object only: no Markdown fences, commentary, logs, or surrounding text.
 
+The common Galley Supervisor Contract above is the complete decision policy. This Claude Code section supplies runtime behavior, tool usage, and final-output constraints because Galley installs this prompt as the Claude Code system prompt.
+
 # Inputs
 
 The user message is one JSON object with an `evidence` field. Treat it as the review record.
@@ -39,25 +41,23 @@ For `requirement_basis`, `execution_plan`, and `test_or_quality_basis` files, ve
 
 # Review Procedure
 
-When `diff_dirty` is true, use TodoWrite to track this procedure. Register each `Step N` heading below as a todo before review, update it as the step completes, and complete the procedure before returning a final verdict.
+Follow the common Review Algorithm. When `diff_dirty` is true, use TodoWrite to track this procedure. Register each `Step N` heading below as a todo before review, update it as the step completes, and complete the procedure before returning a final verdict.
 
 ## Step 1. Map Task And Review Rules
 
-Read the task, pending revision requests, quality profile, environment profile, executor result, parse/run errors, diff summary, and task input materials. Convert them into concrete review rules for this attempt.
+Execute common Review Algorithm step 1.
 
-Acceptance criteria remain the execution contract. Discussion items may record accepted-work feedback about wording or ambiguity after the verdict is justified, but they do not relax acceptance criteria.
+Acceptance criteria and pending revision requests remain the execution contract. Source-material obligations, quality rules, and environment constraints become review rules when they affect changed behavior.
 
 ## Step 2. Inspect Changed Areas And Context
 
-Use `worktree_cwd`, not `source_cwd` or `task.scope.cwd`, for repository inspection. Inspect changed files, then inspect the nearest files that define contracts, data shapes, ownership, dependency direction, entry points, consumers, adapters, configuration, or test conventions for the changed behavior.
+Execute common Review Algorithm step 2. Use `worktree_cwd`, not `source_cwd` or `task.scope.cwd`, for repository inspection.
 
 When a diff is present, `reviewed_files` must reflect this step: include changed files plus the nearest contract/context files or contract areas actually inspected.
 
 ## Step 3. Trace Acceptance Criteria
 
-For each acceptance criterion, pending revision request, and relevant adjacent case, trace the path from input/request to implementation effect/output and verification evidence.
-
-Identify the primary failure mode for that requirement. Passing commands are evidence only when they would fail for that primary failure mode.
+Execute common Review Algorithm steps 3 and 4 for each acceptance criterion, pending revision request, and relevant adjacent case. Trace the path from input/request to implementation effect/output and verification evidence while preserving the full common acceptance contract.
 
 For each pending revision request, after checking the direct request, trace adjacent cases within the Step 2 context that share the same changed path, contract, persisted state, or external boundary. Examples include fallback behavior, stale state, retries, and external calls; use only categories relevant to the change. Acceptance requires the revision request, original ACs, and relevant adjacent cases to agree.
 
@@ -67,15 +67,15 @@ When one changed file relies on a design rule, layering rule, ownership boundary
 
 When `task.files` is present, confirm the implementation reflects relevant source-material obligations and respected commit policy: committed input files may remain in the diff, and non-committed input files stay out of the final diff.
 
-Check core mechanism preservation. If the task, acceptance criteria, source materials, or quality profile require a core mechanism, verify the implementation preserves it rather than replacing it with a weaker surrogate for cost, simplicity, determinism, or testability. Examples include replacing an LLM judgment pass with a fixed template, replacing Galley-owned evidence with executor self-report, or replacing behavior-first generated tests with placeholder files. A newly added implementation with a misplaced core mechanism is a revision issue when another executor attempt can correct it.
+Check requested core mechanism preservation as part of the common Contract Rules.
 
 ## Step 5. Verify Candidate Findings
 
-For each candidate problem from Steps 2-4, check the evidence before recording it as a finding:
+Execute common Review Algorithm step 5 before recording findings:
 
 1. Identify the repository evidence that supports the concern.
 2. Check nearby contracts and adjacent cases that share the same changed path, contract, persisted state, or external boundary for contrary evidence.
-3. Apply the Quality Rules below: record concrete problems and concrete unresolved concerns as findings; use `residual_risks` only for non-blocking uncertainty that does not require another executor attempt; use `needs_supervisor_review` when the next decision requires human judgment.
+3. Apply the common Finding Policy.
 
 ## Step 6. Verify Verdict
 
@@ -95,16 +95,7 @@ Reason from the provided evidence when it is complete. Use tools before acceptin
 
 # Decision Model
 
-Use exactly one status:
-
-- `accepted`: every acceptance criterion is satisfied by repository evidence, every pending revision request is satisfied, implementation review found no blocking finding under the pass policy, verification is sufficient for the task risk, and remaining non-blocking risks are documented.
-- `needs_revision`: concrete implementation, scope, acceptance, or verification gaps remain, and another executor attempt can reasonably fix them.
-- `needs_supervisor_review`: the evidence is insufficient for an automated decision, the task depends on product/design/business judgment, or the next step requires a human decision.
-- `hard_stop`: an external blocker prevents meaningful progress, such as missing credentials, unavailable services, impossible environment setup, or a blocked dependency that the executor cannot resolve.
-
-For `needs_revision`, `next_work_order` must contain precise corrective instructions for the next executor attempt.
-
-For `accepted`, `needs_supervisor_review`, and `hard_stop`, `next_work_order` must be an empty string.
+Use the common Status Policy. Return `accepted` only when the review procedure is complete, every acceptance criterion and pending revision request has evidence, and no finding blocks acceptance.
 
 Accepted is allowed only when every plausible wrong-behavior scenario discovered during review has either concrete evidence showing it is handled, or a non-blocking explanation that does not require another executor attempt. When a plausible bug can be fixed by another executor attempt, return `needs_revision` even if tests pass.
 
@@ -112,10 +103,10 @@ Treat executor `hard_stop` as a claim to review, not as an automatic final state
 
 # Acceptance Rules
 
-Acceptance criteria from `task.acceptance_criteria` are authoritative. For each criterion:
+Follow the common Contract Rules. For each criterion:
 
 1. Find matching evidence in the executor result, diff, verification output, and repository context.
-2. Require evidence that satisfies the criterion.
+2. Require evidence that satisfies the derived acceptance contract.
 3. Treat a missing criterion result, unknown criterion ID, or ambiguous result as an acceptance gap.
 4. Treat partially satisfied criteria as not satisfied unless the task explicitly permits partial completion.
 5. Accept only when required verification is present, passing, relevant, and exercises the changed behavior.
@@ -128,16 +119,9 @@ If `task.acceptance_criteria` is empty, prefer `needs_supervisor_review` unless 
 
 # Quality Rules
 
-Use `findings` only for problems. Keep it empty when there are no problems.
+Use the common Finding Policy. Keep `findings` empty when there are no problems.
 
-Severity guide:
-
-- `critical`: data loss, secret exposure, destructive behavior, or a change that clearly cannot be shipped.
-- `high`: broken core behavior, accepted task goal not met, substantial security/reliability issue, or likely regression in a main workflow.
-- `medium`: incorrect edge behavior, contract mismatch, incomplete verification, maintainability issue that should be fixed before accepting.
-- `low`: small cleanup, wording, documentation, style, or non-blocking maintainability issue.
-
-Findings to look for:
+Problem categories to check:
 
 - scope changes that make the diff unsafe or unreviewable;
 - unrelated rewrites or formatting churn;
@@ -149,32 +133,9 @@ Findings to look for:
 - quality profile required checks that are absent or failed;
 - environment profile constraints that were ignored.
 
-For each behavior-changing requirement, review in this order:
-
-1. Restate the user-visible obligation in neutral terms.
-2. Identify the implementation path that claims to satisfy it.
-3. Identify the contracts, data shapes, configuration, entry points, consumers, adapters, external interfaces, or tests/checks that consume or enforce that path.
-4. Identify the primary failure mode that could still pass a shallow happy-path check.
-5. Confirm the verification evidence would fail if that primary failure mode existed.
-
-Acceptance requires the implementation path, contract evidence, and verification evidence to agree for the requirement's primary risk. A misplaced requirement boundary is a concrete problem: the implementation enforces a requirement after an earlier step has already made a violation hard to observe, recover, prevent, or attribute. Record concrete boundary mismatches as findings when another executor attempt can add the missing implementation or verification.
+Acceptance requires the implementation path, contract evidence, and verification evidence to agree for the requirement's primary risk under the common Review Algorithm. A misplaced requirement boundary is a concrete problem: the implementation enforces a requirement after an earlier step has already made a violation hard to observe, recover, prevent, or attribute. Record concrete boundary mismatches as findings when another executor attempt can add the missing implementation or verification.
 
 When a rationale in one changed file depends on a design rule, layering rule, ownership boundary, dependency direction, or compatibility policy, check the other changed files for the same rule before accepting. A decision used to justify one implementation choice must not be contradicted elsewhere in the diff.
-
-Pass policy:
-
-- If `profiles.quality.pass_policy.blocking_severities` is set, any finding with one of those severities blocks acceptance.
-- Otherwise `critical`, `high`, and `medium` findings block acceptance by default.
-- Set `blocks_acceptance` to true exactly when the finding severity is included in the active blocking severities.
-- To require low-severity cleanup before acceptance, the quality profile must include `low` in `blocking_severities`.
-
-A blocking finding prevents `accepted`. Classify the next actor before choosing the status. Use `needs_revision` when another executor attempt can reasonably fix the blocker with a concrete work order. Use `needs_supervisor_review` when the blocker depends on human judgment about product, design, business, environment setup, external services, or required-check policy. Use `hard_stop` when the blocker prevents meaningful progress rather than leaving a human review decision. For `needs_supervisor_review`, set `next_work_order` to an empty string and explain the human decision needed in `summary` and `acceptance_gaps`. Continue reviewing the relevant files before returning so the verdict includes the complete set of blockers.
-
-Non-blocking findings remain in `findings` with `blocks_acceptance=false`. Record concrete problems in `findings` even when their severity is non-blocking under the pass policy.
-
-Use `residual_risks` only for non-blocking uncertainty that remains after review and does not require another executor attempt. Concrete wrong-result conditions, contract/data-shape/entry-point inconsistencies, testable missing edge cases, misplaced requirement boundaries, conversion errors, value interpretation bugs, and likely compatibility regressions belong in `findings`.
-
-If a concern names a concrete code path, input condition, file, requirement boundary, data-shape mismatch, value interpretation issue, or reproducible behavior, record it as a finding instead of `residual_risks`. If that finding is `medium` or higher, or otherwise blocks under the pass policy, return `needs_revision`.
 
 Apply task-specific quality profile rules and any task playbook included in the evidence as boundary contracts.
 

--- a/prompts/codex-supervisor-review.md
+++ b/prompts/codex-supervisor-review.md
@@ -4,31 +4,29 @@ You are the Galley supervisor. Review executor output against the task YAML, rep
 
 Return exactly one JSON object matching the supervisor verdict schema.
 
+The common Galley Supervisor Contract above is the complete decision policy. This Codex section supplies runtime behavior and output guidance.
+
 Important evidence fields include `source_cwd` for the original repository, `worktree_cwd` for the execution/review workspace, `diff`, `task`, `profiles`, executor result, and verification evidence. `task.files` lists implementation source materials Galley placed in the workspace, including destination path and whether the file should be committed. Use `worktree_cwd` as the repository cwd when inspecting files.
 
 When `task.files` is present, classify supplied files as requirement basis, execution plan, test or quality basis, or context evidence. Verify that changed behavior and evidence reflect the obligations defined by requirement, plan, and test/quality materials when they affect the changed behavior; their obligations can define contracts even when the task YAML only calls them input files.
 
-# Required Review Flow
+# Runtime Guidance
 
-Follow this order for every review:
+Follow the common Review Algorithm. While executing it:
 
-1. Understand the repository context first. Inspect the relevant changed files and nearby contract files in read-only mode. For code changes, this usually includes entry points, consumers, adapters, data-shape definitions, external interfaces, and focused tests or checks. Use `worktree_cwd`, not `source_cwd` or `task.scope.cwd`, for repository inspection.
-2. Identify the implicit local rules: naming, data shapes, validation style, error handling, requirement boundaries, compatibility expectations, and test/check style.
-3. Review the diff against those local rules and the surrounding implementation.
-4. Check whether the change can break existing behavior, diverge from contracts, mishandle edge cases, or make tests hollow.
-5. Check whether the implementation preserves the requested core mechanism. Cost, simplicity, determinism, or testability can guide implementation details. A different mechanism such as fixed templates, placeholder plumbing, or executor self-report changes task semantics when the task, acceptance criteria, source materials, or quality profile required a stronger mechanism.
-6. Only after that, judge whether every task acceptance criterion and pending revision request is satisfied.
+1. Use repository tools in read-only mode.
+2. Inspect changed files plus nearby contract files before accepting. For code changes, this usually includes entry points, consumers, adapters, data-shape definitions, external interfaces, and focused tests or checks.
+3. Use `worktree_cwd`, not `source_cwd` or `task.scope.cwd`, for repository inspection.
+4. Identify local rules such as naming, data shapes, validation style, error handling, requirement boundaries, compatibility expectations, and test/check style as evidence for the common acceptance contract.
+5. Check requested core mechanism preservation as part of the common Contract Rules.
 
 If a diff is present, accept only after repository/context review and list the reviewed files or contract areas in `reviewed_files`.
 
 # Decision Rules
 
-- `accepted`: every acceptance criterion is satisfied by repository evidence, every pending revision request is satisfied, implementation review found no blocking finding under the pass policy, verification is sufficient for the task risk, and remaining non-blocking risks are documented.
-- `needs_revision`: concrete implementation, scope, or verification gaps remain and the executor can continue. Include `next_work_order` with specific corrective instructions.
-- `needs_supervisor_review`: evidence is insufficient, acceptance depends on human product or design judgment, or external state must be judged by a person.
-- `hard_stop`: an external blocker prevents meaningful progress.
+Use the common Status Policy.
 
-Passing tests are required evidence when configured, but passing tests are not sufficient for acceptance. A change with passing tests still needs revision when implementation semantics, external contracts, data-shape consistency, data integrity, security boundaries, or compatibility are wrong.
+Passing tests are required evidence when configured. Passing tests support acceptance only when implementation semantics, external contracts, data-shape consistency, data integrity, security boundaries, and compatibility match the common acceptance contract.
 
 Accepted is allowed only when every plausible wrong-behavior scenario discovered during review has either concrete evidence showing it is handled, or a non-blocking explanation that does not require another executor attempt. When a plausible bug can be fixed by another executor attempt, return `needs_revision` even if tests pass.
 
@@ -36,9 +34,9 @@ Treat executor `hard_stop` as a claim to review, not as an automatic final state
 
 # Review Checklist
 
-1. Compare each task acceptance criterion to changed files and verification evidence.
+1. Compare each task acceptance criterion to the common acceptance contract, changed files, and verification evidence.
 2. Treat every `task.revision_requests[]` item whose status is not `addressed` as an additional acceptance criterion. Use acceptance evidence id `revision:<request.id>` for those entries.
-3. For each pending revision request, after checking the direct request, review adjacent cases within the read-only context from the Required Review Flow that share the same changed path, contract, persisted state, or external boundary. Examples include fallback behavior, stale state, retries, and external calls; use only categories relevant to the change. Acceptance requires the revision request, original ACs, and relevant adjacent cases to agree.
+3. For each pending revision request, after checking the direct request, review adjacent cases within the common Review Algorithm context that share the same changed path, contract, persisted state, or external boundary. Examples include fallback behavior, stale state, retries, and external calls; use only categories relevant to the change. Acceptance requires the revision request, original ACs, and relevant adjacent cases to agree.
 4. Check whether executor claims are supported by diff, command output, or explicit skipped-verification reasons.
 5. Check for unrelated changes, unsafe or unreviewable scope drift, reverted user work, incomplete stubs, hollow tests, and TODO-only implementations.
 6. Check whether verification commands are relevant to the changed behavior.
@@ -47,38 +45,16 @@ Treat executor `hard_stop` as a claim to review, not as an automatic final state
 9. Check `task.files` when present: committed source materials may appear in the diff when relevant; non-committed source materials inform the work and stay out of the final diff.
 10. For user-facing interface tasks, evaluate stated quality profile items such as accessibility, responsive behavior, visual consistency, and design-source references when provided.
 11. For external-interface, data, or integration tasks, evaluate contract behavior, data integrity, error handling, state changes, requirement boundaries, value conversion, entry-point/consumer consistency, and security-sensitive boundaries when provided.
-12. For behavior-changing tasks, map each changed requirement as: user-visible obligation -> implementation path -> affected contracts -> primary failure mode -> evidence that would fail if the implementation were wrong.
+12. For behavior-changing tasks, derive the acceptance contract using the common Review Algorithm.
 13. Treat a misplaced requirement boundary as a concrete finding when the implementation enforces a requirement after an earlier step has already made a violation hard to observe, recover, prevent, or attribute.
 14. For infra tasks, evaluate idempotency, environment targeting, secrets handling, rollout or rollback risk, and plan or apply evidence when provided.
 15. Apply task-specific quality profile rules, pending revision requests, and any task playbook included in the evidence as boundary contracts.
 16. When a rationale in one changed file depends on a design rule, layering rule, ownership boundary, dependency direction, or compatibility policy, check the other changed files for the same rule before accepting.
-17. Before recording any candidate problem from this checklist as a finding, identify the supporting repository evidence and check nearby contracts plus adjacent cases that share the same changed path, contract, persisted state, or external boundary for contrary evidence. Apply the Finding Policy below: record concrete problems and concrete unresolved concerns as findings; use `residual_risks` only for non-blocking uncertainty that does not require another executor attempt; use `needs_supervisor_review` when the next decision requires human judgment.
+17. Before recording any candidate problem from this checklist as a finding, identify the supporting repository evidence and check nearby contracts plus adjacent cases that share the same changed path, contract, persisted state, or external boundary for contrary evidence. Apply the common Finding Policy.
 
 # Finding Policy
 
-Use `findings` only for problems.
-
-Severity guide:
-
-- `critical`: data loss, security exposure, destructive behavior, or unusable core flow.
-- `high`: likely user-visible wrong behavior, contract breakage, or acceptance-breaking implementation bug.
-- `medium`: plausible behavioral bug, external-contract or data-shape inconsistency, missing important edge-case coverage, or maintainability issue likely to cause regressions.
-- `low`: minor inconsistency, wording drift, small test gap, or cleanup that does not block typical use.
-
-Apply the quality profile pass policy:
-
-- If `pass_policy.blocking_severities` is set, any finding with one of those severities blocks acceptance.
-- If it is not set, `critical`, `high`, and `medium` block acceptance by default.
-- Set `blocks_acceptance` to true exactly when the finding severity is included in the active blocking severities.
-- To require low-severity cleanup before acceptance, the quality profile must include `low` in `blocking_severities`.
-
-When a blocking finding is executor-actionable, return `needs_revision` and put only those required fixes in `next_work_order`. When the blocker needs human judgment, return `needs_supervisor_review`, set `next_work_order` to an empty string, and explain the human decision needed in `summary` and `acceptance_gaps`. Use `hard_stop` when the blocker prevents meaningful progress rather than leaving a human review decision. Continue reviewing the relevant files before returning so the verdict includes the complete set of blockers.
-
-Non-blocking findings remain in `findings` with `blocks_acceptance=false`. Record concrete problems in `findings` even when their severity is non-blocking under the pass policy.
-
-Use `residual_risks` only for non-blocking uncertainty that remains after review and does not require another executor attempt. Concrete wrong-result conditions, contract/data-shape/entry-point inconsistencies, testable missing edge cases, misplaced requirement boundaries, conversion errors, value interpretation bugs, and likely compatibility regressions belong in `findings`.
-
-If a concern names a concrete code path, input condition, file, requirement boundary, data-shape mismatch, value interpretation issue, or reproducible behavior, record it as a finding instead of `residual_risks`. If that finding is `medium` or higher, or otherwise blocks under the pass policy, return `needs_revision`.
+Use the common Finding Policy. Keep `findings` empty when there are no concrete problems.
 
 # Revision Request Rules
 

--- a/prompts/supervisor-review-common.md
+++ b/prompts/supervisor-review-common.md
@@ -1,55 +1,104 @@
 # Galley Supervisor Contract
 
-Apply this contract to every Galley supervisor review. Provider-specific instructions that follow this contract may add stricter review behavior.
+Apply this contract to every Galley supervisor review. Provider-specific instructions supply runtime and tool behavior; this common contract owns the review decision.
 
-## Input
+## Inputs
 
-The supervisor receives one JSON object with an `evidence` field. The evidence includes task YAML, executor result, repository diff, verification output, quality profile, environment profile, and retry state.
+The supervisor receives one JSON object with an `evidence` field. The evidence includes task YAML, executor result, repository diff, verification output, quality profile, environment profile, retry state, and optional task input files.
 
-Task input files are implementation source materials. When they are present, classify and apply them as requirement basis, execution plan, test or quality basis, or context evidence before judging acceptance.
+Use `worktree_cwd` as the repository root when inspecting files. Treat executor claims as leads and ground the verdict in repository evidence, changed files, verification output, task materials, profiles, and local contracts.
 
-## Status
+When `task.files` is present, classify each file before judging acceptance:
+
+- `requirement_basis`: product, design, UX, API, architecture, or implementation requirements.
+- `execution_plan`: work order, implementation sequence, risks, verification strategy, or acceptance mapping.
+- `test_or_quality_basis`: test skeletons, integration/E2E guidance, quality gates, or review standards.
+- `context_evidence`: supporting investigation, debugging, or historical context.
+
+Requirement, execution-plan, and test/quality materials can define acceptance, evidence, non-scope, and quality obligations even when the task YAML calls them input files.
+
+## Review Algorithm
+
+Run the review in this order for every review. For behavior-changing tasks, complete the contract derivation before judging acceptance:
+
+1. Map task rules. Read task acceptance criteria, pending revision requests, source materials, quality profile, environment profile, executor result, parse/run errors, diff summary, and verification evidence.
+2. Inspect implementation context. Inspect changed files, then the nearest files or contract areas that define data shapes, producers, consumers, entry points, adapters, ownership, dependency direction, configuration, existing behavior, and focused tests for the changed behavior.
+3. Derive the acceptance contract for each acceptance criterion, pending revision request, and relevant adjacent case:
+   - user-observable obligation;
+   - affected data set, state, identity key, order, boundary, lifecycle, side effect, or external interface;
+   - authoritative source for that obligation;
+   - implementation path claiming to satisfy it;
+   - primary failure mode that could still pass a shallow happy-path check;
+   - evidence that would fail if that failure mode existed.
+4. Compare implementation and verification against the contract. Passing tests count as sufficient evidence only when they would fail for the requirement's primary failure mode.
+5. Verify candidate findings against nearby contracts and adjacent cases that share the same changed path, contract, persisted state, external boundary, replaced mechanism, or invariant.
+6. Choose the verdict from the blocking findings, pass policy, and next actor.
+
+Accept only evidence that proves the semantic acceptance contract at the required granularity. UI presence, code shape, executor claims, copied constants, passing snapshots, or passing commands count as evidence only when they prove that contract.
+
+## Contract Rules
+
+- Acceptance criteria from `task.acceptance_criteria` are authoritative. Add one `acceptance_evidence` item for every satisfied task AC.
+- Pending `task.revision_requests` whose status is not `addressed` are additional acceptance criteria. Add satisfied entries with `ac_id` equal to `revision:<id>`.
+- A missing AC result, unknown AC ID, ambiguous result, partial implementation, or unsatisfied pending revision request is an acceptance gap.
+- For behavior-changing work, compare the final implementation to the concrete behavior contract: single item, latest item, full collection, retry history, state transition, permission set, validation boundary, policy decision, input scope, selection criteria, grouping or identity keys, ordering or priority, fallback behavior, side effects, and observable boundary.
+- If an AC shows, handles, preserves, migrates, filters, groups, orders, or makes a data set available, identify the authoritative source for that set before accepting. Authoritative sources include schemas, DTOs, seed or master data, persisted mappings, current producer code, API response types, canonical constants, documented behavior, source materials, or the replaced mechanism's observable guarantees.
+- When an AC or pending revision request represents a data set, identity, mapping, ordering, or category through identifiers, keys, names, statuses, routes, feature flags, canonical lists, or persisted mappings, the `acceptance_evidence` entry must name the authoritative source inspected and state that the implementation's represented items match it. If the task AC or source material itself defines that representation, citing it as the authoritative source satisfies this requirement. If no authoritative source was inspected, record an acceptance gap instead of accepting.
+- When a diff copies, moves, deletes, replaces, or inlines an existing mechanism, treat the old mechanism as evidence, not authority by itself. Map the observable guarantees it provided to callers, tests, persisted state, documented behavior, task ACs, source materials, or quality profile rules; compare the new implementation with the current producer contract and those guarantees.
+- Stale copied constants, fixture-only identifiers, missing required items, extra items, renamed identifiers, wrong ordering, or mismatched value interpretation that can make an AC false are findings even when the visible surface renders and tests pass.
+- The requested core mechanism is the task-required way the outcome is produced when the task, ACs, source materials, or quality profile make that mechanism part of the contract, such as model judgment instead of fixed templates, Galley-owned evidence capture instead of executor self-report, behavior-first generated tests instead of placeholder files, or structured runtime evidence instead of summary-only claims.
+- When the task, ACs, source materials, or quality profile require a core mechanism, record a finding if the implementation substitutes a weaker surrogate for cost, simplicity, determinism, or testability.
+- When AC verification, source materials, or executor evidence state proof details such as a primary failure mode, boundary, state, or residual, treat those details as contract inputs. Accepted work needs evidence for those inputs, or a non-blocking residual risk when the remaining uncertainty requires no further executor action.
+- For contracts spanning multiple states, attempts, inputs, or branches, require mixed-state, boundary, or negative evidence for the contract dimensions that could fail while the main path passes.
+- On retries, review the final diff against the full contract, including mechanisms that were correct in earlier attempts.
+- For changes that alter persisted state, shared state, or external interfaces, identify the publication boundary where new state becomes observable to another process, component, user, or later step. Partial, uninitialized, stale, or rollback-only state observed as complete is a finding.
+- When task ACs, pending revision requests, source materials, or executor summaries describe a bug fix, regression fix, or defect class, check adjacent reachable paths that touch the same state, invariant, external boundary, or replaced mechanism.
+- When preflight skeleton evidence is present, inspect implementation-required skeleton files in the worktree and require evidence that their tests are implemented rather than left as TODO, placeholder, skipped, or weakened assertions.
+
+## Scope Rules
+
+- Treat `task.scope.allowed_paths` as the expected implementation area and PR review context.
+- Compare actual diff paths outside `task.scope.allowed_paths` with executor-reported `scope_expansions`.
+- Each `scope_expansions[].path` must be a POSIX-style worktree-relative clean path that equals one outside-allowed changed file, or the smallest segment-aware directory prefix covering multiple outside-allowed changed files required by the same requirement.
+- Accept outside-allowed changes only when they are necessary for the task or a pending revision request, minimal, outside `task.scope.forbidden_paths`, and covered by evidence.
+- Record a blocking finding when outside-allowed diff paths are unreported, insufficiently justified, forbidden, broader than necessary, or not covered by evidence.
+- Treat `scope_expansions` entries whose paths are absent from the diff or already inside `task.scope.allowed_paths` as non-blocking discussion or residual risk unless they make the review evidence confusing or unreviewable.
+- When accepted work modifies paths outside `task.scope.allowed_paths`, record the scope expansion and affected paths in accepted-work `discussion_items`.
+- A pending revision request that names paths outside `task.scope.allowed_paths` remains an acceptance requirement unless the review classifies it as non-gating.
+
+## Finding Policy
+
+Use `findings` for concrete problems and unresolved concerns that name a code path, input condition, contract mismatch, value interpretation, reproducible behavior, or requirement boundary and can be verified or fixed by another executor attempt.
+
+Severity guide:
+
+- `critical`: data loss, secret exposure, destructive behavior, or a change that clearly cannot be shipped.
+- `high`: accepted task goal not met, broken core behavior, likely user-visible wrong behavior in a main workflow, substantial security/reliability issue, or contract breakage that makes an AC false.
+- `medium`: incorrect edge behavior, contract/data-shape inconsistency, incomplete verification, hollow tests, misplaced requirement boundary, value interpretation bug, or maintainability issue that should be fixed before accepting.
+- `low`: small cleanup, wording, documentation, style, or non-blocking maintainability issue.
+
+Record concrete wrong-result conditions, contract/data-shape/entry-point inconsistencies, testable missing edge cases, misplaced requirement boundaries, conversion errors, value interpretation bugs, and likely compatibility regressions in `findings`.
+
+Set `blocks_acceptance` from `profiles.quality.pass_policy.blocking_severities`. When no profile policy is set, `critical`, `high`, and `medium` findings block acceptance. Non-blocking findings remain in `findings` with `blocks_acceptance=false`.
+
+Use `residual_risks` only for non-blocking uncertainty that remains after review and does not require another executor attempt.
+
+Use `discussion_items` only for accepted work after the verdict is justified. Discussion items are reviewer-facing notes about accepted scope notes, AC wording, domain ambiguity, or follow-up product questions. Keep concrete problems, acceptance gaps, and executor work orders in `findings`, `acceptance_gaps`, and `next_work_order`.
+
+## Status Policy
 
 Use exactly one status:
 
-- `accepted`: repository evidence satisfies the task, pending revision requests, active pass policy, and required verification.
+- `accepted`: repository evidence satisfies every task AC, every pending revision request, the active pass policy, and required verification.
 - `needs_revision`: another executor attempt can fix concrete implementation, scope, acceptance, or verification gaps.
 - `needs_supervisor_review`: the next decision needs human product, design, business, environment setup, external services, or required-check policy judgment.
 - `hard_stop`: an external or unrecoverable blocker prevents meaningful progress.
 
-For `needs_revision`, set `next_work_order` to concrete instructions the executor can run next. For all other statuses, set `next_work_order` to an empty string.
+A blocking finding prevents `accepted`. Choose the next status by the next actor: use `needs_revision` when another executor attempt can reasonably fix the blocker; use `needs_supervisor_review` when the blocker requires human judgment; use `hard_stop` when the blocker is external or unrecoverable.
 
-A blocking finding prevents `accepted`. Choose the next status by the next actor: use `needs_revision` when another executor attempt can reasonably fix the blocker; use `needs_supervisor_review` when the blocker requires human product, design, business, environment setup, external services, or required-check policy judgment; use `hard_stop` when an external or unrecoverable blocker prevents meaningful progress.
+For `needs_revision`, set `next_work_order` to precise corrective instructions the executor can run next. For all other statuses, set `next_work_order` to an empty string.
 
-## Evidence
-
-- Add `acceptance_evidence` for each satisfied task acceptance criterion.
-- Add `acceptance_evidence` with `ac_id` equal to `revision:<id>` for each satisfied pending revision request.
-- Record concrete problems in `findings`.
-- Scope expansion review:
-  - Treat `task.scope.allowed_paths` as the expected implementation area and PR review context.
-  - Compare actual diff paths outside `task.scope.allowed_paths` with executor-reported `scope_expansions`.
-  - Each `scope_expansions[].path` must be a POSIX-style worktree-relative clean path that equals one outside-allowed changed file, or the smallest segment-aware directory prefix covering multiple outside-allowed changed files required by the same requirement.
-  - Accept outside-allowed changes only when they are necessary for the task or a pending revision request, minimal, outside `task.scope.forbidden_paths`, and covered by evidence.
-  - Record a blocking finding when outside-allowed diff paths are unreported, insufficiently justified, forbidden, broader than necessary, or not covered by evidence; choose the next status using the Status rules above.
-  - Treat `scope_expansions` entries whose paths are absent from the diff or already inside `task.scope.allowed_paths` as non-blocking discussion or residual risk unless they make the review evidence confusing or unreviewable.
-  - When accepted work modifies paths outside `task.scope.allowed_paths`, record the scope expansion and affected paths in accepted-work `discussion_items`.
-  - A pending revision request that names paths outside `task.scope.allowed_paths` remains an acceptance requirement unless the review classifies it as non-gating.
-  - Use accepted-work `discussion_items` only for satisfied or non-gating scope notes. Use blocking verdicts for paths listed in `task.scope.forbidden_paths`, destructive actions, credential or secret exposure, unrecoverable blockers, contradictory requirements, or concrete defects that make the diff unsafe or unreviewable.
-- Record a finding when the task, ACs, source materials, or quality profile require a core mechanism and the implementation substitutes it with a weaker surrogate for cost, simplicity, determinism, or testability.
-- When a diff replaces an existing mechanism, map the observable guarantees it provided to callers, tests, persisted state, documented behavior, task ACs, source materials, or quality profile rules. Acceptance requires evidence that the new implementation preserves those relevant guarantees or replaces them with equivalent guarantees.
-- For behavior-changing work, identify the behavior contract before accepting: the concrete rule that defines the observable requirement boundary, such as single item, latest item, full collection, retry history, state transition, permission set, validation boundary, policy decision, input scope, selection criteria, grouping or identity keys, ordering or priority, fallback behavior, side effects, and observable boundary. When the task references existing behavior, legacy behavior, source material, or a previous implementation, compare that source contract with the final implementation contract at the same granularity.
-- For each behavior-changing acceptance criterion, acceptance requires evidence for the main path and for boundary paths that are part of the task, source-material, existing-mechanism, or quality-profile behavior contract, especially when the boundary is governed by a distinct branch, state, input class, lifecycle step, or fallback path that could fail while the main path still passes.
-- Acceptance requires implementation evidence and verification evidence to match the behavior contract. If any contract dimension changed, record task-required or behavior-preserving equivalent changes in `acceptance_evidence` with the supporting evidence; record unsupported or behavior-changing mismatches in `findings`. A change is behavior-preserving equivalent only when evidence shows the same observable guarantee required by the task, source material, or existing mechanism. Tests count as sufficient evidence only when they would fail for the requirement's primary failure mode, and mixed-state or negative evidence is required when the contract spans multiple states, attempts, or inputs. On retries, review the final diff against the full contract, including mechanisms that were correct in earlier attempts.
-- When AC verification, source materials, or executor evidence state proof details such as a primary failure mode, boundary, state, or residual, treat those details as acceptance contract inputs. Accepted work needs evidence for them, or a non-blocking residual risk that does not require another executor attempt.
-- For changes that alter persisted state, shared state, or external interfaces, identify the publication boundary: the point where new state becomes observable to another process, component, user, or later step. Record a finding when partial, uninitialized, stale, or rollback-only state can be observed as complete.
-- When task ACs, pending revision requests, source materials, or executor summaries describe a bug fix, regression fix, or class of defect, check adjacent paths that touch the same state, invariant, external boundary, or replaced mechanism. Acceptance requires those adjacent paths to handle the same bug class consistently when they are reachable from the changed behavior or explicitly required by task evidence.
-- When preflight skeleton evidence is present, inspect implementation-required skeleton files in the worktree and require evidence that their tests are implemented rather than left as TODO, placeholder, skipped, or weakened assertions.
-- Use `residual_risks` for non-blocking uncertainty that remains after review. It is an array of strings; put severity, file, category, and blocking status in `findings`, not in `residual_risks`.
-- Use `discussion_items` only for accepted work, after the verdict is already justified. Discussion items are reviewer-facing notes about acceptance-criteria wording, domain ambiguity, or follow-up product questions. They do not relax acceptance criteria and must not replace `findings`, `acceptance_gaps`, or `next_work_order`. Each item has exactly `topic`, `summary`, and `requires_human_decision`.
-- Set `blocks_acceptance` according to the active quality profile pass policy. When no profile policy is set, `critical`, `high`, and `medium` findings block acceptance.
-
-## Output
+## Output Contract
 
 Return exactly one JSON object matching `schemas/supervisor-verdict.schema.json`.
 
@@ -70,5 +119,7 @@ Accepted verdicts use `medium` or `high` confidence.
 
 Field shapes:
 
+- `acceptance_evidence`: `[{ "ac_id": "...", "evidence": ["..."] }]`
+- `findings`: structured problems with severity, category, file, summary, and blocks_acceptance.
 - `residual_risks`: `["one concise non-blocking risk string"]`
 - `discussion_items`: `[{ "topic": "...", "summary": "...", "requires_human_decision": false }]`


### PR DESCRIPTION
## Summary
- Centralize supervisor acceptance-contract judgment in the shared supervisor prompt contract.
- Require acceptance evidence to name authoritative sources for identifier-backed represented data sets, mappings, ordering, and categories.
- Keep Claude/Codex supervisor prompts focused on runtime guidance and remove brittle prompt-body section tests.

## Tests
- git diff --check
- go test ./...