### PR TITLE
Align Galley's general environment-profile examples and LLM-facing profile-authoring template with the documented Claude default, while publishing the skill change through synchronized patch-versioned plugin manifests.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.21`: general environment-profile guidance (the shipped `environment-local.yaml` example, `docs/profiles.md`, and the profile-authoring skill template) now explicitly uses Claude for the backend defaults it presents — `executor.default_cli: "claude"`, plus `supervisor.default_cli: "claude"` in the `docs/profiles.md` example — so new task authoring selects Claude as the default backend instead of Codex.
+
 ## v0.9.2 - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows semantic versioning.
 
 ### Changed
 
-- Packaged Claude and Codex Galley plugins are now versioned as `0.1.21`: general environment-profile guidance (the shipped `environment-local.yaml` example, `docs/profiles.md`, and the profile-authoring skill template) now explicitly uses Claude for the backend defaults it presents — `executor.default_cli: "claude"`, plus `supervisor.default_cli: "claude"` in the `docs/profiles.md` example — so new task authoring selects Claude as the default backend instead of Codex.
+- Packaged Claude and Codex Galley plugins are now versioned as `0.1.21`. General environment-profile examples and authoring guidance now use Claude as the default executor and supervisor backend.
 
 ## v0.9.2 - 2026-07-10
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -88,9 +88,9 @@ commands:
   test_unit: "go test ./..."
   build: "go build ./cmd/galley"
 executor:
-  default_cli: "codex"
+  default_cli: "claude"
 supervisor:
-  default_cli: "codex"
+  default_cli: "claude"
 required_checks:
   shell: "auto"
 constraints:

--- a/examples/environment-local.yaml
+++ b/examples/environment-local.yaml
@@ -4,7 +4,7 @@ commands:
   test_unit: "go test ./..."
   build: "go build ./cmd/galley"
 executor:
