### PR TITLE
Allow each repository to pin the model used by its built-in supervisor while preserving the selected supervisor CLI's default model when no override is configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Added
+
+- `environment.yaml` now accepts an optional `supervisor.model` that pins the exact model the repository's built-in supervisor runs. Galley passes the value through unchanged via the CLI's native `--model` option for the Codex, Claude, and GLM supervisor adapters; accepted values are whatever the selected provider CLI recognizes rather than a Galley-defined enum. When it is absent or empty, Galley omits `--model` and preserves the supervisor CLI default. Each run records the resolved model and its source (`environment_profile` or `cli_default`) in `runs/<run-id>/supervisor.json`.
+
 ## v0.9.2 - 2026-07-10
 
 ### Fixed

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -91,6 +91,7 @@ executor:
   default_cli: "codex"
 supervisor:
   default_cli: "codex"
+  model: "gpt-5-codex"
 required_checks:
   shell: "auto"
 constraints:
@@ -114,6 +115,7 @@ Supported fields:
 - `commands`: named local commands the executor and supervisor can reference.
 - `executor.default_cli`: optional implementation executor default for new task authoring. Values are `claude`, `codex`, and `glm`. `glm` runs the `claude` binary against GLM's Z.ai endpoint and needs a `glm_api_key` in `daemon.yaml`. When it is unset, new task authoring uses Claude unless the author explicitly chooses another backend. An explicit task YAML `executor.cli` remains authoritative for that task.
 - `supervisor.default_cli`: optional repository-scoped supervisor adapter. Values are `claude`, `codex`, and `glm`. When set, it overrides daemon startup supervisor settings for tasks in this repository.
+- `supervisor.model`: optional exact model the selected supervisor CLI runs for this repository. Galley passes the value through unchanged via the CLI's native `--model` option (Codex, Claude, and GLM), so accepted values are whatever the selected provider CLI recognizes rather than a Galley-defined enum. When it is absent or empty, Galley omits `--model` and the supervisor CLI uses its default model. Each run records the resolved model in `runs/<run-id>/supervisor.json` (`model` plus `model_source`, which is `environment_profile` when pinned and `cli_default` otherwise).
 - `required_checks.shell`: optional shell for Galley-owned `quality.required_checks` execution. Values are `auto`, `sh`, `bash`, `cmd`, `powershell`, and `pwsh`.
 - `required_checks.shell_path`: optional executable path override for required-check shell selection. When both `shell` and `shell_path` are set, `shell_path` wins.
 - `constraints.network`: local network policy.

--- a/examples/environment-local.yaml
+++ b/examples/environment-local.yaml
@@ -5,6 +5,13 @@ commands:
   build: "go build ./cmd/galley"
 executor:
   default_cli: "codex"
+# supervisor optionally pins the repository review supervisor and its model.
+# default_cli is one of claude, codex, or glm. model is an optional exact model
+# passed unchanged to that CLI's --model option; accepted values depend on the
+# selected provider CLI. Omit or leave model empty to keep the CLI default.
+# supervisor:
+#   default_cli: "codex"
+#   model: "gpt-5-codex"
 required_checks:
   # Use shell_path to pin a custom shell executable. Recognized executable
   # names such as bash, cmd.exe, powershell.exe, and pwsh.exe can stand alone;

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -96,7 +96,14 @@ type Options struct {
 	// daemon CLI wiring before Preflight and then overridden per task when an
 	// environment.yaml supervisor.default_cli wins for that task. The value is
 	// persisted to runs/<run-id>/supervisor.json as evidence.
-	SupervisorSource     string
+	SupervisorSource string
+	// SupervisorModel optionally pins the exact model the built-in supervisor
+	// adapter runs for a task. It is populated per task from the resolved
+	// environment profile's supervisor.model and passed through unchanged to the
+	// supervisor CLI's native --model option. An empty value preserves the
+	// supervisor CLI default. There is no daemon CLI flag for it: the override is
+	// repository-scoped configuration, not a runtime-tunable startup knob.
+	SupervisorModel      string
 	ShutdownTimeout      time.Duration
 	DisableClaudeGuard   bool
 	ClaudeGuardPluginDir string

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -105,6 +105,7 @@ func defaultSupervisorRunner(ctx context.Context, opts Options, evidence supervi
 		ArtifactDir:  tryDir,
 		ClaudeBin:    opts.ClaudeBin,
 		CodexBin:     opts.CodexBin,
+		Model:        opts.SupervisorModel,
 		GLMAuthToken: opts.GLMAuthToken,
 	}, evidence)
 }
