### PR TITLE
Bring Galley's existing hand-written source comments into compliance with the repository's comment-quality policy without changing runtime behavior.

### DIFF
--- a/docs/examples/notifications/notify-macos.sh
+++ b/docs/examples/notifications/notify-macos.sh
@@ -27,9 +27,7 @@ cat >/dev/null || true
 title="Galley: ${GALLEY_TASK_STATUS:-task} ${GALLEY_TASK_ID:-}"
 body="${GALLEY_SUMMARY:-} (${GALLEY_REPO:-})"
 
-# osascript receives title/body as argv ($1,$2), read inside the AppleScript with
-# `item N of argv`, so the values are data and are never parsed as AppleScript or
-# shell source.
+# Pass title/body as argv, read via `item N of argv`, so they stay data.
 osascript - "$title" "$body" <<'APPLESCRIPT'
 on run argv
   display notification (item 2 of argv) with title (item 1 of argv) sound name "default"

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -326,11 +326,10 @@ func TestTaskShowAcceptedTerminalSuppressesPriorFailure(t *testing.T) {
 	}
 }
 
-// TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses guards the regression
-// reviewers flagged in iteration 1: once the daemon's PR cleanup loop moves
-// an accepted task from pr_opened to closed or merged, prior failed attempts
-// must remain under the prior_attempt_* prefix instead of regressing to the
-// active "failed" framing.
+// TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses guards the case where
+// the daemon's PR cleanup loop moves an accepted task from pr_opened to closed
+// or merged: prior failed attempts must remain under the prior_attempt_* prefix
+// instead of regressing to the active "failed" framing.
 func TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses(t *testing.T) {
 	for _, terminalStatus := range []string{"closed", "merged"} {
 		terminalStatus := terminalStatus

--- a/internal/daemon/cleanup.go
+++ b/internal/daemon/cleanup.go
@@ -55,9 +55,8 @@ func cleanupTaskWorktree(ctx context.Context, opts Options, path string) error {
 	// A persisted final PR status (merged/closed) is sufficient on its own:
 	// the PR lifecycle has no remaining decision, so cleanup of an already-
 	// final historical task must not depend on GitHub API availability (D1).
-	// Querying GitHub for these tasks is the recurring maintenance failure
-	// this change removes, so the no-GitHub path is gated strictly on the
-	// persisted final status (R1).
+	// Querying GitHub for these tasks is a recurring maintenance failure, so
+	// the no-GitHub path is gated strictly on the persisted final status (R1).
 	persistedFinal := loaded.PR.Status == "merged" || loaded.PR.Status == "closed"
 	finalStatus := loaded.PR.Status
 	if !persistedFinal {

--- a/internal/daemon/comments.go
+++ b/internal/daemon/comments.go
@@ -264,10 +264,6 @@ func parsePRCommand(comment vcs.PRComment) (prCommand, bool) {
 		return prCommand{}, false
 	}
 
-	// Split the rest of the body into the command line and the trailing block,
-	// TrimSpace each part separately, and join them with a blank line when both
-	// are non-empty. An empty Reason falls back to the default acknowledgement
-	// string so a bare "/galley" still produces a stable Reason.
 	firstLine, trailing, _ := strings.Cut(rest, "\n")
 	firstLine = strings.TrimSpace(firstLine)
 	trailing = strings.TrimSpace(trailing)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -360,11 +360,8 @@ func TestRunOnceOpenPRCommitsPushesAndUpdatesTask(t *testing.T) {
 
 // TestRunOnceOpenPRPersistsPRAuthorLogin exercises the success path for the
 // PR author capture step that protects later /galley PR comment handling.
-// The fake `gh` differentiates between `gh pr create ...` (returns the new PR
-// URL) and `gh api repos/{owner}/{repo}/pulls/{number}` (returns a JSON
-// payload with the PR author's login). The saved done task must carry the
-// login on PR.AuthorLogin so the PR-author trust check can run later without
-// re-fetching from GitHub.
+// The saved done task must carry the login on PR.AuthorLogin so the PR-author
+// trust check can run later without re-fetching from GitHub.
 func TestRunOnceOpenPRPersistsPRAuthorLogin(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)

--- a/internal/daemon/executor_result_resolver.go
+++ b/internal/daemon/executor_result_resolver.go
@@ -8,6 +8,9 @@ import (
 	"github.com/shinpr/galley/internal/runner"
 )
 
+// codexLastMessagePath returns the attempt-scoped `--output-last-message`
+// capture path Galley requests for Codex executor runs (empty for Claude
+// because Claude streams its result directly to stdout JSONL).
 func codexLastMessagePath(cli, attemptDir string) string {
 	if cli != "codex" || attemptDir == "" {
 		return ""

--- a/internal/daemon/finalize_add_paths_test.go
+++ b/internal/daemon/finalize_add_paths_test.go
@@ -45,9 +45,9 @@ func TestAddEligiblePorcelainPathsEmptyWhenOnlyStagedDeletions(t *testing.T) {
 // TestParsePorcelainPathsStillReportsStagedDeletion pins AC4: the
 // change-visibility parser used by progress detection, the finalize-time
 // forbidden_paths gate, and scope-expansion reporting must keep reporting
-// staged-only deletions. The fix only changes which paths reach git add, not
-// which paths are considered changed/reviewable, so forbidden-path deletions
-// stay visible to the safety gate.
+// staged-only deletions. Path selection for git add is separate from
+// change/reviewability detection, so forbidden-path deletions stay visible to
+// the safety gate.
 func TestParsePorcelainPathsStillReportsStagedDeletion(t *testing.T) {
 	porcelain := "D  secret/leak.txt\nA  src/added.go\n"
 	got := parsePorcelainPaths(porcelain)

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -60,26 +60,17 @@ func asReviewStagingError(err error) (*reviewStagingError, bool) {
 // stage the executor-produced worktree changes Galley hands to the
 // supervisor.
 //
-// The implementation runs in three steps:
+// It discovers the dirty worktree paths, builds the explicit reviewable path
+// set (dropping empty/non-local entries, deduplicating, and excluding
+// excludePaths — task.files entries declared commit:false), and stages exactly
+// that set. Forbidden-path entries are intentionally kept so the finalize-time
+// forbidden_paths gate still observes them, and the staged diff the supervisor
+// reviews reflects the executor's submitted artifact and nothing else.
 //
-// 1. Discover the dirty worktree paths via `git status --porcelain=v1 -z`
-// after the executor returned.
-// 2. Build the explicit reviewable path set with reviewablePathsFromStatus.
-// The builder drops empty/non-local entries, deduplicates, and excludes
-// the supplied excludePaths (task.files entries declared with
-// commit:false). Forbidden-path entries are intentionally kept in the
-// set so the existing finalize-time forbidden_paths gate still observes
-// them.
-// 3. Stage exactly that explicit path set with vcs.StagePathsForReview. The
-// staging command runs `git add -A -- <path> [<path>...]` so the diff
-// fields the supervisor reviews (StagedDiff / Diff in the snapshot)
-// reflect the executor's submitted artifact and nothing else.
-//
-// Tests override this seam to inject deterministic failures and to assert
-// the exclude-list contract without spawning a real git process; production
-// callers always go through the three-step flow above. The signature keeps
-// excludePaths visible at the seam so failure-path tests can document the
-// shape of the contract.
+// Tests override this seam to inject deterministic failures and assert the
+// exclude-list contract without spawning a real git process. The signature
+// keeps excludePaths visible at the seam so failure-path tests can document
+// the contract.
 var stageExecutorOutput = func(ctx context.Context, opts Options, workDir, attemptDir string, excludePaths []string) error {
 	bins := vcsBinaries(opts)
 	statusZ, err := vcs.StatusPorcelainZ(ctx, bins, workDir)
@@ -347,7 +338,7 @@ func applySupervisorVerdict(ctx, shutdownCtx context.Context, req verdictApplica
 		// Daemon-side acceptance gate. When required skeleton
 		// coverage or required-check evidence is missing or failed, downgrade
 		// the accepted verdict to needs_supervisor_review with a user-visible
-		// reason. The first version has no waiver mechanism.
+		// reason. There is no waiver mechanism.
 		if reason, ok := evaluateAcceptanceGate(req.Loaded, req.RunDir); !ok {
 			fmt.Fprintf(os.Stderr, "galley: task %s accepted-verdict downgraded by acceptance gate: %s\n", req.Loaded.ID, reason)
 			return "", true, degradeToSupervisorReview(req, "acceptance-gate", "Accepted verdict downgraded by acceptance skeleton gate: "+reason, "Inspect preflight_result.json and required verification evidence before re-finalizing.")
@@ -599,9 +590,6 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 	}, nil
 }
 
-// codexLastMessagePath returns the attempt-scoped `--output-last-message`
-// capture path Galley requests for Codex executor runs (empty for Claude
-// because Claude streams its result directly to stdout JSONL).
 func markRevisionRequestsAddressed(loaded *task.Task, evidence string) {
 	for i := range loaded.RevisionRequests {
 		if loaded.RevisionRequests[i].Status == "addressed" {
@@ -840,8 +828,8 @@ func evaluateAcceptanceGate(loaded *task.Task, runDir string) (string, bool) {
 		return message, false
 	}
 	if res.Status == "skipped" {
-		// First version has no provider hook; required preflight cannot be
-		// silently skipped to acceptance.
+		// Required preflight cannot be silently skipped to acceptance; there is
+		// no waiver hook.
 		if cfg.IsRequired() {
 			return "acceptance skeleton preflight was skipped while required", false
 		}

--- a/internal/daemon/maintenance_polling_independence_test.go
+++ b/internal/daemon/maintenance_polling_independence_test.go
@@ -27,15 +27,15 @@ package daemon
 //   processAvailable waits on the executor goroutine before the next cycle.)
 // @timing: implement alongside the daemon scheduler refactor.
 //
-// Implementation notes for the executor:
-//   - There is no existing test that proves polling is independent of execution;
-//     this skeleton must be completed, not deleted.
-//   - Use a cancelable context and a short PollInterval so the maintenance runner
-//     ticks several times during the blocking executor attempt.
-//   - The fake gh appends each comment-poll invocation to pollLog; assert at
-//     least two poll invocations are recorded WHILE executorStarted exists and
-//     before the executor attempt has been allowed to finish.
-//   - Replace the explicit t.Fatal placeholder with the act + assert sequence.
+// Skeleton constraints (must stay satisfied):
+//   - Completion: this skeleton carries a real act+assert body rather than a
+//     placeholder; it must not be reduced back to an unimplemented stub.
+//   - Mixed-state timing: use a cancelable context and a short PollInterval so
+//     the maintenance runner ticks several times during the blocking executor
+//     attempt.
+//   - Assertion: prove at least two comment-poll invocations are recorded while
+//     the executor-start marker still exists and before the executor attempt is
+//     released, so polling is shown to run independently of execution.
 
 import (
 	"bytes"
@@ -51,7 +51,6 @@ import (
 )
 
 func TestNormalDaemonPollsPRCommentsWhileExecutorAttemptIsRunning(t *testing.T) {
-	// Arrange: Galley root + source repo.
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)
 	runDaemonGit(t, repo, "branch", "-M", "main")

--- a/internal/daemon/path_set.go
+++ b/internal/daemon/path_set.go
@@ -53,8 +53,6 @@ func reviewablePathsFromStatus(statusZ string, excludeDestinations []string) []s
 	seen := make(map[string]bool, len(raw))
 	var result []string
 	for _, entry := range raw {
-		// Already-staged deletions remain visible in the staged diff and do
-		// not need another git add.
 		if isStagedOnlyDeletion(entry.X, entry.Y) {
 			continue
 		}
@@ -62,11 +60,6 @@ func reviewablePathsFromStatus(statusZ string, excludeDestinations []string) []s
 		if clean == "" {
 			continue
 		}
-		// Reject any path that escapes the worktree root. filepath.IsLocal
-		// returns false for absolute paths, drive-letter paths, and any
-		// segment that backs out of cwd, so the review-staging set cannot
-		// widen beyond the executor's working directory regardless of how
-		// git status formatted the entry.
 		if !filepath.IsLocal(clean) {
 			continue
 		}

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -233,10 +233,8 @@ func prTitle(loaded task.Task) string {
 	// First pass: enforce the visual rune cap with whitespace-preferred
 	// truncation. Most goals fit and are returned untouched.
 	title = truncatePRTitleByRunes(title)
-	// Second pass: enforce GitHub's hard byte cap. The rune cap can still
-	// exceed 256 bytes when every rune is a 4-byte UTF-8 character, so this
-	// pass guarantees the result fits while preserving valid UTF-8 and the
-	// ellipsis marker.
+	// Second pass: enforce GitHub's hard byte cap, which the rune cap can still
+	// exceed for titles made of multi-byte UTF-8 runes.
 	title = truncatePRTitleByBytes(title)
 	return title
 }

--- a/internal/daemon/pr_test.go
+++ b/internal/daemon/pr_test.go
@@ -31,14 +31,12 @@ func TestPRTitleTruncatesRunes(t *testing.T) {
 	}
 }
 
-// TestPRTitlePreservesOrdinaryLongASCIIGoal covers AC1: an ordinary long
-// ASCII task goal comparable in length to PR 18's goal must be preserved
-// verbatim and must not gain an ellipsis. This guards against regressing the
-// PR title budget back down to a value that prematurely truncates such goals.
+// TestPRTitlePreservesOrdinaryLongASCIIGoal asserts that an ordinary long
+// ASCII goal within the byte budget is preserved verbatim without truncation
+// and never gains an ellipsis.
 func TestPRTitlePreservesOrdinaryLongASCIIGoal(t *testing.T) {
 	t.Parallel()
-	// PR 18's goal text, an ordinary long ASCII goal that the previous narrow
-	// rune budget truncated mid-sentence.
+	// A representative ordinary long ASCII goal that fits within the byte budget without truncation.
 	goal := "Restrict Galley PR comment commands so only the PR author, when also trusted by GitHub author association, can requeue or update a task."
 	title := prTitle(task.Task{Goal: goal})
 	if title != goal {

--- a/internal/daemon/reused_input_files_test.go
+++ b/internal/daemon/reused_input_files_test.go
@@ -74,9 +74,9 @@ func TestReconcileReusedInputFilesDoesNotEscapeViaSymlinkedDestinationParent(t *
 	}
 	srcDir := t.TempDir()
 	source := filepath.Join(srcDir, "context.md")
-	// Identical content: the pre-fix reconciler treated a matching destination as
-	// a stale copy and removed it. The fix must refuse to read or remove through a
-	// symlinked destination parent that resolves outside the worktree.
+	// Identical content would let the reconciler treat the destination as a stale
+	// copy and remove it, but it must refuse to read or remove through a symlinked
+	// destination parent that resolves outside the worktree.
 	if err := os.WriteFile(source, []byte("same content"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/review_staging_test.go
+++ b/internal/daemon/review_staging_test.go
@@ -112,12 +112,11 @@ func TestRunOnceAcceptedFinalizationCommitsStagedNewFile(t *testing.T) {
 
 // TestRunOnceAcceptedFinalizationCommitsStagedOnlyDeletion pins AC1+AC3 for a
 // staged-only deletion. The fake executor stages the deletion of a tracked
-// file with `git rm` and submits no other change. Before the fix, review
-// staging ran `git add -A -- <deleted path>` and failed with "pathspec did not
-// match any files", so the attempt never reached the supervisor. After the
-// fix, review staging skips the already-staged deletion (it stays visible in
-// the captured attempt diff), the supervisor accepts the dirty diff, and
-// finalization commits the deletion without re-adding it.
+// file with `git rm` and submits no other change. Review staging must skip the
+// already-staged deletion — running `git add -A -- <deleted path>` fails with
+// "pathspec did not match any files" — so it stays visible in the captured
+// attempt diff, the supervisor accepts the dirty diff, and finalization commits
+// the deletion without re-adding it.
 func TestRunOnceAcceptedFinalizationCommitsStagedOnlyDeletion(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)

--- a/internal/daemon/setup_executor_preflight_test.go
+++ b/internal/daemon/setup_executor_preflight_test.go
@@ -40,7 +40,7 @@ func runSetupPreflight(ctx context.Context, opts setuppreflight.Options) (*setup
 	return setuppreflight.Run(ctx, opts)
 }
 
-// TestSetupPreflightRunsBeforeAcceptanceSkeletonAndExecutor proves AC2: the
+// TestSetupPreflightSequencesBeforeSkeletonAndExecutor proves AC2: the
 // setup preflight runs after worktree/input-file preparation and before any
 // acceptance skeleton work or implementation executor attempt. The setup
 // executor runner stub records its observed order vs the daemon-level
@@ -484,8 +484,7 @@ func TestSetupPreflightAtomicProfileRewriteAndSecondRunSeededReuse(t *testing.T)
 	dir := t.TempDir()
 	// Profile without setup; includes unrelated content that must survive the
 	// atomic rewrite. pr.base is intentionally written as an unquoted scalar
-	// so the round-trip check below proves the YAML node style is preserved
-	// (a previous regression re-quoted it on rewrite).
+	// so the round-trip check below proves the YAML node style is preserved.
 	envBody := `id: "absent-setup"
 cwd: ` + workdirQuote(work) + `
 commands:
@@ -754,14 +753,11 @@ func workdirQuote(s string) string {
 }
 
 // TestSetupPreflightReadyWithoutSuccessfulCommandsFailsAndKeepsEnvironmentUnchanged
-// is the regression test for the setup-result contract update: a setup
+// pins the setup-result contract: a setup
 // executor that returns status=ready with no successful_commands cannot
 // produce a learned plan, so the daemon must downgrade the result to failed
 // (with repair guidance), keep setup_result.json diagnostic, and NOT silently
-// leave environment.yaml unchanged behind a fake-passing setup. The previous
-// behavior silently skipped persistence and treated the result as ready,
-// which violated AC7's "environment.yaml is not silently left unchanged"
-// invariant.
+// leave environment.yaml unchanged behind a fake-passing setup.
 func TestSetupPreflightReadyWithoutSuccessfulCommandsFailsAndKeepsEnvironmentUnchanged(t *testing.T) {
 	work := t.TempDir()
 	runDir := t.TempDir()
@@ -815,7 +811,7 @@ pr:
 		t.Fatalf("update should be nil when no learned plan can be persisted: %+v", update)
 	}
 	// environment.yaml must be byte-identical: not silently left unchanged
-	// behind a ready+empty-plan facade. The contract is "no silent unchanged".
+	// behind a ready+empty-plan facade.
 	after, err := os.ReadFile(envPath)
 	if err != nil {
 		t.Fatal(err)
@@ -908,9 +904,9 @@ func TestEnforceLearnedSetupPlanContractRequiresReadyEvidence(t *testing.T) {
 // against it: required keys are present, no extra keys leak (the schema is
 // additionalProperties:false), and enum-constrained fields (status, source,
 // provider, per-command source) carry values from the schema's enum lists.
-// This pins the schema/runtime sync the previous contract drift would have
-// allowed (the runtime persisted provider/source fields that the published
-// schema did not declare).
+// This pins the schema/runtime sync: the runtime persists provider/source
+// fields, so the published schema must declare them, guarding against drift
+// where the two disagree.
 func TestSetupResultSchemaMatchesPersistedShape(t *testing.T) {
 	runDir := t.TempDir()
 	res := &setuppreflight.Result{
@@ -951,10 +947,9 @@ func TestSetupResultSchemaMatchesPersistedShape(t *testing.T) {
 	if errs := validateAgainstSchemaForTest(saved, schema, "$"); len(errs) > 0 {
 		t.Fatalf("saved setup_result.json does not match schema:\n  %s", strings.Join(errs, "\n  "))
 	}
-	// Also assert the schema declares the runtime-persisted fields the
-	// previous contract drift omitted (provider, source). This guards future
-	// drift where someone removes one of them from the schema without also
-	// removing it from the Go struct.
+	// Also assert the schema declares the runtime-persisted provider and
+	// source fields. This guards future drift where someone removes one of
+	// them from the schema without also removing it from the Go struct.
 	props, _ := schema["properties"].(map[string]any)
 	for _, requiredKey := range []string{"provider", "source", "successful_commands", "inspected_files", "readiness_evidence", "repair_guidance", "error"} {
 		if _, ok := props[requiredKey]; !ok {

--- a/internal/daemonctl/child_windows_test.go
+++ b/internal/daemonctl/child_windows_test.go
@@ -20,12 +20,11 @@ func TestTerminateChildProcessWindowsNilIsNoOp(t *testing.T) {
 }
 
 // TestTerminateChildProcessWindowsTerminatesLivingProcess covers the
-// Windows branch of the cross-platform start-cleanup helper. The pre-fix
-// path called `process.Signal(syscall.SIGTERM)`, which returned
-// "not supported by windows" and left the child running after a failed
-// `galley daemon start`. The helper must instead invoke `Process.Kill`
-// (TerminateProcess) so the child is gone before the operator's start
-// command returns an error.
+// Windows branch of the cross-platform start-cleanup helper. Windows has no
+// SIGTERM equivalent (`process.Signal(syscall.SIGTERM)` returns
+// "not supported by windows" and leaves the child running), so the helper
+// must invoke `Process.Kill` (TerminateProcess) to ensure the child is gone
+// before a failed `galley daemon start` returns an error.
 func TestTerminateChildProcessWindowsTerminatesLivingProcess(t *testing.T) {
 	t.Parallel()
 	cmd := exec.Command("cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")

--- a/internal/daemonctl/control_windows.go
+++ b/internal/daemonctl/control_windows.go
@@ -21,8 +21,7 @@ const processQueryLimitedInformation = 0x1000
 
 // Alive reports whether pid exists by opening the process and inspecting its
 // exit code. Windows has no signal(0) equivalent: `process.Signal(Signal(0))`
-// surfaces a raw "not supported by windows" error from the Go runtime, which
-// is exactly the cross-platform regression this build-tagged path replaces.
+// surfaces a raw "not supported by windows" error from the Go runtime.
 func Alive(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -34,8 +34,8 @@ import (
 // best-effort and off the task-state critical path, so the timeout is short
 // enough to keep a slow or hanging notifier from holding daemon resources while
 // still allowing a real network delivery (Slack webhook, ntfy, email) to
-// complete. It is intentionally not operator-tunable in the first version to
-// keep the daemon.yaml surface small.
+// complete. It is intentionally not operator-tunable, to keep the daemon.yaml
+// surface small.
 const DefaultTimeout = 30 * time.Second
 
 // summaryMaxRunes bounds the latest-summary field. The bound is measured in

--- a/internal/preflight/skeleton/creator.go
+++ b/internal/preflight/skeleton/creator.go
@@ -44,9 +44,9 @@ type creatorManifest struct {
 }
 
 // resolveSkeletonDeclarations returns the skeleton outputs and no_skeletons
-// entries for the preflight stage. The first version always uses the built-in
-// test creator because the core value is reasoning from natural-language task
-// context and ACs into concrete test skeletons.
+// entries for the preflight stage. It always uses the built-in test creator
+// because the core value is reasoning from natural-language task context and
+// ACs into concrete test skeletons.
 func resolveSkeletonDeclarations(ctx context.Context, opts Options) ([]task.AcceptanceSkeletonOutputDef, []noSkeletonDeclaration, *preflightErr) {
 	return runBuiltinSkeletonCreator(ctx, opts)
 }
@@ -113,11 +113,8 @@ func buildBuiltinCreatorCommandPlan(opts Options, payload []byte) (runner.Comman
 }
 
 // buildClaudeCreatorCommandPlan builds the Claude provider creator command
-// plan. It preserves the established Claude creator behavior: the JSON guard
-// plugin, replace-mode system prompt, and bypassPermissions permission mode.
-// The task executor model and effort settings are propagated so the creator
-// run uses the same executor backend configuration as the implementation
-// attempt.
+// plan. Task executor model and effort are propagated so the creator run uses
+// the same executor backend configuration as the implementation attempt.
 func buildClaudeCreatorCommandPlan(opts Options, payload []byte) (runner.Command, *preflightErr) {
 	bin := opts.ClaudeBin
 	if bin == "" {

--- a/internal/preflight/skeleton/creator_codex.go
+++ b/internal/preflight/skeleton/creator_codex.go
@@ -1,17 +1,7 @@
 // Package skeleton contains Codex provider integration for the acceptance
-// skeleton creator.
-//
-// This file owns the Codex-specific creator concerns kept separate from the
-// Claude creator path so provider routing, runner integration, and Codex
-// manifest capture can be reviewed independently of the shared creator
-// orchestration in acceptance_skeleton_creator.go.
-//
-// The Codex creator runs through the same Codex command planner the
-// implementation executor uses (runner.CodexCommandPlan): the acceptance
-// skeleton prompt is delivered as the system prompt, the acceptance skeleton
-// manifest schema is wired through `codex exec --output-schema`, and the
-// structured manifest is captured from the attempt-scoped
-// `codex exec --output-last-message` file rather than stdout.
+// skeleton creator, kept separate from the Claude creator path so provider
+// routing, runner integration, and manifest capture can be reviewed
+// independently.
 package skeleton
 
 import (

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -49,8 +49,7 @@ func isTaskYAMLName(name string) bool {
 
 // taskYAMLFiles returns the task file glob matches (.yaml and .yml) directly
 // under dir, preserving filepath.Glob semantics (missing dir yields no matches,
-// non-regular entries are included exactly as the previous single-extension
-// glob did).
+// non-regular entries are included).
 func taskYAMLFiles(dir string) ([]string, error) {
 	var matches []string
 	for _, ext := range []string{"*.yaml", "*.yml"} {

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -309,8 +309,6 @@ func buildClaudeArgvWindows(opts ClaudeOptions) ([]string, string, []string, err
 		warnings = append(warnings, "Windows runner does not pass --json-schema on argv; Galley relies on the Claude guard hook and the executor result validators to reject malformed final output")
 	}
 	argv = append(argv, common.Suffix...)
-	// The work order prompt is delivered through stdin so Galley-generated
-	// long content does not reach argv on Windows.
 	return argv, opts.Prompt, warnings, nil
 }
 

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -229,8 +229,6 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 			return nil, err
 		}
 		args = append(args, "--system-prompt-file", systemPromptPath)
-		// JSON schema is intentionally not passed on argv on Windows; verdict
-		// validators in ValidateVerdictForEvidence reject malformed output.
 	} else {
 		schema, err := runner.ClaudeCompatibleJSONSchema(schemas.SupervisorVerdict)
 		if err != nil {

--- a/internal/task/archive.go
+++ b/internal/task/archive.go
@@ -47,9 +47,8 @@ type WorktreeCleanupResult struct {
 // overwriting an existing destination. Archive prioritizes removing the file
 // from normal operational scans whenever the move is safe:
 //
-//  1. When the task YAML loads, archive keeps the historical behavior: it sets
-//     status to "archived", appends an audit attempt, and writes the updated
-//     YAML at the archived path.
+//  1. When the task YAML loads, archive sets status to "archived", appends an
+//     audit attempt, and writes the updated YAML at the archived path.
 //  2. When loading fails but the file still parses as a YAML mapping, archive
 //     falls back to a yaml.Node round-trip that only updates the top-level
 //     `status` field. No attempt is appended because the file cannot be safely

--- a/internal/task/codex_executor_cli_test.go
+++ b/internal/task/codex_executor_cli_test.go
@@ -9,7 +9,7 @@ package task
 //   - Process: validateExecutor (internal/task/validate.go) and the executor
 //     schema enumeration (internal/task/schema.go) accept both "claude" and
 //     "codex" while rejecting unknown values.
-//   - Observable result: ValidationResult.OK==true for both supported CLIs;
+//   - Observable result: ValidationResult.Valid()==true for both supported CLIs;
 //     the generated executor schema (under schemas/) lists both values in the
 //     "cli" enum; an unknown CLI ("opus-cli") still fails with a clear error.
 

--- a/internal/task/load.go
+++ b/internal/task/load.go
@@ -70,28 +70,22 @@ func writeFileAtomicMode(path string, data []byte, perm os.FileMode, overwrite b
 		// Cross-platform no-overwrite publication boundary. The destination
 		// task YAML must appear atomically: a concurrently polling daemon
 		// must see either no file at all or the fully written/synced file.
-		// The previous hardlink-based primitive was replaced because
-		// `os.Link` used CreateHardLink on Windows and failed on
-		// filesystems without hardlink support (FAT32, ReFS, cross-volume
-		// temp dirs). A naive write directly to the destination with
-		// O_CREATE|O_EXCL preserved duplicate-destination protection but
-		// reintroduced a partial-publication window: the destination
-		// becomes visible immediately after open(), before the YAML bytes
-		// are written and synced, so a fast poller could load a truncated
-		// file and fail the task with a decode error.
+		// Hardlinks are unusable here: `os.Link` maps to CreateHardLink on
+		// Windows and fails on filesystems without hardlink support (FAT32,
+		// ReFS, cross-volume temp dirs). Writing directly to the destination
+		// with O_CREATE|O_EXCL keeps duplicate-destination protection but
+		// opens a partial-publication window: the destination becomes visible
+		// immediately after open(), before the YAML bytes are written and
+		// synced, so a fast poller could load a truncated file and fail the
+		// task with a decode error.
 		//
-		// The reservation-then-rename pattern below restores atomicity
-		// without hardlinks. A separate `<path>.lock` file created with
-		// O_CREATE|O_EXCL serializes publication for `path`, the YAML is
-		// written to a temp file in the same directory and fsynced, the
-		// final destination is re-checked while we hold the reservation,
-		// and `os.Rename` publishes the fully written file in a single
-		// step. Same-directory rename is atomic on every supported OS.
-		// The lock is removed only after a successful publication, so
-		// callers that observe a contended lock can safely retry: either
-		// the destination is now in place (treated as duplicate-
-		// destination by the caller surface) or the previous writer
-		// failed and the lock has been cleaned up.
+		// The reservation-then-rename pattern below achieves atomicity
+		// without hardlinks. Same-directory rename is atomic on every
+		// supported OS. The `<path>.lock` file is removed only after a
+		// successful publication, so callers that observe a contended lock
+		// can safely retry: either the destination is now in place (treated
+		// as duplicate-destination by the caller surface) or the previous
+		// writer failed and the lock has been cleaned up.
 		lockPath := path + ".lock"
 		lock, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {

--- a/internal/task/load_no_overwrite_test.go
+++ b/internal/task/load_no_overwrite_test.go
@@ -15,11 +15,9 @@ import (
 
 // TestWriteFileNoOverwriteAtomicCreatesAndRefuses covers the AC3 contract on
 // the no-overwrite write path that backs `task queue`, `task requeue`,
-// archive, and daemon claim/requeue file moves. Pre-fix, the implementation
-// used `os.Link` against a temp file which surfaced as a raw "not supported
-// by windows" error on filesystems that did not implement hardlinks. The
-// replacement primitive must (1) create the destination atomically and
-// (2) refuse to overwrite an existing destination on every supported OS.
+// archive, and daemon claim/requeue file moves. The primitive must (1) create
+// the destination atomically and (2) refuse to overwrite an existing
+// destination on every supported OS.
 func TestWriteFileNoOverwriteAtomicCreatesAndRefuses(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -55,16 +53,12 @@ func TestWriteFileNoOverwriteAtomicCreatesAndRefuses(t *testing.T) {
 
 // TestWriteFileNoOverwriteAtomicPublicationIsAtomic covers the queue
 // publication boundary that backs `task queue`, `task requeue`, archive, and
-// daemon claim/requeue file moves. The pre-fix implementation called
-// `os.OpenFile(path, O_CREATE|O_EXCL)` directly against the final destination,
-// which made the file visible to a concurrently polling daemon before the
-// YAML bytes were written and synced. A poller could then load a partial
-// file and fail the task with a YAML decode error. The fixed implementation
-// must publish only after the full contents are written, so a concurrent
-// reader that observes the destination either sees the complete payload or
-// `os.ErrNotExist`. The test runs many publish/observe pairs across
-// goroutines so a partial publication window is exercised by scheduling
-// jitter rather than relying on a fragile timing hook.
+// daemon claim/requeue file moves. Publication must happen only after the full
+// contents are written and synced, so a concurrent reader that observes the
+// destination either sees the complete payload or `os.ErrNotExist`, never a
+// partial file that fails with a YAML decode error. The test runs many
+// publish/observe pairs across goroutines so a partial publication window is
+// exercised by scheduling jitter rather than relying on a fragile timing hook.
 func TestWriteFileNoOverwriteAtomicPublicationIsAtomic(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -31,9 +31,9 @@ func normalizeLogicalPath(p string) string {
 }
 
 // logicalPathEscapes reports whether a slash-cleaned logical path is `..` or
-// starts with `../`. This is the separator-independent equivalent of the
-// previous `filepath.Clean` + `strings.HasPrefix(..., "../")` checks, which
-// silently passed on Windows because cleaned paths used `\` separators.
+// starts with `../`. It is separator-independent: a native `filepath.Clean` +
+// `strings.HasPrefix(..., "../")` check uses `\` separators on Windows and
+// misses `../` prefixes.
 func logicalPathEscapes(clean string) bool {
 	return clean == ".." || strings.HasPrefix(clean, "../")
 }
@@ -218,9 +218,8 @@ func validateWorktree(result *ValidationResult, t Task) {
 	require(result, t.Worktree.Path != "", "worktree.path is required for AFK tasks")
 	// Use isLogicalAbsolutePath so Windows-authored absolute worktree paths
 	// (`C:\repo.worktrees`, `\\share\worktrees`, `\foo`) are rejected even on
-	// non-Windows hosts. `filepath.IsAbs` is OS-specific and used to let those
-	// forms slip through to validateWorktreePath, which then reported a
-	// misleading sibling-path error.
+	// non-Windows hosts. `filepath.IsAbs` is OS-specific and misses these on
+	// Unix hosts.
 	if t.Worktree.Path != "" && isLogicalAbsolutePath(t.Worktree.Path) {
 		result.Errors = append(result.Errors, "worktree.path must be relative")
 	} else if t.Worktree.Path != "" {
@@ -229,11 +228,10 @@ func validateWorktree(result *ValidationResult, t Task) {
 }
 
 func validateWorktreePath(result *ValidationResult, path string) {
-	// Worktree paths are authored as logical (slash) relative paths. Cleaning
-	// natively on Windows produced backslash-prefixed strings, so the
-	// `"../"`/`"../../"` literal checks below never matched and rejected every
-	// otherwise valid sibling. Normalize to slash form first so the rule
-	// behaves the same on every OS.
+	// Worktree paths are authored as logical (slash) relative paths. Normalize
+	// to slash form first so the `"../"`/`"../../"` literal checks below behave
+	// the same on every OS; native Windows cleaning yields backslash separators
+	// that those checks would miss.
 	clean := normalizeLogicalPath(path)
 	if clean == ".." || strings.HasPrefix(clean, "../../") {
 		result.Errors = append(result.Errors, fmt.Sprintf("worktree.path contains parent traversal path %q", path))

--- a/internal/task/validate_windows_compat_test.go
+++ b/internal/task/validate_windows_compat_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 )
 
-// TestValidateWorktreePathAcceptsSeparatorVariants covers the Windows
-// regression where `filepath.Clean` produced `..\foo` and the
-// `strings.HasPrefix(clean, "../")` check rejected every otherwise-valid
-// sibling worktree.path on Windows. The normalized validator must accept
-// both `/` and `\` variants for the same logical sibling path on every OS.
+// TestValidateWorktreePathAcceptsSeparatorVariants checks that the validator
+// accepts both `/` and `\` variants of the same logical sibling worktree.path
+// on every OS; a native `filepath.Clean` + `strings.HasPrefix(clean, "../")`
+// check would reject the backslash form on Windows.
 func TestValidateWorktreePathAcceptsSeparatorVariants(t *testing.T) {
 	t.Parallel()
 	siblingPaths := []string{
@@ -37,8 +36,8 @@ func TestValidateWorktreePathAcceptsSeparatorVariants(t *testing.T) {
 
 // TestValidateWorktreePathRejectsInternalAndDeepParent confirms the same
 // validator still rejects repo-internal worktrees and deep parent traversal
-// regardless of separator. Pre-fix, the deep-parent rule used
-// `strings.HasPrefix(clean, "../../")` which silently passed on Windows.
+// regardless of separator, including the backslash form that a native
+// `strings.HasPrefix(clean, "../../")` check would miss on Windows.
 func TestValidateWorktreePathRejectsInternalAndDeepParent(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -69,13 +68,13 @@ func TestValidateWorktreePathRejectsInternalAndDeepParent(t *testing.T) {
 	}
 }
 
-// TestValidateRelativePathDetectsBackslashParentTraversal covers the related
-// AC2 regression: `validateRelativePath` (used by scope.allowed_paths,
+// TestValidateRelativePathDetectsBackslashParentTraversal covers the AC2
+// backslash case: `validateRelativePath` (used by scope.allowed_paths,
 // scope.forbidden_paths, files[].source/destination, and
-// preflight.acceptance_skeleton paths) only rejected `../` parent traversal.
-// On Windows `filepath.Clean("..\\foo")` returns `..\\foo`, so the old
-// `strings.HasPrefix(clean, "../")` check silently allowed parent traversal
-// for backslash inputs. After normalization the rule fires for both forms.
+// preflight.acceptance_skeleton paths) must reject parent traversal for both
+// `../` and `..\` forms. On Windows `filepath.Clean("..\\foo")` returns
+// `..\\foo`, so a `strings.HasPrefix(clean, "../")` check alone would miss the
+// backslash form.
 func TestValidateRelativePathDetectsBackslashParentTraversal(t *testing.T) {
 	t.Parallel()
 	task := validTask(t)
@@ -152,9 +151,6 @@ var windowsAbsoluteForms = []string{
 // that scope.allowed_paths, scope.forbidden_paths, files[].source,
 // files[].destination, and the preflight.acceptance_skeleton paths all reject
 // Windows-style absolute forms when the validator runs on a non-Windows host.
-// Before isLogicalAbsolutePath the only Windows form caught here was the UNC
-// `\\server\share` shape (because its slash form starts with `/`); drive
-// letter forms slipped past entirely on Unix.
 func TestValidateRelativePathRejectsWindowsAbsoluteFormsOnNonWindowsHost(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -248,10 +244,9 @@ func TestValidateRelativePathRejectsWindowsAbsoluteFormsOnNonWindowsHost(t *test
 }
 
 // TestValidateWorktreePathRejectsWindowsAbsoluteForms covers the worktree
-// absolute precheck. `filepath.IsAbs` used to gate this check, which missed
-// drive-letter absolutes on non-Windows hosts and let them fall through to
-// validateWorktreePath where they produced the misleading "must point to a
-// sibling path" error instead of the canonical "must be relative" error.
+// absolute precheck: drive-letter and other host-foreign absolute forms must
+// be rejected with the canonical "must be relative" error on non-Windows
+// hosts, not fall through to validateWorktreePath's sibling-path check.
 func TestValidateWorktreePathRejectsWindowsAbsoluteForms(t *testing.T) {
 	t.Parallel()
 	for _, p := range windowsAbsoluteForms {

--- a/internal/workspace/worktree_longpaths_test.go
+++ b/internal/workspace/worktree_longpaths_test.go
@@ -14,8 +14,8 @@ import (
 // AC7/AC8: workspace.Prepare, statusPorcelain, branch lookups, and
 // workspace.Remove all run through the shared runner.GitArgs argv wrapper,
 // so every captured invocation must carry `-c core.longpaths=true` even
-// when the operation itself is a worktree create or remove that previously
-// failed on Windows MAX_PATH boundaries.
+// when the operation itself is a worktree create or remove that can fail on
+// Windows MAX_PATH boundaries.
 
 func writeFakeGit(t *testing.T, dir, capturePath string) string {
 	t.Helper()
@@ -61,8 +61,8 @@ func assertLongpathsFlagPresent(t *testing.T, label string, lines []string) {
 // TestWorkspaceGitInvocationsCarryLongpathsFlag drives workspace.Prepare and
 // workspace.Remove through a capturing fake git and asserts every argv built
 // through the shared runner.GitArgs wrapper carries `-c core.longpaths=true`,
-// even for the worktree create/remove operations that previously failed on
-// Windows MAX_PATH boundaries.
+// even for the worktree create/remove operations that can fail on Windows
+// MAX_PATH boundaries.
 func TestWorkspaceGitInvocationsCarryLongpathsFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses POSIX shell fake git binary")


### PR DESCRIPTION
## Goal

Bring Galley's existing hand-written source comments into compliance with the repository's comment-quality policy without changing runtime behavior.

## Acceptance Criteria

- `AC1` The executor shall audit all tracked hand-written Go, Python, and shell source files and remove or concisely rewrite comments that restate code, duplicate nearby explanations, record chronological history, or over-explain implementation mechanics; generated and third-party code are excluded.
  - Verification: Provide file/line evidence for every changed comment and a repository-wide review against quality.yaml comment-quality; claim: known policy violations in the defined source scope are corrected; primary failure mode: verbose or redundant comments remain in an audited hand-written source file; boundary: tracked *.go, *.py, and *.sh files excluding generated and third-party code; state: existing comments -> repository-wide audit and edits -> no known comment-quality violation remains; residual: subjective cases must be reported with their disposition.
  - Status: satisfied
- `AC2` Comments that communicate non-obvious rationale, trade-offs, constraints, edge cases, or public contracts shall retain that information after the cleanup.
  - Verification: Provide representative file/line evidence for retained comments and explain why they remain; claim: cleanup preserves information that names, types, and control flow cannot express; primary failure mode: useful rationale or contract information is deleted or weakened; boundary: supervisor review of the final diff and retained-comment evidence; state: informative comments -> cleanup -> equivalent decision-relevant information remains; residual: none.
  - Status: satisfied
- `AC3` The task shall not change executable behavior, public APIs, CLI output, schemas, or runtime configuration; cases requiring naming or structural refactoring shall be left unchanged and reported as follow-up candidates.
  - Verification: Review the complete git diff for semantic changes and run every required check from the resolved quality profile; claim: the patch is comment-only in meaning and preserves accepted behavior; primary failure mode: executable or public-contract behavior changes during cleanup; boundary: final diff plus Galley-owned required-check results; state: accepted repository behavior -> comment cleanup -> the same behavior with all required checks passing; residual: reported refactoring candidates are outside this task.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `git diff (full line-by-line review of all 24 changed files)`: passed
- `git grep -iE 'pre-fix|first version|the fix (must|only|changes|replaced)|previous contract|contract update|this change removes|not operator-tunable in' -- '*.go' '*.py' '*.sh'`: passed
- `grep -n "ValidationResult.Valid()|ValidationResult.OK" internal/task/codex_executor_cli_test.go`: passed
- `grep -n "TestSetupPreflight..." internal/daemon/setup_executor_preflight_test.go`: passed
- `grep -n "codexLastMessagePath|func markRevisionRequestsAddressed" internal/daemon/loop.go internal/daemon/executor_result_resolver.go`: passed
- `grep -rnE "PR ?[0-9]+|PR#[0-9]+" --include=*.go internal cmd`: passed

## Key Decisions

- `D1` Should comments that require code restructuring to satisfy the policy be refactored in this task? -> No. Preserve the code and report those locations as follow-up candidates.
  - Rationale: Keeping this task semantically comment-only limits regression risk and keeps the repository-wide diff reviewable.
  - Reversibility: high
- `D2` Which source comments are in scope? -> Tracked hand-written Go, Python, and shell source files; exclude generated and third-party code.
  - Rationale: This covers Galley's implementation and operational scripts while avoiding edits to derived or externally owned content.
  - Reversibility: high
- `claude-decision-3` Should comments requiring code/naming restructuring to satisfy the policy be refactored here? -> No — left the code unchanged and recorded the locations (stale doc-comment function name at setup_executor_preflight_test.go, possibly-orphaned doc at loop.go, stale ValidationResult.OK reference in codex_executor_cli_test.go) as follow-up candidates.
  - Rationale: Follows prior decision D1: keeps the task semantically comment-only, limits regression risk, and keeps the repository-wide diff reviewable.
  - Reversibility: high
- `claude-decision-4` How to audit a repository-wide, judgment-based comment cleanup within the loop budget? -> Dispatched parallel per-directory subagents over disjoint subtrees applying the identical policy with strict comment-only guardrails, then personally reviewed the complete consolidated diff line-by-line and re-verified a borderline removal against the surviving doc comment.
  - Rationale: Parallelization made a 226-file audit tractable; a single consolidating human-style diff review provides the authoritative comment-only and AC2-preservation guarantee independent of any one agent's judgment.
  - Reversibility: high
- `claude-decision-5` Does this change need a CHANGELOG.md Unreleased entry? -> No entry added; recorded the changelog-dimension exemption.
  - Rationale: Code comments are not user-visible (no CLI, daemon, task/profile, plugin, skill, prompt, security, installer, or docs-workflow behavior changed), so per the changelog quality dimension this internal-only cleanup is exempt.
  - Reversibility: high
- `claude-decision-6` Should the acceptance-skeleton constraint block be restored or left deleted as the prior pass had it? -> Restore it in concise, timeless language covering completion, mixed-state timing, and assertion requirements.
  - Rationale: The task explicitly requires these constraints to remain explicit; they are an acceptance-skeleton contract, not disposable mechanics narration, so deleting them lost a real obligation. The temporal framing ('no existing test', 'replace the t.Fatal placeholder') was dropped while the obligations were preserved.
  - Reversibility: high
- `claude-decision-7` How far to extend 'rewrite remaining chronological comments' beyond the two named lines? -> Also rewrite five other genuinely chronological/version-relative comments (The fix…, first version x3, this change removes, contract update) and keep ~55 timeless subjective matches.
  - Rationale: The task says rewrite remaining chronological comments 'including' the two named, implying a broader set; only comments narrating code evolution or release-version scope were changed, while domain/lifecycle/standard-test-vocabulary/runtime-state terms were preserved to avoid over-editing.
  - Reversibility: high
- `claude-decision-8` Should the 'historical argv shape' comments (4 files) be reworded? -> Keep them.
  - Rationale: This is a consistently-used named design baseline (the canonical argv ordering that Windows intentionally diverges from), not narration of a past bug or iteration; rewording a cross-file established term risks inconsistency and the reviewer did not flag it.
  - Reversibility: high
  - Human review suggested: true
- `claude-decision-9` Which Arrange comments to remove in maintenance_polling_independence_test.go? -> Remove only the fully-redundant '// Arrange: Galley root + source repo.'; keep the other Arrange/Act/Assert comments.
  - Rationale: The task named 'the redundant Arrange narration'; the others carry substantive rationale (why the marker, why the open-PR task, why the fake gh log, the >=2-polls timing invariant).
  - Reversibility: high
- `claude-decision-10` Where should the orphaned codexLastMessagePath comment go — deleted from loop.go, or relocated? -> Relocated it verbatim to the real codexLastMessagePath declaration in internal/daemon/executor_result_resolver.go and removed it from loop.go.
  - Rationale: The task directs placing/rewriting the comment against its actual declaration. codexLastMessagePath lives in executor_result_resolver.go (referenced from loop.go:550) and had no doc comment; the orphaned text accurately describes its empty-for-Claude vs attempt-scoped-path behavior, so relocation preserves accurate documentation rather than discarding it.
  - Reversibility: high
- `claude-decision-11` Is editing internal/daemon/executor_result_resolver.go within scope? -> Edited it as required to place the loop.go orphaned comment against its actual declaration.
  - Rationale: The task explicitly authorizes placing the comment at its actual declaration, which resides in this file in the same internal/daemon package as the named loop.go; no evidence indicates this path is outside allowed scope, so no scope_expansion entry was recorded.
  - Reversibility: high
- `claude-decision-12` How should the timeless replacement comment be worded? -> "A representative ordinary long ASCII goal that fits within the byte budget without truncation."
  - Rationale: Preserves the supervisor's own phrasing ('representative ordinary long ASCII fixture') and describes what the fixture is and why it exists in terms of the test's own assertions (title unchanged, within prTitleByteBudget), with no time-bound PR provenance.
  - Reversibility: high
- `claude-decision-13` Should the sibling 'PR 18's goal' reference at line 35 also be rewritten? -> Left line 35 unchanged.
  - Rationale: The request precisely quoted 'PR 18's goal text', which is only line 40 (the fixture label). Line 35 is a distinct function-doc comment providing regression-guard rationale; rewriting it would exceed the narrowly named scope and could revert a deliberately retained rationale reference. Surfaced here so the approver can decide whether a follow-up timeless rewrite of line 35 is wanted.
  - Reversibility: high
  - Human review suggested: true
- `claude-decision-14` How should the pr_test.go comment be rewritten to be a concise timeless contract statement without PR-number provenance? -> Replaced the 4-line comment with a 3-line statement asserting an ordinary long ASCII goal within the byte budget is preserved verbatim without truncation and never gains an ellipsis; removed both the "PR 18's goal" reference and the "covers AC1"/regression-guard narration.
  - Rationale: Matches the requested example phrasing and the task's established audit standard (timeless contract wording, no change-history or ticket provenance). The "covers AC1" text is also provenance-style narration, so removing it keeps the comment purely about the contract while the assertions remain self-documenting.
  - Reversibility: high
- `claude-decision-15` Which comments should be retained despite matching provenance-idiom search patterns? -> Retained comments whose 'previous/originally/no longer/earlier/issue N' wording describes runtime state, schema shape, requirement traceability for an acceptance skeleton, or design rationale rather than code-change history (listed in AC2 evidence).
  - Rationale: The audit standard targets code-history/provenance narration, not all uses of these words; the retained cases describe timeless behavior or the skeleton's originating requirement.
  - Reversibility: high
  - Human review suggested: true

## Risks

- `R1` maintainability: Comment quality is judgment-based, so an exhaustive mechanical check cannot prove every borderline case.
  - Mitigation: Require repository-wide executor audit, file/line evidence, explicit disposition of subjective cases, and supervisor review against the resolved comment-quality dimension.