-  default_cli: "codex"
+  default_cli: "claude"
 required_checks:
   # Use shell_path to pin a custom shell executable. Recognized executable
   # names such as bash, cmd.exe, powershell.exe, and pwsh.exe can stand alone;

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -43,7 +43,7 @@ func TestLoadAndValidateEnvironmentExample(t *testing.T) {
 	if env.Commands["test_unit"] == "" {
 		t.Fatalf("commands got %#v", env.Commands)
 	}
-	if env.Executor == nil || env.Executor.DefaultCLI != "codex" {
+	if env.Executor == nil || env.Executor.DefaultCLI != "claude" {
 		t.Fatalf("executor default got %#v", env.Executor)
 	}
 }

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -170,7 +170,7 @@ setup:
     - run: "<fresh worktree setup command>"
       why: "<why this prepares the worktree>"
 executor:
-  default_cli: "codex"
+  default_cli: "claude"
 constraints:
   network: "approval_required"
   secrets_policy: "never_read_env_files"


### PR DESCRIPTION
## Goal

Align Galley's general environment-profile examples and LLM-facing profile-authoring template with the documented Claude default, while publishing the skill change through synchronized patch-versioned plugin manifests.

## Acceptance Criteria

- `AC1` Galley's general environment-profile examples shall explicitly use `executor.default_cli: "claude"` in `examples/environment-local.yaml`, `docs/profiles.md`, and `plugins/galley/skills/galley/references/profile-authoring.md`; the general example in `docs/profiles.md` shall also use `supervisor.default_cli: "claude"`.
  - Verification: Focused file review; claim: every general-purpose profile example explicitly selects Claude for each backend default it shows; primary failure mode: a user or task-authoring LLM copies a general example that selects Codex; boundary: shipped example, documentation, and skill template; state: each general profile example is read -> executor and displayed supervisor defaults are identified -> each displayed default is exactly `claude`; residual: Codex-specific examples, explicit override tests, supported-value documentation, and historical CHANGELOG entries remain unchanged.
  - Status: satisfied
- `AC2` The profile-authoring skill change shall be limited to replacing the existing template value `executor.default_cli: "codex"` with `executor.default_cli: "claude"`; its workflow, questions, structure, and all other guidance shall remain unchanged.
  - Verification: Focused diff review of `plugins/galley/skills/galley/references/profile-authoring.md`; claim: the skill gives the LLM an explicit Claude default without unrelated prompt rewriting; primary failure mode: the change expands into new instructions, duplicated rationale, reordered workflow, or additional constraints; boundary: skill reference diff; state: existing skill reference -> one template scalar changes -> all unrelated lines remain unchanged; residual: none.
  - Status: satisfied
- `AC3` Because packaged skill content changes, `.claude-plugin/marketplace.json`, `plugins/galley/.claude-plugin/plugin.json`, and `plugins/galley/.codex-plugin/plugin.json` shall all advance from version `0.1.20` to `0.1.21`.
  - Verification: JSON inspection and plugin validation; claim: every version-bearing distribution surface publishes the updated skill under one synchronized patch version; primary failure mode: stale plugin caches or different versions between clients; boundary: Claude marketplace manifest and both plugin manifests; state: all three contain `0.1.20` -> skill changes -> all three contain exactly `0.1.21`; residual: `.agents/plugins/marketplace.json` has no version field and remains unchanged.
  - Status: satisfied
- `AC4` The Unreleased CHANGELOG shall state that packaged Claude and Codex Galley plugins are version `0.1.21` and that general environment-profile guidance now explicitly uses Claude for the backend defaults it presents.
  - Verification: CHANGELOG review; claim: the user-visible skill and packaged-plugin change is release-visible; primary failure mode: manifests advance without an explanation of the shipped guidance change; boundary: Unreleased CHANGELOG; state: plugin manifests advance -> release note is added -> version and reason agree; residual: historical entries remain unchanged.
  - Status: satisfied
- `AC5` The updated environment example, its contract tests, generated contracts, and both plugin packages shall remain valid, and every required check from the active Galley quality profile shall pass after the targeted guidance and version changes.
  - Verification: Run every command from the active quality profile, including `go test ./...`, `./scripts/smoke-local.sh`, both example profile validators, the task example validator, build, gofmt, schema check, and JSON validation, plus `claude plugin validate plugins/galley` and `claude plugin validate .`; claim: the targeted default and patch-version changes preserve all shipped contracts; primary failure mode: an edited example, its contract test, or a manifest remains inconsistent, or a required check is omitted; boundary: full repository test suite, profile and task validators, build, schema checker, plugin validators, smoke test, formatting, and JSON parser; state: files and the example expectation test are updated -> all repository required checks run -> all succeed with recorded evidence; residual: none.
  - Status: satisfied

## Final Verification

- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `claude plugin validate plugins/galley`: passed
- `claude plugin validate .`: passed
- `python3 -m json.tool for .claude-plugin/marketplace.json, plugins/galley/.claude-plugin/plugin.json, plugins/galley/.codex-plugin/plugin.json`: passed
- `<galley:setup:claude>`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool <9 schema/manifest files> >/dev/null`: passed
- `claude plugin validate plugins/galley && claude plugin validate .`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Should the general profile template omit `executor.default_cli` and rely on the runtime fallback? -> Keep the field explicit and set it to `claude`.
  - Rationale: The skill is operational guidance for an LLM, so an explicit value prevents the authoring agent from treating the executor choice as missing or inferring a different backend.
  - Reversibility: high
- `D2` Which Codex references should change? -> Change Codex values that act as backend defaults in general profile examples, including the displayed supervisor default in `docs/profiles.md`; preserve Codex-specific examples, explicit override tests, supported-value documentation, and historical CHANGELOG entries.
  - Rationale: Codex remains a supported explicit backend; the defect is stale default guidance, not Codex support.
  - Reversibility: high
- `claude-decision-3` Should supervisor.default_cli: "codex" in the docs/profiles.md example also be changed to claude? -> Change supervisor.default_cli from "codex" to "claude" in the general docs example.
  - Rationale: README identifies Claude as the supervisor default, and the general profile example should present the same default tone rather than retain a stale Codex-era value.
  - Reversibility: high
- `requeue-4` Why was this task requeued? -> Revise after supervisor review: align the general supervisor example with Claude, update the environment-example contract test, and pass every active quality-profile required check. The prior claude_guard_plugin failure was not reproducible; the confirmed regression is the stale Codex expectation in internal/profile/profile_test.go.
  - Rationale: A reviewer or PR comment requested another executor attempt.
  - Reversibility: high
- `claude-decision-5` Should the CHANGELOG entry be broadened beyond executor to reflect the displayed supervisor default change? -> Reworded the existing Unreleased entry to say Claude is used for the backend defaults presented, naming both executor.default_cli and the docs supervisor.default_cli.
  - Rationale: AC4 requires the note to state guidance now explicitly uses Claude for the backend defaults it presents (plural); the docs example now also sets supervisor.default_cli to claude, so the note must cover it to stay accurate.
  - Reversibility: high

## Risks

- `R1` scope: A prompt-cleanup pass could expand the skill diff beyond the stale default value.
  - Mitigation: Treat any unrelated change in `profile-authoring.md` as out of scope and fail AC2.