@@ -503,15 +504,33 @@ func attemptsLeft(budget, attempt int) int {
 	return budget - attempt
 }
 
+// Supervisor model evidence labels. Persisted in run evidence so AFK users and
+// later agents can tell whether a review used a repository-pinned model or the
+// supervisor CLI's own default without re-deriving it from the profile.
+const (
+	SupervisorModelSourceProfile    = "environment_profile"
+	SupervisorModelSourceCLIDefault = "cli_default"
+)
+
 // writeSupervisorEvidence persists the resolved supervisor and its source for
 // a run so reviewers can verify which precedence layer (repository
 // environment profile, CLI startup flag, daemon.yaml, or built-in default)
-// determined the supervisor adapter Galley used. The function is
-// extracted from runSupervisorLoop so it can be unit-tested without driving a
-// full task through the daemon loop.
+// determined the supervisor adapter Galley used. It also records the resolved
+// supervisor model and its source so an explicitly pinned model is
+// observable and distinguishable from letting the supervisor CLI pick its
+// default: `model` is the exact pinned value (empty when none is pinned) and
+// `model_source` is "environment_profile" only when a model was pinned. The
+// function is extracted from runSupervisorLoop so it can be unit-tested without
+// driving a full task through the daemon loop.
 func writeSupervisorEvidence(runDir string, effectiveOpts Options) error {
+	modelSource := SupervisorModelSourceCLIDefault
+	if effectiveOpts.SupervisorModel != "" {
+		modelSource = SupervisorModelSourceProfile
+	}
 	return writeJSON(filepath.Join(runDir, "supervisor.json"), map[string]string{
-		"resolved": effectiveOpts.Supervisor,
-		"source":   effectiveOpts.SupervisorSource,
+		"resolved":     effectiveOpts.Supervisor,
+		"source":       effectiveOpts.SupervisorSource,
+		"model":        effectiveOpts.SupervisorModel,
+		"model_source": modelSource,
 	})
 }

--- a/internal/daemon/options_test.go
+++ b/internal/daemon/options_test.go
@@ -190,6 +190,109 @@ func TestWriteSupervisorEvidenceRecordsResolvedAndSource(t *testing.T) {
 	}
 }
 
