### PR TITLE
Fix Claude JSON schema compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.9.1 - 2026-07-10
+
+### Fixed
+
+- Claude executor and supervisor runs now pass Claude-compatible JSON schemas by stripping unsupported root `$schema` and schema combinators before invoking Claude Code.
+
 ## v0.9.0 - 2026-07-08
 
 ### Changed

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -668,8 +668,11 @@ func TestClaudeArgsShell(t *testing.T) {
 	if stderr != "" {
 		t.Fatalf("stderr got %q", stderr)
 	}
-	if !strings.HasPrefix(stdout, "cd ") || !strings.Contains(stdout, `--system-prompt "$(cat `) || !strings.Contains(stdout, `--json-schema "$(cat `) {
+	if !strings.HasPrefix(stdout, "cd ") || !strings.Contains(stdout, `--system-prompt "$(cat `) || !strings.Contains(stdout, `--json-schema `) {
 		t.Fatalf("unexpected shell preview: %q", stdout)
+	}
+	if strings.Contains(stdout, `--json-schema "$(cat `) || strings.Contains(stdout, "$schema") {
+		t.Fatalf("shell preview must inline Claude-compatible schema: %q", stdout)
 	}
 }
 

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -153,10 +154,13 @@ func ClaudeShellPreview(opts ClaudeOptions) (string, []string, error) {
 	}
 	opts = withDefaultEmbeddedOptions(opts)
 
-	argv, err := buildClaudeArgv(opts, func(_ string, path string) (string, error) {
+	argv, err := buildClaudeArgv(opts, func(label string, path string) (string, error) {
 		absolute, err := absPath(path)
 		if err != nil {
 			return "", err
+		}
+		if label == "JSON schema" {
+			return readOptionFile("JSON schema", absolute)
 		}
 		return fmt.Sprintf("$(cat %s)", shellToken(absolute)), nil
 	})
@@ -200,11 +204,38 @@ func buildClaudeArgv(opts ClaudeOptions, fileValue func(label, path string) (str
 				return nil, err
 			}
 		}
+		var err error
+		schema, err = ClaudeCompatibleJSONSchema(schema)
+		if err != nil {
+			return nil, err
+		}
 		argv = append(argv, "--json-schema", schema)
 	}
 	argv = append(argv, common.Suffix...)
 	argv = append(argv, opts.Prompt)
 	return argv, nil
+}
+
+// ClaudeCompatibleJSONSchema removes root JSON Schema keywords that current
+// Claude Code versions reject before validating the body passed to
+// --json-schema. Galley still validates parsed executor results after Claude
+// returns, so provider compatibility does not own the semantic contract.
+func ClaudeCompatibleJSONSchema(schema string) (string, error) {
+	var doc any
+	if err := json.Unmarshal([]byte(schema), &doc); err != nil {
+		return "", fmt.Errorf("parse Claude JSON schema: %w", err)
+	}
+	if obj, ok := doc.(map[string]any); ok {
+		delete(obj, "$schema")
+		delete(obj, "allOf")
+		delete(obj, "anyOf")
+		delete(obj, "oneOf")
+	}
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("encode Claude JSON schema: %w", err)
+	}
+	return string(body), nil
 }
 
 type claudeCommonArgs struct {

--- a/internal/runner/claude_test.go
+++ b/internal/runner/claude_test.go
@@ -51,7 +51,7 @@ func TestClaudeArgvAppendPrompt(t *testing.T) {
 	command, err := ClaudeCommandPlanForOS(ClaudeOptions{
 		PromptMode:       "append",
 		SystemPromptFile: promptPath,
-		JSONSchema:       `{"type":"object"}`,
+		JSONSchema:       `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`,
 		Prompt:           "do the work",
 	}, "linux")
 	if err != nil {
@@ -106,6 +106,12 @@ func TestClaudeCommandPlanUsesEmbeddedPromptAndSchemaByDefault(t *testing.T) {
 			t.Fatalf("argv missing %q", want)
 		}
 	}
+	if strings.Contains(argAfter(t, command.Argv, "--json-schema"), "$schema") {
+		t.Fatalf("Claude argv schema must omit root $schema: %s", argAfter(t, command.Argv, "--json-schema"))
+	}
+	if strings.Contains(argAfter(t, command.Argv, "--json-schema"), `"allOf"`) {
+		t.Fatalf("Claude argv schema must omit root allOf: %s", argAfter(t, command.Argv, "--json-schema"))
+	}
 }
 
 func TestClaudeArgvRejectsUnknownPromptMode(t *testing.T) {
@@ -127,29 +133,31 @@ func TestClaudeArgvRejectsUnknownPromptMode(t *testing.T) {
 
 func TestClaudeShellPreviewUsesCatAndCd(t *testing.T) {
 	t.Parallel()
-	promptPath, err := filepath.Abs("prompts/claude-executor-full.md")
-	if err != nil {
-		t.Fatal(err)
-	}
-	schemaPath, err := filepath.Abs("schemas/claude-result.schema.json")
-	if err != nil {
-		t.Fatal(err)
-	}
+	promptPath, schemaPath := writePromptFixtures(t)
 
 	got, warnings, err := ClaudeShellPreview(ClaudeOptions{
 		WorkDir:          "/tmp/project",
 		PromptMode:       "replace",
-		SystemPromptFile: "prompts/claude-executor-full.md",
-		JSONSchemaFile:   "schemas/claude-result.schema.json",
+		SystemPromptFile: promptPath,
+		JSONSchemaFile:   schemaPath,
 		Prompt:           "do the work",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := `cd /tmp/project && claude -p --output-format stream-json --verbose --system-prompt "$(cat ` + shellToken(promptPath) + `)" --json-schema "$(cat ` + shellToken(schemaPath) + `)" 'do the work'`
-	if got != want {
-		t.Fatalf("got %q, want %q", got, want)
+	for _, want := range []string{
+		`cd /tmp/project && claude -p --output-format stream-json --verbose`,
+		`--system-prompt "$(cat ` + shellToken(promptPath) + `)"`,
+		`--json-schema`,
+		`'do the work'`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("preview missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "$schema") || strings.Contains(got, `$(cat `+shellToken(schemaPath)+`)`) {
+		t.Fatalf("preview must inline Claude-compatible schema without root $schema:\n%s", got)
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("unexpected warnings: %#v", warnings)
@@ -348,7 +356,7 @@ func TestClaudeCommandPlanNonWindowsPreservesArgvShape(t *testing.T) {
 		Bin:          "claude",
 		PromptMode:   "replace",
 		SystemPrompt: "system body",
-		JSONSchema:   `{"type":"object"}`,
+		JSONSchema:   `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`,
 		Prompt:       "do the work",
 	}, "linux")
 	if err != nil {
@@ -361,11 +369,33 @@ func TestClaudeCommandPlanNonWindowsPreservesArgvShape(t *testing.T) {
 	if !containsArg(command.Argv, "--json-schema") {
 		t.Fatalf("non-Windows argv must keep --json-schema: %#v", command.Argv)
 	}
+	if got := argAfter(t, command.Argv, "--json-schema"); got != `{"type":"object"}` {
+		t.Fatalf("non-Windows argv must pass Claude-compatible schema, got %q", got)
+	}
 	if command.Argv[len(command.Argv)-1] != "do the work" {
 		t.Fatalf("non-Windows argv must end with work order prompt: %#v", command.Argv)
 	}
 	if command.Stdin != "" {
 		t.Fatalf("non-Windows command should not set stdin, got %q", command.Stdin)
+	}
+}
+
+func TestClaudeCompatibleJSONSchemaRemovesUnsupportedRootKeywordsOnly(t *testing.T) {
+	t.Parallel()
+	got, err := ClaudeCompatibleJSONSchema(`{"$schema":"https://json-schema.org/draft/2020-12/schema","allOf":[{"required":["x"]}],"anyOf":[{"type":"object"}],"oneOf":[{"type":"object"}],"type":"object","properties":{"nested":{"$schema":"kept","allOf":[{"required":["y"]}],"type":"string"}}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "draft/2020-12") {
+		t.Fatalf("root $schema was not removed: %s", got)
+	}
+	for _, unsupported := range []string{`"allOf":[{"required":["x"]}]`, `"anyOf":[{"type":"object"}]`, `"oneOf":[{"type":"object"}]`} {
+		if strings.Contains(got, unsupported) {
+			t.Fatalf("root unsupported keyword was not removed: %s", got)
+		}
+	}
+	if !strings.Contains(got, `"nested":{"$schema":"kept","allOf":[{"required":["y"]}],"type":"string"}`) {
+		t.Fatalf("nested schema metadata should remain untouched: %s", got)
 	}
 }
 
@@ -397,7 +427,7 @@ func writePromptFixtures(t *testing.T) (string, string) {
 	if err := os.WriteFile(promptPath, []byte("system prompt"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(schemaPath, []byte(`{"type":"object"}`), 0o600); err != nil {
+	if err := os.WriteFile(schemaPath, []byte(`{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return promptPath, schemaPath

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -232,9 +232,13 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 		// JSON schema is intentionally not passed on argv on Windows; verdict
 		// validators in ValidateVerdictForEvidence reject malformed output.
 	} else {
+		schema, err := runner.ClaudeCompatibleJSONSchema(schemas.SupervisorVerdict)
+		if err != nil {
+			return nil, fmt.Errorf("prepare Claude supervisor schema: %w", err)
+		}
 		args = append(args,
 			"--system-prompt", prompts.ClaudeSupervisor(),
-			"--json-schema", schemas.SupervisorVerdict,
+			"--json-schema", schema,
 		)
 	}
 	args = append(args, "--plugin-dir", guardDir)

--- a/internal/supervisor/adapter_test.go
+++ b/internal/supervisor/adapter_test.go
@@ -120,6 +120,9 @@ printf '%s\n' '{"status":"accepted","summary":"ok","acceptance_gaps":[],"reviewe
 			t.Fatalf("claude args missing %q:\n%s", want, args)
 		}
 	}
+	if strings.Contains(string(args), "$schema") || strings.Contains(string(args), "draft/2020-12") {
+		t.Fatalf("claude supervisor schema must omit root $schema:\n%s", args)
+	}
 	for _, unwanted := range []string{"--allowedTools", "--allowed-tools"} {
 		if strings.Contains(string(args), unwanted) {
 			t.Fatalf("claude args should not set %q:\n%s", unwanted, args)


### PR DESCRIPTION
## Summary
- Strip unsupported root JSON Schema keywords before passing schemas to Claude Code.
- Apply the Claude-compatible schema path to executor, setup executor, shell preview, and Claude supervisor invocations.
- Add v0.9.1 changelog entry.

## Validation
- go test ./...