### PR TITLE
Make task queue registration recover automatically when daemon state transitions move an existing task during duplicate-ID inspection, without weakening duplicate protection or misreporting a task execution failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Fixed
+
+- `task queue` no longer fails when the daemon moves an existing task between state directories (e.g. queued to running) during duplicate-ID inspection; it rescans the current task state, still rejects genuine duplicate IDs, and only reports a bounded, source-preserving failure (distinct from a task execution failure) if it cannot obtain a stable view.
+
 ## v0.9.1 - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.9.2 - 2026-07-10
+
 ### Fixed
 
 - `task queue` no longer fails when the daemon moves an existing task between state directories (e.g. queued to running) during duplicate-ID inspection; it rescans the current task state, still rejects genuine duplicate IDs, and only reports a bounded, source-preserving failure (distinct from a task execution failure) if it cannot obtain a stable view.

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,18 @@ import (
 	"github.com/shinpr/galley/internal/strutil"
 	"go.yaml.in/yaml/v3"
 )
+
+// duplicateScanMaxAttempts bounds how many times duplicate-ID inspection reruns
+// the complete scan when a previously enumerated task disappears mid-scan. The
+// daemon can rename a task between state directories (e.g. queued -> running)
+// after enumeration but before its ID is read; a bounded rescan finds it at its
+// new location without a global lock that could stall daemon processing.
+const duplicateScanMaxAttempts = 5
+
+// taskIDForDuplicateScan reads a task ID during duplicate-ID inspection. It is a
+// package variable so move-race regression tests can deterministically relocate
+// a task between path enumeration and the ID read.
+var taskIDForDuplicateScan = taskIDFromFile
 
 type QueueOptions struct {
 	Reason     string
@@ -73,27 +86,55 @@ func rejectDuplicateTaskID(path, id, root string) error {
 	if err != nil {
 		return err
 	}
+	for attempt := 0; attempt < duplicateScanMaxAttempts; attempt++ {
+		duplicatePath, moved, err := scanForDuplicateTaskID(root, current, id)
+		if err != nil {
+			return err
+		}
+		if moved {
+			// A task disappeared between enumeration and its ID read, so the
+			// daemon relocated it mid-scan. Rescan to inspect it at its new
+			// location instead of aborting on the now-stale path.
+			continue
+		}
+		if duplicatePath != "" {
+			return fmt.Errorf("task id %q already exists at %s", id, duplicatePath)
+		}
+		return nil
+	}
+	return fmt.Errorf("queue registration failed: could not obtain a stable view of existing tasks after %d attempts because tasks kept moving between state directories; the task source was preserved and not queued; retry the queue command", duplicateScanMaxAttempts)
+}
+
+// scanForDuplicateTaskID runs one complete duplicate-ID scan. It reports the
+// path of a same-ID task when found, or moved=true when a previously enumerated
+// task vanished mid-scan (os.ErrNotExist) so the caller can rescan. Any other
+// inspection error is returned as the underlying cause rather than treated as a
+// move race.
+func scanForDuplicateTaskID(root, current, id string) (string, bool, error) {
 	matches, err := filepath.Glob(filepath.Join(root, "tasks", "*", "*.y*ml"))
 	if err != nil {
-		return err
+		return "", false, err
 	}
 	for _, match := range matches {
 		absMatch, err := filepath.Abs(match)
 		if err != nil {
-			return err
+			return "", false, err
 		}
 		if absMatch == current {
 			continue
 		}
-		existingID, err := taskIDFromFile(match)
+		existingID, err := taskIDForDuplicateScan(match)
 		if err != nil {
-			return fmt.Errorf("inspect existing task %s: %w", match, err)
+			if errors.Is(err, os.ErrNotExist) {
+				return "", true, nil
+			}
+			return "", false, fmt.Errorf("inspect existing task %s: %w", match, err)
 		}
 		if existingID == id {
-			return fmt.Errorf("task id %q already exists at %s", id, match)
+			return match, false, nil
 		}
 	}
-	return nil
+	return "", false, nil
 }
 
 func taskIDFromFile(path string) (string, error) {

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -12,16 +12,10 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// duplicateScanMaxAttempts bounds how many times duplicate-ID inspection reruns
-// the complete scan when a previously enumerated task disappears mid-scan. The
-// daemon can rename a task between state directories (e.g. queued -> running)
-// after enumeration but before its ID is read; a bounded rescan finds it at its
-// new location without a global lock that could stall daemon processing.
+// Bound retries so continuous task movement cannot block queue registration.
 const duplicateScanMaxAttempts = 5
 
-// taskIDForDuplicateScan reads a task ID during duplicate-ID inspection. It is a
-// package variable so move-race regression tests can deterministically relocate
-// a task between path enumeration and the ID read.
+// Overridden by tests to reproduce a move between enumeration and read.
 var taskIDForDuplicateScan = taskIDFromFile
 
 type QueueOptions struct {
@@ -92,9 +86,6 @@ func rejectDuplicateTaskID(path, id, root string) error {
 			return err
 		}
 		if moved {
-			// A task disappeared between enumeration and its ID read, so the
-			// daemon relocated it mid-scan. Rescan to inspect it at its new
-			// location instead of aborting on the now-stale path.
 			continue
 		}
 		if duplicatePath != "" {
@@ -105,11 +96,7 @@ func rejectDuplicateTaskID(path, id, root string) error {
 	return fmt.Errorf("queue registration failed: could not obtain a stable view of existing tasks after %d attempts because tasks kept moving between state directories; the task source was preserved and not queued; retry the queue command", duplicateScanMaxAttempts)
 }
 
-// scanForDuplicateTaskID runs one complete duplicate-ID scan. It reports the
-// path of a same-ID task when found, or moved=true when a previously enumerated
-// task vanished mid-scan (os.ErrNotExist) so the caller can rescan. Any other
-// inspection error is returned as the underlying cause rather than treated as a
-// move race.
+// scanForDuplicateTaskID requests a rescan when an enumerated task has moved.
 func scanForDuplicateTaskID(root, current, id string) (string, bool, error) {
 	matches, err := filepath.Glob(filepath.Join(root, "tasks", "*", "*.y*ml"))
 	if err != nil {

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -93,7 +93,7 @@ func rejectDuplicateTaskID(path, id, root string) error {
 		}
 		return nil
 	}
-	return fmt.Errorf("queue registration failed: could not obtain a stable view of existing tasks after %d attempts because tasks kept moving between state directories; the task source was preserved and not queued; retry the queue command", duplicateScanMaxAttempts)
+	return fmt.Errorf("queue registration failed after %d scans: task state kept changing; source preserved and not queued; retry the command", duplicateScanMaxAttempts)
 }
 
 // scanForDuplicateTaskID requests a rescan when an enumerated task has moved.

--- a/internal/task/queue_move_race_test.go
+++ b/internal/task/queue_move_race_test.go
@@ -214,7 +214,7 @@ func TestQueueDuplicateScanRetryExhaustion(t *testing.T) {
 		t.Fatal("expected retry exhaustion to fail queue registration")
 	}
 	msg := err.Error()
-	for _, want := range []string{"queue registration failed", "preserved", "retry the queue command"} {
+	for _, want := range []string{"queue registration failed", "preserved", "retry the command"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error missing %q recovery fact: %v", want, err)
 		}

--- a/internal/task/queue_move_race_test.go
+++ b/internal/task/queue_move_race_test.go
@@ -1,0 +1,231 @@
+package task
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// swapDuplicateScanReader replaces the duplicate-ID scan reader for a single
+// test and returns a restore function. Tests using it must not run in parallel
+// because the reader is package-global state.
+func swapDuplicateScanReader(fn func(string) (string, error)) func() {
+	prev := taskIDForDuplicateScan
+	taskIDForDuplicateScan = fn
+	return func() { taskIDForDuplicateScan = prev }
+}
+
+// writeTaskFileWithID writes a valid task file at path with the given ID and status.
+func writeTaskFileWithID(t *testing.T, path, id, status string) {
+	t.Helper()
+	base := writeTaskYAML(t, "loop_budget: 3")
+	loaded, err := Load(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.ID = id
+	loaded.Status = status
+	if err := Save(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func countTasksWithID(t *testing.T, dir, id string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, m := range matches {
+		got, err := taskIDFromFile(m)
+		if err != nil {
+			t.Fatalf("read %s: %v", m, err)
+		}
+		if got == id {
+			count++
+		}
+	}
+	return count
+}
+
+// AC1: an existing task relocating queued -> running mid-scan must not abort
+// registration of a unique incoming task; a rescan finds it at its new location.
+func TestQueueRescansWhenTaskMovesDuringDuplicateScan(t *testing.T) {
+	root := t.TempDir()
+	queuedDir := filepath.Join(root, "tasks", "queued")
+	runningDir := filepath.Join(root, "tasks", "running")
+	draftDir := filepath.Join(root, "tasks", "draft")
+	for _, d := range []string{queuedDir, runningDir, draftDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	existingQueued := filepath.Join(queuedDir, "existing.yaml")
+	writeTaskFileWithID(t, existingQueued, "existing-task", "queued")
+	draftPath := filepath.Join(draftDir, "incoming.yaml")
+	writeTaskFileWithID(t, draftPath, "incoming-task", "draft")
+
+	moved := false
+	restore := swapDuplicateScanReader(func(p string) (string, error) {
+		if !moved && filepath.Base(p) == "existing.yaml" && filepath.Base(filepath.Dir(p)) == "queued" {
+			moved = true
+			if err := os.Rename(existingQueued, filepath.Join(runningDir, "existing.yaml")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return taskIDFromFile(p)
+	})
+	t.Cleanup(restore)
+
+	result, err := Queue(draftPath, QueueOptions{Root: root})
+	if err != nil {
+		t.Fatalf("queue should recover from a move race, got error: %v", err)
+	}
+	if !moved {
+		t.Fatal("expected the move-race injection to fire during inspection")
+	}
+	if result.Task.ID != "incoming-task" || result.Task.Status != "queued" {
+		t.Fatalf("queued task got %#v", result.Task)
+	}
+	if got := countTasksWithID(t, queuedDir, "incoming-task"); got != 1 {
+		t.Fatalf("incoming task should appear exactly once in queued, got %d", got)
+	}
+	if _, err := os.Stat(filepath.Join(runningDir, "existing.yaml")); err != nil {
+		t.Fatalf("existing task should remain at its new running location: %v", err)
+	}
+}
+
+// AC2: a same-ID task relocating mid-scan must still be detected as a duplicate
+// at its new location; the rescan must not weaken duplicate protection.
+func TestQueueRejectsDuplicateWhenSameIDTaskMovesDuringScan(t *testing.T) {
+	root := t.TempDir()
+	queuedDir := filepath.Join(root, "tasks", "queued")
+	runningDir := filepath.Join(root, "tasks", "running")
+	draftDir := filepath.Join(root, "tasks", "draft")
+	for _, d := range []string{queuedDir, runningDir, draftDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	existingQueued := filepath.Join(queuedDir, "existing.yaml")
+	writeTaskFileWithID(t, existingQueued, "dupe-id", "queued")
+	draftPath := filepath.Join(draftDir, "incoming.yaml")
+	writeTaskFileWithID(t, draftPath, "dupe-id", "draft")
+
+	moved := false
+	restore := swapDuplicateScanReader(func(p string) (string, error) {
+		if !moved && filepath.Base(p) == "existing.yaml" && filepath.Base(filepath.Dir(p)) == "queued" {
+			moved = true
+			if err := os.Rename(existingQueued, filepath.Join(runningDir, "existing.yaml")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return taskIDFromFile(p)
+	})
+	t.Cleanup(restore)
+
+	_, err := Queue(draftPath, QueueOptions{Root: root})
+	if err == nil {
+		t.Fatal("expected duplicate task id rejection after rescan")
+	}
+	if !strings.Contains(err.Error(), `task id "dupe-id" already exists`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(draftPath); statErr != nil {
+		t.Fatalf("draft source should remain unchanged after rejection: %v", statErr)
+	}
+	if got := countTasksWithID(t, queuedDir, "dupe-id"); got != 0 {
+		t.Fatalf("no same-ID copy should be published to queued, got %d", got)
+	}
+}
+
+// AC3: a non-ENOENT inspection error must surface as the underlying cause and
+// must not be retried as a move race.
+func TestQueueDuplicateScanReportsNonENOENTError(t *testing.T) {
+	root := t.TempDir()
+	queuedDir := filepath.Join(root, "tasks", "queued")
+	draftDir := filepath.Join(root, "tasks", "draft")
+	for _, d := range []string{queuedDir, draftDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTaskFileWithID(t, filepath.Join(queuedDir, "existing.yaml"), "existing-task", "queued")
+	draftPath := filepath.Join(draftDir, "incoming.yaml")
+	writeTaskFileWithID(t, draftPath, "incoming-task", "draft")
+
+	sentinel := errors.New("permission denied")
+	calls := 0
+	restore := swapDuplicateScanReader(func(p string) (string, error) {
+		if filepath.Base(p) == "existing.yaml" {
+			calls++
+			return "", sentinel
+		}
+		return taskIDFromFile(p)
+	})
+	t.Cleanup(restore)
+
+	_, err := Queue(draftPath, QueueOptions{Root: root})
+	if err == nil {
+		t.Fatal("expected the underlying inspection error to be reported")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("underlying cause should be preserved, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("non-ENOENT error must not be retried as a move race, got %d scans", calls)
+	}
+	if _, statErr := os.Stat(draftPath); statErr != nil {
+		t.Fatalf("draft source should remain unchanged: %v", statErr)
+	}
+}
+
+// AC4: when every scan observes a disappearing path, inspection must fail within
+// the bounded retry policy, preserve the source, publish nothing, and report the
+// recovery facts distinctly from a task execution failure.
+func TestQueueDuplicateScanRetryExhaustion(t *testing.T) {
+	root := t.TempDir()
+	queuedDir := filepath.Join(root, "tasks", "queued")
+	draftDir := filepath.Join(root, "tasks", "draft")
+	for _, d := range []string{queuedDir, draftDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTaskFileWithID(t, filepath.Join(queuedDir, "existing.yaml"), "existing-task", "queued")
+	draftPath := filepath.Join(draftDir, "incoming.yaml")
+	writeTaskFileWithID(t, draftPath, "incoming-task", "draft")
+
+	calls := 0
+	restore := swapDuplicateScanReader(func(p string) (string, error) {
+		if filepath.Base(p) == "existing.yaml" {
+			calls++
+			return "", os.ErrNotExist
+		}
+		return taskIDFromFile(p)
+	})
+	t.Cleanup(restore)
+
+	_, err := Queue(draftPath, QueueOptions{Root: root})
+	if err == nil {
+		t.Fatal("expected retry exhaustion to fail queue registration")
+	}
+	msg := err.Error()
+	for _, want := range []string{"queue registration failed", "preserved", "retry the queue command"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error missing %q recovery fact: %v", want, err)
+		}
+	}
+	if calls != duplicateScanMaxAttempts {
+		t.Fatalf("retry must be bounded to %d scans, got %d", duplicateScanMaxAttempts, calls)
+	}
+	if _, statErr := os.Stat(draftPath); statErr != nil {
+		t.Fatalf("draft source must be preserved on retry exhaustion: %v", statErr)
+	}
+	if got := countTasksWithID(t, queuedDir, "incoming-task"); got != 0 {
+		t.Fatalf("no incoming copy should be published on retry exhaustion, got %d", got)
+	}
+}


### PR DESCRIPTION
## Goal

Make task queue registration recover automatically when daemon state transitions move an existing task during duplicate-ID inspection, without weakening duplicate protection or misreporting a task execution failure.

## Acceptance Criteria

- `AC1` When the daemon moves an existing task between state directories during duplicate-ID inspection, galley task queue shall rescan the current task state and successfully register an incoming task with a unique ID without requiring the user to retry the command.
  - Verification: Deterministic regression test in internal/task that forces an existing task to move from queued to running between path enumeration and ID read; claim: a unique incoming task is queued successfully despite the move; primary failure mode: the stale path returns ENOENT and aborts queue registration; boundary: task.Queue and the file-backed task directories; state: existing task is queued -> duplicate-ID scan begins -> daemon-style rename occurs -> incoming task appears exactly once in queued; residual: none.
  - Status: satisfied
- `AC2` When an existing task moves between state directories during duplicate-ID inspection and has the same ID as the incoming task, galley task queue shall still reject the incoming task as a duplicate using its current location.
  - Verification: Deterministic regression test that relocates a same-ID task during inspection; claim: retrying the scan does not weaken duplicate-ID protection; primary failure mode: the moved task is missed and a second task with the same ID is published; boundary: duplicate-ID inspection across tasks/* state directories; state: same-ID task is queued -> scan begins -> task moves to running -> incoming queue is rejected and its source remains unchanged; residual: none.
  - Status: satisfied
- `AC3` If inspection of an existing task fails for a reason other than the task disappearing during a concurrent state transition, galley task queue shall report the error without treating it as a retryable move race.
  - Verification: Focused unit tests for non-ENOENT filesystem errors; claim: only transient missing-path errors trigger rescan; primary failure mode: permission or persistent I/O failures are hidden or retried as state movement; boundary: duplicate-ID file inspection; state: existing path returns a non-ENOENT error -> queue fails with the underlying cause -> incoming source remains unchanged; residual: platform-specific error construction may use test injection.
  - Status: satisfied
- `AC4` If duplicate-ID inspection cannot obtain a stable view within its bounded retry policy, galley task queue shall fail without publishing or executing the incoming task and shall report that queue registration failed, the source was preserved, and retrying the queue command is the next action.
  - Verification: Focused unit test that makes every scan observe a disappearing path; claim: retry exhaustion is bounded, preserves the task, and is distinguishable from a task execution failure; primary failure mode: an infinite retry, partial queue publication, added execution attempt, or ambiguous task-error message; boundary: queue command result and task files; state: draft exists -> every scan is invalidated -> command returns -> draft is unchanged, no queued copy or queue attempt exists, and the error contains the required recovery facts; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go test -race ./internal/task/...`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool <all profile/schema/plugin/marketplace json>`: passed
- `GOOS=windows GOARCH=amd64 go test -exec=true ./internal/task/...`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` How should duplicate-ID inspection recover from a task moving between state directories? -> Retry the complete duplicate-ID scan only when reading a previously enumerated path returns os.ErrNotExist, using a small bounded retry policy.
  - Rationale: A complete rescan finds the task at its new location without weakening duplicate detection or introducing a global lock that could stall daemon processing.
  - Reversibility: high
- `claude-decision-2` How to make the queued->running move race deterministic and testable without a public API change? -> Introduced an unexported package variable taskIDForDuplicateScan (defaulting to taskIDFromFile) as the read seam, overridden only by non-parallel regression tests.
  - Rationale: Keeps the public Queue API and QueueOptions unchanged (compatibility), enables full end-to-end Queue() move-race tests, and the race detector confirms no data race since injecting tests run sequentially before parallel tests.
  - Reversibility: high
- `claude-decision-3` What bound for the retry policy? -> duplicateScanMaxAttempts=5 with immediate rescan (no sleep).
  - Rationale: Task calls for a small bounded policy and R1 mitigation asks for deterministic tests without OS-specific locking; a fixed small bound keeps tests deterministic and avoids infinite retry.
  - Reversibility: high

## Risks

- `R1` cross-platform-filesystem-race: macOS, Linux, and Windows may expose different timing around directory enumeration and same-directory rename.
  - Mitigation: Keep the recovery based on errors.Is(err, os.ErrNotExist), avoid OS-specific locking, and provide deterministic move-race tests plus the repository's cross-platform verification evidence.