+func TestEffectiveOptionsForProfilesAppliesRepoSupervisorModel(t *testing.T) {
+	t.Parallel()
+	// AC1: a repository supervisor.model resolves onto the effective daemon
+	// options unchanged so it can reach the supervisor adapter later. The model
+	// resolves independently of default_cli: pinning a model must not require
+	// also overriding the supervisor selection.
+	opts := Options{
+		Root:             t.TempDir(),
+		Supervisor:       "codex",
+		SupervisorSource: SupervisorSourceCLI,
+	}
+	effective := effectiveOptionsForProfiles(opts, profile.Bundle{
+		Environment: &profile.Environment{
+			Supervisor: &profile.SupervisorDefault{Model: "pinned-model-42"},
+		},
+	})
+	if effective.SupervisorModel != "pinned-model-42" {
+		t.Fatalf("supervisor model got %q, want pinned-model-42", effective.SupervisorModel)
+	}
+	// default_cli was not set in the profile, so supervisor selection is
+	// preserved from the CLI layer.
+	if effective.Supervisor != "codex" || effective.SupervisorSource != SupervisorSourceCLI {
+		t.Fatalf("supervisor selection changed unexpectedly: %q/%q", effective.Supervisor, effective.SupervisorSource)
+	}
+}
+
+func TestEffectiveOptionsForProfilesTreatsBlankSupervisorModelAsUnset(t *testing.T) {
+	t.Parallel()
+	// AC3: an absent or whitespace-only supervisor.model preserves the CLI
+	// default (empty SupervisorModel), so the adapter omits --model.
+	cases := map[string]*profile.SupervisorDefault{
+		"absent":          {DefaultCLI: "claude"},
+		"empty":           {Model: ""},
+		"whitespace-only": {Model: "   "},
+	}
+	for name, sup := range cases {
+		sup := sup
+		t.Run(name, func(t *testing.T) {
+			effective := effectiveOptionsForProfiles(Options{Root: t.TempDir()}, profile.Bundle{
+				Environment: &profile.Environment{Supervisor: sup},
+			})
+			if effective.SupervisorModel != "" {
+				t.Fatalf("%s: supervisor model got %q, want empty", name, effective.SupervisorModel)
+			}
+		})
+	}
+}
+
+func TestWriteSupervisorEvidenceRecordsPinnedModel(t *testing.T) {
+	t.Parallel()
+	// AC4: a pinned model is observable in run evidence and reported as coming
+	// from the environment profile rather than the CLI default.
+	runDir := t.TempDir()
+	if err := writeSupervisorEvidence(runDir, Options{
+		Supervisor:       "codex",
+		SupervisorSource: SupervisorSourceRepoProfile,
+		SupervisorModel:  "pinned-model-42",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := readSupervisorEvidence(t, runDir)
+	if got["model"] != "pinned-model-42" {
+		t.Fatalf("model got %q, want pinned-model-42", got["model"])
+	}
+	if got["model_source"] != SupervisorModelSourceProfile {
+		t.Fatalf("model_source got %q, want %s", got["model_source"], SupervisorModelSourceProfile)
+	}
+}
+
+func TestWriteSupervisorEvidenceRecordsCLIDefaultModel(t *testing.T) {
+	t.Parallel()
+	// AC4: an omitted model is not reported as pinned; the evidence records an
+	// empty model and a cli_default source so a default is distinguishable from
+	// a pin.
+	runDir := t.TempDir()
+	if err := writeSupervisorEvidence(runDir, Options{
+		Supervisor:       "claude",
+		SupervisorSource: SupervisorSourceDefault,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := readSupervisorEvidence(t, runDir)
+	if got["model"] != "" {
+		t.Fatalf("model got %q, want empty", got["model"])
+	}
+	if got["model_source"] != SupervisorModelSourceCLIDefault {
+		t.Fatalf("model_source got %q, want %s", got["model_source"], SupervisorModelSourceCLIDefault)
+	}
+}
+
+func readSupervisorEvidence(t *testing.T, runDir string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(runDir, "supervisor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
 func TestEffectiveOptionsForProfilesCleansWorktreesByDefault(t *testing.T) {
 	t.Parallel()
 	effective := effectiveOptionsForProfiles(Options{Root: t.TempDir()}, profile.Bundle{})

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/shinpr/galley/internal/fileutil"
 	"github.com/shinpr/galley/internal/galleyhome"
@@ -176,6 +177,7 @@ type effectiveTaskOptions struct {
 	CleanupWorktrees bool
 	Supervisor       string
 	SupervisorSource string
+	SupervisorModel  string
 }
 
 func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiveTaskOptions {
@@ -188,6 +190,7 @@ func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiv
 		CleanupWorktrees: true,
 		Supervisor:       opts.Supervisor,
 		SupervisorSource: opts.SupervisorSource,
+		SupervisorModel:  opts.SupervisorModel,
 	}
 	if profiles.Environment != nil {
 		env := profiles.Environment
@@ -201,6 +204,13 @@ func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiv
 		if env.Supervisor != nil && env.Supervisor.DefaultCLI != "" {
 			effective.Supervisor = env.Supervisor.DefaultCLI
 			effective.SupervisorSource = SupervisorSourceRepoProfile
+		}
+		// The supervisor model is resolved independently of default_cli: a
+		// repository can pin a model while leaving supervisor selection to
+		// daemon startup state. A whitespace-only value is treated as absent so
+		// it preserves the CLI default rather than forcing a malformed override.
+		if env.Supervisor != nil && strings.TrimSpace(env.Supervisor.Model) != "" {
+			effective.SupervisorModel = env.Supervisor.Model
 		}
 	}
 	if effective.OpenPR {
@@ -218,6 +228,7 @@ func (effective effectiveTaskOptions) apply(opts Options) Options {
 	opts.CleanupWorktrees = effective.CleanupWorktrees
 	opts.Supervisor = effective.Supervisor
 	opts.SupervisorSource = effective.SupervisorSource
+	opts.SupervisorModel = effective.SupervisorModel
 	return opts
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -93,8 +93,15 @@ type ExecutorDefault struct {
 // is set, the daemon uses it for that task even when daemon CLI startup
 // options, `daemon.yaml`, or the built-in default would otherwise pick a
 // different supervisor. Allowed values are `claude`, `codex`, and `glm`.
+//
+// Model optionally pins the exact model the selected supervisor CLI runs for
+// this repository. Galley passes the value through unchanged via the CLI's
+// native `--model` option and does not validate it against an enum: model
+// availability depends on the provider account and CLI configuration. An
+// absent or empty value preserves the supervisor CLI's default model.
 type SupervisorDefault struct {
 	DefaultCLI string `yaml:"default_cli,omitempty" json:"default_cli,omitempty"`
+	Model      string `yaml:"model,omitempty" json:"model,omitempty"`
 }
 
 type RequiredCheckEnvironment struct {

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -76,6 +76,11 @@ func EnvironmentJSONSchema() ([]byte, error) {
 			"supervisor": object(
 				properties(map[string]any{
 					"default_cli": enumSchema(daemonconfig.SupervisorCLIs()),
+					// model has no enum: accepted values are whatever the selected
+					// provider CLI recognizes, so Galley cannot maintain an
+					// authoritative list. An empty string is allowed and preserves
+					// the CLI default, matching resolution's absent/empty handling.
+					"model": stringSchema("description", "Optional exact model the selected supervisor CLI runs for this repository, passed through unchanged via the CLI's native `--model` option. Accepted values are determined by the selected provider CLI, not by Galley. Absent or empty preserves the supervisor CLI's default model."),
 				}),
 			),
 			"required_checks": object(

--- a/internal/profile/schema_reference_test.go
+++ b/internal/profile/schema_reference_test.go
@@ -49,3 +49,41 @@ func TestGeneratedProfileSchemasMatchSkillReferences(t *testing.T) {
 	assertGeneratedSchemaMatchesReference(t, "quality", QualitySchemaPath, quality)
 	assertGeneratedSchemaMatchesReference(t, "environment", EnvironmentSchemaPath, environment)
 }
+
+func TestEnvironmentSchemaExposesSupervisorModelAsOptionalString(t *testing.T) {
+	t.Parallel()
+	// AC5: supervisor.model must appear as an optional free-form string, not a
+	// Galley-defined enum, so authors are not misled about its validation
+	// semantics. It must also stay outside the object's required list.
+	environment, err := EnvironmentJSONSchema()
+	if err != nil {
+		t.Fatalf("EnvironmentJSONSchema: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(environment, &doc); err != nil {
+		t.Fatalf("environment schema is invalid JSON: %v", err)
+	}
+	props := doc["properties"].(map[string]any)
+	supervisor := props["supervisor"].(map[string]any)
+	supProps := supervisor["properties"].(map[string]any)
+	model, ok := supProps["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("supervisor.model missing from environment schema: %v", supProps)
+	}
+	if model["type"] != "string" {
+		t.Fatalf("supervisor.model type got %v, want string", model["type"])
+	}
+	if _, hasEnum := model["enum"]; hasEnum {
+		t.Fatalf("supervisor.model must not define an enum: %v", model)
+	}
+	if _, hasDesc := model["description"]; !hasDesc {
+		t.Fatalf("supervisor.model must document its provider-defined semantics")
+	}
+	if req, ok := supervisor["required"]; ok {
+		for _, field := range req.([]any) {
+			if field == "model" {
+				t.Fatalf("supervisor.model must remain optional")
+			}
+		}
+	}
+}

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -34,6 +34,12 @@ type AdapterOptions struct {
 	ArtifactDir string
 	CodexBin    string
 	ClaudeBin   string
+	// Model, when non-empty, is passed through unchanged to the selected
+	// supervisor CLI's native --model option (Codex `exec` and Claude both
+	// accept --model). An empty value omits the option so the CLI uses its
+	// default model. Galley does not validate the value against an enum;
+	// availability is the provider CLI's responsibility.
+	Model string
 	// GLMAuthToken is the Z.ai token used when Provider is "glm". A glm
 	// supervisor is the Claude adapter pointed at GLM's endpoint, so it reuses
 	// the entire Claude review path and only redirects via the child env.
@@ -168,19 +174,26 @@ func runCodexAdapter(ctx context.Context, opts AdapterOptions, request []byte) (
 	if err := writeSupervisorFile(schemaPath, []byte(schemas.SupervisorVerdict)); err != nil {
 		return nil, err
 	}
+	argv := []string{
+		opts.CodexBin,
+		"exec",
+		"--cd", opts.WorkDir,
+		"--sandbox", "workspace-write",
+		"--json",
+		"--output-schema", schemaPath,
+		"--output-last-message", outPath,
+	}
+	// A pinned model is applied through Codex's native --model option and
+	// omitted entirely otherwise so Codex keeps its default. The positional "-"
+	// (read prompt from stdin) stays last.
+	if opts.Model != "" {
+		argv = append(argv, "--model", opts.Model)
+	}
+	argv = append(argv, "-")
 	_, err = runner.RunCommand(ctx, runner.Command{
 		WorkDir: opts.WorkDir,
-		Argv: []string{
-			opts.CodexBin,
-			"exec",
-			"--cd", opts.WorkDir,
-			"--sandbox", "workspace-write",
-			"--json",
-			"--output-schema", schemaPath,
-			"--output-last-message", outPath,
-			"-",
-		},
-		Stdin: prompt,
+		Argv:    argv,
+		Stdin:   prompt,
 	}, runner.RunOptions{Timeout: opts.Timeout, IdleTimeout: opts.IdleTimeout, StdoutPath: eventsPath})
 	if err != nil {
 		return nil, fmt.Errorf("codex supervisor failed: %w", err)
@@ -227,6 +240,13 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 		"--tools", "default",
 		"--disallowedTools", "Write,Edit,MultiEdit,NotebookEdit",
 		"--output-format", "text",
+	}
+	// A pinned model is applied through Claude's native --model option and
+	// omitted otherwise so Claude keeps its default. This path also serves the
+	// glm supervisor, which is this same Claude command redirected to GLM's
+	// endpoint, so a configured model reaches Claude and GLM identically.
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
 	}
 	if goos == "windows" {
 		systemPromptPath := filepath.Join(dir, ClaudeSupervisorSystemPromptFilename)

--- a/internal/supervisor/adapter_model_test.go
+++ b/internal/supervisor/adapter_model_test.go
@@ -1,0 +1,154 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// verdictJSON is a minimal accepted verdict the fake supervisor CLIs emit so
+// RunAdapterPayload returns without error and the test can assert only on argv.
+const verdictJSON = `{"status":"accepted","summary":"ok","acceptance_gaps":[],"reviewed_files":["README.md"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["checked"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"medium","next_work_order":""}`
+
+// writeFakeCodex writes a codex stub that records argv and emits the verdict to
+// the --output-last-message path so runCodexAdapter reads a valid verdict.
+func writeFakeCodex(t *testing.T, capturePath string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "codex")
+	script := `#!/bin/sh
+printf '%s\n' "$*" > ` + capturePath + `
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+cat >/dev/null
+printf '%s\n' '` + verdictJSON + `' > "$out"
+printf '%s\n' '{"event":"done"}'
+`
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// writeFakeClaude writes a claude stub that records argv and emits the verdict
+// on stdout so both the claude and glm adapters can read a valid verdict.
+func writeFakeClaude(t *testing.T, capturePath string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "claude")
+	script := `#!/bin/sh
+printf '%s\n' "$*" > ` + capturePath + `
+cat >/dev/null
+printf '%s\n' '` + verdictJSON + `'
+`
+	if err := os.WriteFile(bin, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// AC2: each adapter includes the exact configured model exactly once through
+// the native --model option.
+func TestSupervisorAdaptersApplyConfiguredModelOnce(t *testing.T) {
+	skipPOSIXFakeSupervisorOnWindows(t)
+	const model = "pinned-model-42"
+	cases := []struct {
+		name  string
+		build func(t *testing.T, capture string) AdapterOptions
+	}{
+		{
+			name: "codex",
+			build: func(t *testing.T, capture string) AdapterOptions {
+				return AdapterOptions{Provider: "codex", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), CodexBin: writeFakeCodex(t, capture), Model: model}
+			},
+		},
+		{
+			name: "claude",
+			build: func(t *testing.T, capture string) AdapterOptions {
+				return AdapterOptions{Provider: "claude", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), ClaudeBin: writeFakeClaude(t, capture), Model: model}
+			},
+		},
+		{
+			name: "glm",
+			build: func(t *testing.T, capture string) AdapterOptions {
+				return AdapterOptions{Provider: "glm", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), ClaudeBin: writeFakeClaude(t, capture), GLMAuthToken: "zai-token", Model: model}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := filepath.Join(t.TempDir(), "args")
+			opts := tc.build(t, capture)
+			if _, err := RunAdapterPayload(context.Background(), opts, []byte(`{"evidence":{"task":{"id":"task"},"diff":""}}`)); err != nil {
+				t.Fatal(err)
+			}
+			args := readArgs(t, capture)
+			if !strings.Contains(args, "--model "+model) {
+				t.Fatalf("%s argv missing exact configured model:\n%s", tc.name, args)
+			}
+			if got := strings.Count(args, "--model"); got != 1 {
+				t.Fatalf("%s argv has %d --model options, want exactly 1:\n%s", tc.name, got, args)
+			}
+		})
+	}
+}
+
+// AC3: an omitted (or whitespace-only) model omits the --model option so each
+// adapter preserves the supervisor CLI default.
+func TestSupervisorAdaptersOmitModelWhenUnset(t *testing.T) {
+	skipPOSIXFakeSupervisorOnWindows(t)
+	cases := []struct {
+		name  string
+		model string
+		build func(t *testing.T, capture, model string) AdapterOptions
+	}{
+		{
+			name:  "codex-empty",
+			model: "",
+			build: func(t *testing.T, capture, model string) AdapterOptions {
+				return AdapterOptions{Provider: "codex", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), CodexBin: writeFakeCodex(t, capture), Model: model}
+			},
+		},
+		{
+			name:  "claude-empty",
+			model: "",
+			build: func(t *testing.T, capture, model string) AdapterOptions {
+				return AdapterOptions{Provider: "claude", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), ClaudeBin: writeFakeClaude(t, capture), Model: model}
+			},
+		},
+		{
+			name:  "glm-empty",
+			model: "",
+			build: func(t *testing.T, capture, model string) AdapterOptions {
+				return AdapterOptions{Provider: "glm", WorkDir: t.TempDir(), ArtifactDir: t.TempDir(), ClaudeBin: writeFakeClaude(t, capture), GLMAuthToken: "zai-token", Model: model}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := filepath.Join(t.TempDir(), "args")
+			opts := tc.build(t, capture, tc.model)
+			if _, err := RunAdapterPayload(context.Background(), opts, []byte(`{"evidence":{"task":{"id":"task"},"diff":""}}`)); err != nil {
+				t.Fatal(err)
+			}
+			args := readArgs(t, capture)
+			if strings.Contains(args, "--model") {
+				t.Fatalf("%s argv must omit --model when model is unset:\n%s", tc.name, args)
+			}
+		})
+	}
+}
+
+func readArgs(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/plugins/galley/skills/galley/references/environment.schema.json
+++ b/plugins/galley/skills/galley/references/environment.schema.json
@@ -160,6 +160,10 @@
             "glm"
           ],
           "type": "string"
+        },
+        "model": {
+          "description": "Optional exact model the selected supervisor CLI runs for this repository, passed through unchanged via the CLI's native `--model` option. Accepted values are determined by the selected provider CLI, not by Galley. Absent or empty preserves the supervisor CLI's default model.",
+          "type": "string"
         }
       },
       "type": "object"

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -19,6 +19,7 @@ Backend defaults are intentionally separate:
 
 - Implementation executor default: stored in `environment.yaml` as `executor.default_cli`; unset resolves to Claude when a new task is authored.
 - Review supervisor default: optionally stored in `environment.yaml` as `supervisor.default_cli`; unset falls back to daemon startup state and then Claude.
+- Review supervisor model: optionally stored in `environment.yaml` as `supervisor.model`; an exact model passed unchanged to the selected supervisor CLI's native `--model` option. Accepted values are whatever the provider CLI recognizes, not a Galley enum. Unset or empty keeps the supervisor CLI default.
 - Valid backends for either default are `claude`, `codex`, and `glm`. `glm` runs the Claude Code binary against GLM's Anthropic-compatible endpoint (Z.ai) and requires `glm_api_key` in `daemon.yaml`. The supervisor is the acceptance gate, so its default is the user's choice; the daemon default is `claude`.
 
 Use the bundled schemas as the profile field contract:


### PR DESCRIPTION
## Goal

Allow each repository to pin the model used by its built-in supervisor while preserving the selected supervisor CLI's default model when no override is configured.

## Acceptance Criteria

- `AC1` When `environment.yaml` specifies `supervisor.model`, Galley shall pass that exact value to every built-in supervisor evaluation for that repository.
  - Verification: Profile resolution and supervisor invocation tests; claim: the repository model override reaches the supervisor subprocess unchanged; primary failure mode: the value is ignored, replaced, or lost between profile loading and review; boundary: environment profile -> effective daemon options -> supervisor adapter; state: profile contains a model -> a task reaches review -> every supervisor try uses that model; residual: actual model availability remains the provider CLI's responsibility.
  - Status: satisfied
- `AC2` Galley shall apply a configured supervisor model through the native `--model <value>` option for Codex, Claude, and GLM supervisor adapters.
  - Verification: Focused argv tests for all three adapters; claim: each adapter includes the exact configured model once; primary failure mode: an adapter silently uses its default or emits a malformed/duplicate option; boundary: supervisor adapter command construction; state: each provider receives the same configured value -> command is built -> argv contains one matching `--model` pair; residual: none.
  - Status: satisfied
- `AC3` If `supervisor.model` is absent or empty, Galley shall omit the supervisor model option and preserve the current CLI-default behavior for Codex, Claude, and GLM.
  - Verification: Regression tests for all three supervisor adapters; claim: an omitted override does not change existing invocations; primary failure mode: Galley supplies an empty or hard-coded model; boundary: environment profile -> supervisor subprocess argv; state: no model is configured -> review starts -> argv contains no `--model` option; residual: none.
  - Status: satisfied
- `AC4` Supervisor run evidence shall identify an explicitly resolved model and shall distinguish it from using the supervisor CLI default.
  - Verification: Run-evidence tests for configured and omitted cases; claim: AFK users and later agents can determine which model setting governed review; primary failure mode: a pinned model is not observable or an omitted model is reported as pinned; boundary: effective supervisor settings -> persisted run evidence; state: configured and omitted reviews run -> evidence is written -> each records the correct model state; residual: none.
  - Status: satisfied
- `AC5` The generated environment profile schema, examples, Galley skill references, and operator documentation shall describe `supervisor.model` as an optional exact model override whose accepted values are determined by the selected provider CLI.
  - Verification: Schema generation/check, example profile validation, skill reference validation, and documentation review; claim: users and task-authoring agents can configure the feature without guessing its fallback or validation semantics; primary failure mode: the field is rejected, omitted from a contract surface, or presented as a Galley-defined enum; boundary: Go profile contract -> generated schemas/examples/docs; state: the field is added -> contract artifacts are regenerated -> all surfaces expose the same optional-string behavior; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go test ./...`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `./scripts/smoke-local.sh`: passed
- `GOOS=windows GOARCH=amd64 go test -exec=true ./internal/supervisor/ ./internal/daemon/ ./internal/profile/`: passed
- `python3 -m json.tool schemas/... plugins/... marketplace.json`: passed

## Key Decisions

- `D1` Which configuration surface owns the supervisor model override? -> Add optional `supervisor.model` to the repository `environment.yaml`; do not add a task YAML field or daemon CLI flag.
  - Rationale: Supervisor selection already supports a repository profile override, and this keeps the ordinary path repository-scoped without multiplying configuration precedence layers.
  - Reversibility: high
- `D2` How shall Galley validate supervisor model names? -> Accept any non-empty string and pass it unchanged to the selected provider CLI.
  - Rationale: Model availability depends on provider account and CLI configuration, so Galley cannot maintain an authoritative model enum.
  - Reversibility: high
- `claude-decision-3` How should the JSON schema and validation treat supervisor.model given AC3 requires empty to be a valid omitted case? -> Model is a plain string with no enum and no minLength; ValidateEnvironment adds no constraint, and resolution treats whitespace-only as absent.
  - Rationale: D2 mandates accepting any non-empty string with no Galley enum; allowing empty in the schema keeps schema validation consistent with AC3's absent/empty handling (a minLength would reject the documented empty case).
  - Reversibility: high
- `claude-decision-4` How should run evidence distinguish a pinned model from the CLI default (AC4)? -> Record two string fields in supervisor.json: `model` (exact pinned value or empty) and `model_source` (environment_profile when pinned, cli_default otherwise).
  - Rationale: Reuses the existing map[string]string evidence shape (backward compatible: existing resolved/source keys unchanged) and makes both the value and the pin-vs-default distinction explicit for AFK users and later agents.
  - Reversibility: high
- `claude-decision-5` Where should --model be placed in each adapter's argv? -> Codex: after the flag block and before the trailing positional '-'; Claude/GLM: appended after the base flags and before the goos-specific system-prompt handling.
  - Rationale: Keeps the existing argv shape intact, preserves Codex's stdin-positional contract, and ensures the flag applies on both the POSIX and Windows Claude paths (and to GLM which reuses the Claude command).
  - Reversibility: high

## Risks

- `R1` compatibility: Adding the model field could accidentally force an override for repositories that do not configure it.
  - Mitigation: Keep the field optional and cover omitted and empty values for every supervisor adapter.
