### PR TITLE
Allow each repository to pin the model used by its built-in supervisor while preserving the selected supervisor CLI's default model when no override is configured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Added
+
+- Repository-scoped supervisor model override. `environment.yaml` now accepts an optional `supervisor.model` string that Galley forwards unchanged to the selected built-in supervisor CLI (`claude`, `codex`, or `glm`) through its native `--model` option for every supervisor evaluation of a task in that repository. It is resolved independently of `supervisor.default_cli`; accepted values are whatever the selected provider CLI accepts (Galley does not validate model availability); and when absent or empty the supervisor CLI keeps its own default model. `runs/<run-id>/supervisor.json` now also records `model` (empty when unpinned) and `model_source` (`environment_profile` or `cli_default`) so reviewers can tell a pinned model from the CLI default. The bundled `environment.schema.json` declares the new optional field.
+
 ### Changed
 
 - Packaged Claude and Codex Galley plugins are now versioned as `0.1.21`. General environment-profile examples and authoring guidance now use Claude as the default executor and supervisor backend.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -157,7 +157,9 @@ The `command` string is operator-owned. Task content is untrusted and is deliver
 3. The `supervisor` field in `daemon.yaml`.
 4. The built-in default (`claude`).
 
-`galley daemon status` omits startup defaults it cannot report accurately, such as effective supervisor and concurrency. The supervisor that actually ran a task is persisted to `runs/<run-id>/supervisor.json`.
+The supervisor model is a separate, optional repository setting: `environment.yaml` `supervisor.model` pins the exact model Galley forwards to the selected supervisor CLI's native `--model` option for every supervisor evaluation of a task in that repository. It is resolved independently of the supervisor CLI selection above, and when absent or empty the supervisor CLI uses its own default model.
+
+`galley daemon status` omits startup defaults it cannot report accurately, such as effective supervisor and concurrency. The supervisor that actually ran a task is persisted to `runs/<run-id>/supervisor.json`, including the resolved `model` (empty when unpinned) and a `model_source` of `environment_profile` or `cli_default` so reviewers can tell a pinned model from the supervisor CLI default.
 
 On Unix, foreground and background daemons use the same shutdown path. On `SIGINT` or `SIGTERM`, Galley stops claiming new queued tasks, lets active attempts finish until the shutdown timeout, records evidence, and avoids starting another retry attempt after shutdown is requested.
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -91,6 +91,7 @@ executor:
   default_cli: "claude"
 supervisor:
   default_cli: "claude"
+  # model: "claude-sonnet-4-5"  # optional exact model override; omit to use the CLI default
 required_checks:
   shell: "auto"
 constraints:
@@ -114,6 +115,7 @@ Supported fields:
 - `commands`: named local commands the executor and supervisor can reference.
 - `executor.default_cli`: optional implementation executor default for new task authoring. Values are `claude`, `codex`, and `glm`. `glm` runs the `claude` binary against GLM's Z.ai endpoint and needs a `glm_api_key` in `daemon.yaml`. When it is unset, new task authoring uses Claude unless the author explicitly chooses another backend. An explicit task YAML `executor.cli` remains authoritative for that task.
 - `supervisor.default_cli`: optional repository-scoped supervisor adapter. Values are `claude`, `codex`, and `glm`. When set, it overrides daemon startup supervisor settings for tasks in this repository.
+- `supervisor.model`: optional exact model override for the built-in supervisor. Galley passes the string unchanged to the selected supervisor CLI (`claude`, `codex`, or `glm`) through its native `--model` option for every supervisor evaluation of a task in this repository. The accepted values are whatever the selected provider CLI accepts — Galley does not validate model availability or maintain a model enum. When absent or empty, Galley omits the option and the supervisor CLI uses its own default model. This is independent of `supervisor.default_cli`: a repository can pin a model without also overriding the supervisor CLI. The resolved model (and whether it was pinned) is recorded in `runs/<run-id>/supervisor.json` as `model` and `model_source`.
 - `required_checks.shell`: optional shell for Galley-owned `quality.required_checks` execution. Values are `auto`, `sh`, `bash`, `cmd`, `powershell`, and `pwsh`.
 - `required_checks.shell_path`: optional executable path override for required-check shell selection. When both `shell` and `shell_path` are set, `shell_path` wins.
 - `constraints.network`: local network policy.

--- a/examples/environment-local.yaml
+++ b/examples/environment-local.yaml
@@ -5,6 +5,13 @@ commands:
   build: "go build ./cmd/galley"
 executor:
   default_cli: "claude"
+# supervisor pins the repository review backend and, optionally, its model.
+# default_cli overrides the daemon supervisor for this repository; model is an
+# exact override forwarded to the CLI's native --model option (omit to use the
+# supervisor CLI default). Both are optional and resolved independently.
+# supervisor:
+#   default_cli: "claude"
+#   model: "claude-sonnet-4-5"
 required_checks:
   # Use shell_path to pin a custom shell executable. Recognized executable
   # names such as bash, cmd.exe, powershell.exe, and pwsh.exe can stand alone;

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -96,7 +96,15 @@ type Options struct {
 	// daemon CLI wiring before Preflight and then overridden per task when an
 	// environment.yaml supervisor.default_cli wins for that task. The value is
 	// persisted to runs/<run-id>/supervisor.json as evidence.
-	SupervisorSource     string
+	SupervisorSource string
+	// SupervisorModel is the exact model name resolved from the repository
+	// environment profile's supervisor.model. Galley passes it unchanged to the
+	// built-in supervisor adapter's native --model option for every supervisor
+	// try of a task in that repository. Empty means no repository override, so
+	// the selected supervisor CLI uses its own default model. The value (and
+	// whether it was pinned) is persisted to runs/<run-id>/supervisor.json as
+	// review evidence.
+	SupervisorModel      string
 	ShutdownTimeout      time.Duration
 	DisableClaudeGuard   bool
 	ClaudeGuardPluginDir string
@@ -192,6 +200,14 @@ const (
 	SupervisorSourceCLI          = "cli"
 	SupervisorSourceDaemonConfig = "daemon_config"
 	SupervisorSourceDefault      = "default"
+)
+
+// Supervisor model source labels. Persisted in run evidence so reviewers and
+// AFK users can tell whether the supervisor ran on a model pinned by the
+// repository environment profile or on the supervisor CLI's own default.
+const (
+	SupervisorModelSourceRepoProfile = "environment_profile"
+	SupervisorModelSourceCLIDefault  = "cli_default"
 )
 
 // Run starts the daemon loop.

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -106,6 +106,7 @@ func defaultSupervisorRunner(ctx context.Context, opts Options, evidence supervi
 		ClaudeBin:    opts.ClaudeBin,
 		CodexBin:     opts.CodexBin,
 		GLMAuthToken: opts.GLMAuthToken,
+		Model:        opts.SupervisorModel,
 	}, evidence)
 }
 
@@ -510,8 +511,17 @@ func attemptsLeft(budget, attempt int) int {
 // extracted from runSupervisorLoop so it can be unit-tested without driving a
 // full task through the daemon loop.
 func writeSupervisorEvidence(runDir string, effectiveOpts Options) error {
+	// model records the exact repository-pinned supervisor model (empty when
+	// unpinned), and model_source distinguishes a pinned model from using the
+	// supervisor CLI default so an omitted model is never reported as pinned.
+	modelSource := SupervisorModelSourceCLIDefault
+	if effectiveOpts.SupervisorModel != "" {
+		modelSource = SupervisorModelSourceRepoProfile
+	}
 	return writeJSON(filepath.Join(runDir, "supervisor.json"), map[string]string{
-		"resolved": effectiveOpts.Supervisor,
-		"source":   effectiveOpts.SupervisorSource,
+		"resolved":     effectiveOpts.Supervisor,
+		"source":       effectiveOpts.SupervisorSource,
+		"model":        effectiveOpts.SupervisorModel,
+		"model_source": modelSource,
 	})
 }

--- a/internal/daemon/options_test.go
+++ b/internal/daemon/options_test.go
@@ -190,6 +190,86 @@ func TestWriteSupervisorEvidenceRecordsResolvedAndSource(t *testing.T) {
 	}
 }
 
+func TestWriteSupervisorEvidenceRecordsModelState(t *testing.T) {
+	t.Parallel()
+	// AC4: run evidence must identify an explicitly resolved supervisor model
+	// and distinguish a pinned model from using the supervisor CLI default so
+	// AFK users and later agents can tell which model setting governed review.
+	cases := []struct {
+		name            string
+		model           string
+		wantModel       string
+		wantModelSource string
+	}{
+		{name: "pinned model recorded", model: "provider-model-x", wantModel: "provider-model-x", wantModelSource: SupervisorModelSourceRepoProfile},
+		{name: "omitted model reported as cli default", model: "", wantModel: "", wantModelSource: SupervisorModelSourceCLIDefault},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runDir := t.TempDir()
+			if err := writeSupervisorEvidence(runDir, Options{
+				Supervisor:       "claude",
+				SupervisorSource: SupervisorSourceRepoProfile,
+				SupervisorModel:  tt.model,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(filepath.Join(runDir, "supervisor.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]string
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
+			if got["model"] != tt.wantModel || got["model_source"] != tt.wantModelSource {
+				t.Fatalf("supervisor evidence got model=%q model_source=%q; want %q/%q", got["model"], got["model_source"], tt.wantModel, tt.wantModelSource)
+			}
+			// The resolved supervisor and its source remain present so the
+			// added model fields extend, not replace, existing evidence.
+			if got["resolved"] != "claude" || got["source"] != SupervisorSourceRepoProfile {
+				t.Fatalf("supervisor evidence lost resolved/source: %#v", got)
+			}
+		})
+	}
+}
+
+func TestEffectiveSupervisorModelResolution(t *testing.T) {
+	t.Parallel()
+	// AC1: environment.yaml supervisor.model reaches effective daemon options
+	// unchanged, and it resolves independently of default_cli so a repository
+	// can pin a model without also overriding the supervisor CLI selection.
+	cases := []struct {
+		name       string
+		supervisor *profile.SupervisorDefault
+		base       Options
+		wantModel  string
+		wantCLI    string
+	}{
+		{name: "no supervisor block leaves model empty", supervisor: nil, base: Options{Supervisor: "claude", SupervisorSource: SupervisorSourceDefault}, wantModel: "", wantCLI: "claude"},
+		{name: "empty model omitted", supervisor: &profile.SupervisorDefault{Model: ""}, base: Options{Supervisor: "claude", SupervisorSource: SupervisorSourceDefault}, wantModel: "", wantCLI: "claude"},
+		{name: "model pinned without cli override", supervisor: &profile.SupervisorDefault{Model: "provider-model-x"}, base: Options{Supervisor: "codex", SupervisorSource: SupervisorSourceCLI}, wantModel: "provider-model-x", wantCLI: "codex"},
+		{name: "model and cli override together", supervisor: &profile.SupervisorDefault{DefaultCLI: "glm", Model: "glm-model-y"}, base: Options{Supervisor: "codex", SupervisorSource: SupervisorSourceCLI}, wantModel: "glm-model-y", wantCLI: "glm"},
+	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			bundle := profile.Bundle{Environment: &profile.Environment{}}
+			bundle.Environment.Supervisor = tt.supervisor
+			got := effectiveOptionsForProfiles(tt.base, bundle)
+			if got.SupervisorModel != tt.wantModel {
+				t.Fatalf("resolved supervisor model=%q; want %q", got.SupervisorModel, tt.wantModel)
+			}
+			if got.Supervisor != tt.wantCLI {
+				t.Fatalf("resolved supervisor cli=%q; want %q", got.Supervisor, tt.wantCLI)
+			}
+		})
+	}
+}
+
 func TestEffectiveOptionsForProfilesCleansWorktreesByDefault(t *testing.T) {
 	t.Parallel()
 	effective := effectiveOptionsForProfiles(Options{Root: t.TempDir()}, profile.Bundle{})

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -176,6 +176,7 @@ type effectiveTaskOptions struct {
 	CleanupWorktrees bool
 	Supervisor       string
 	SupervisorSource string
+	SupervisorModel  string
 }
 
 func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiveTaskOptions {
@@ -188,6 +189,7 @@ func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiv
 		CleanupWorktrees: true,
 		Supervisor:       opts.Supervisor,
 		SupervisorSource: opts.SupervisorSource,
+		SupervisorModel:  opts.SupervisorModel,
 	}
 	if profiles.Environment != nil {
 		env := profiles.Environment
@@ -198,9 +200,18 @@ func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiv
 		if env.Worktree.Cleanup != nil {
 			effective.CleanupWorktrees = *env.Worktree.Cleanup
 		}
-		if env.Supervisor != nil && env.Supervisor.DefaultCLI != "" {
-			effective.Supervisor = env.Supervisor.DefaultCLI
-			effective.SupervisorSource = SupervisorSourceRepoProfile
+		if env.Supervisor != nil {
+			if env.Supervisor.DefaultCLI != "" {
+				effective.Supervisor = env.Supervisor.DefaultCLI
+				effective.SupervisorSource = SupervisorSourceRepoProfile
+			}
+			// supervisor.model is resolved independently of default_cli: a
+			// repository may pin a model for whichever supervisor adapter runs
+			// (built-in default, CLI startup flag, daemon.yaml, or a repository
+			// default_cli override) without also overriding the CLI selection.
+			if env.Supervisor.Model != "" {
+				effective.SupervisorModel = env.Supervisor.Model
+			}
 		}
 	}
 	if effective.OpenPR {
@@ -218,6 +229,7 @@ func (effective effectiveTaskOptions) apply(opts Options) Options {
 	opts.CleanupWorktrees = effective.CleanupWorktrees
 	opts.Supervisor = effective.Supervisor
 	opts.SupervisorSource = effective.SupervisorSource
+	opts.SupervisorModel = effective.SupervisorModel
 	return opts
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -95,6 +95,14 @@ type ExecutorDefault struct {
 // different supervisor. Allowed values are `claude`, `codex`, and `glm`.
 type SupervisorDefault struct {
 	DefaultCLI string `yaml:"default_cli,omitempty" json:"default_cli,omitempty"`
+	// Model pins the exact model name Galley passes to the selected supervisor
+	// CLI through its native `--model` option for every built-in supervisor
+	// evaluation in this repository. It is an optional free-form string: Galley
+	// forwards it unchanged and does not maintain a model enum because model
+	// availability depends on the provider account and CLI configuration. When
+	// absent or empty, Galley omits the option so the supervisor CLI uses its
+	// own default model.
+	Model string `yaml:"model,omitempty" json:"model,omitempty"`
 }
 
 type RequiredCheckEnvironment struct {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -160,6 +160,73 @@ func TestValidateEnvironmentAcceptsSupervisorDefaultCLI(t *testing.T) {
 	}
 }
 
+func TestLoadEnvironmentDecodesSupervisorModel(t *testing.T) {
+	// The KnownFields(true) loader rejects unknown keys, so this proves
+	// supervisor.model is part of the environment contract and is forwarded as
+	// an exact free-form string with no Galley-side enum. An empty/omitted model
+	// stays absent (nil pointer only carries what YAML provided).
+	path := filepath.Join(t.TempDir(), "environment.yaml")
+	body := `id: local-dev
+cwd: /tmp/repo
+commands:
+  build: go build ./...
+supervisor:
+  model: "provider-model-x"
+constraints:
+  network: approval_required
+  secrets_policy: never_read_env_files
+  destructive_commands: deny
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env, err := LoadEnvironment(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.Supervisor == nil || env.Supervisor.Model != "provider-model-x" {
+		t.Fatalf("supervisor model got %#v", env.Supervisor)
+	}
+	if result := ValidateEnvironment(env); !result.Valid() {
+		t.Fatalf("model-only supervisor block must validate: %#v", result.Errors)
+	}
+}
+
+func TestLoadEnvironmentAcceptsExplicitEmptySupervisorModel(t *testing.T) {
+	// AC3 (profile-side): An explicit empty supervisor.model must round-trip
+	// through the loader and pass ValidateEnvironment. Galley treats an empty
+	// string the same as an omitted model (the supervisor CLI keeps its own
+	// default), so the explicit-empty YAML form must not be rejected.
+	path := filepath.Join(t.TempDir(), "environment.yaml")
+	body := `id: local-dev
+cwd: /tmp/repo
+commands:
+  build: go build ./...
+supervisor:
+  model: ""
+constraints:
+  network: approval_required
+  secrets_policy: never_read_env_files
+  destructive_commands: deny
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env, err := LoadEnvironment(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.Supervisor == nil {
+		t.Fatalf("supervisor block must decode even with an empty model: %#v", env.Supervisor)
+	}
+	if env.Supervisor.Model != "" {
+		t.Fatalf("supervisor model got %q, want empty", env.Supervisor.Model)
+	}
+	if result := ValidateEnvironment(env); !result.Valid() {
+		t.Fatalf("explicit-empty supervisor model must validate: %#v", result.Errors)
+	}
+}
+
 func TestValidateEnvironmentRejectsInvalidSupervisorDefault(t *testing.T) {
 	env := validEnvironmentForTest()
 	env.Supervisor = &SupervisorDefault{DefaultCLI: "opus"}

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -76,6 +76,7 @@ func EnvironmentJSONSchema() ([]byte, error) {
 			"supervisor": object(
 				properties(map[string]any{
 					"default_cli": enumSchema(daemonconfig.SupervisorCLIs()),
+					"model":       stringSchema("description", "Optional exact model name passed to the selected supervisor CLI through its native `--model` option. Accepted values are determined by the selected provider CLI; Galley forwards the string unchanged and does not validate model availability or maintain a model enum. When absent or empty, Galley omits the option and the supervisor CLI uses its own default model."),
 				}),
 			),
 			"required_checks": object(

--- a/internal/profile/schema_reference_test.go
+++ b/internal/profile/schema_reference_test.go
@@ -49,3 +49,34 @@ func TestGeneratedProfileSchemasMatchSkillReferences(t *testing.T) {
 	assertGeneratedSchemaMatchesReference(t, "quality", QualitySchemaPath, quality)
 	assertGeneratedSchemaMatchesReference(t, "environment", EnvironmentSchemaPath, environment)
 }
+
+// AC3 (schema): supervisor.model is documented as an optional override that
+// Galley omits when absent or empty. The environment schema must therefore
+// describe it as a plain free-form string with no minLength floor, so
+// supervisor.model: "" is structurally permitted rather than rejected. A
+// minLength: 1 here would conflict with the "absent or empty omits the option"
+// contract, so this regression guards against reintroducing it.
+func TestEnvironmentJSONSchemaAllowsEmptySupervisorModelStructurally(t *testing.T) {
+	t.Parallel()
+	data, err := EnvironmentJSONSchema()
+	if err != nil {
+		t.Fatalf("EnvironmentJSONSchema: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("environment schema is invalid JSON: %v", err)
+	}
+	props := schema["properties"].(map[string]any)
+	supervisor := props["supervisor"].(map[string]any)
+	supervisorProps := supervisor["properties"].(map[string]any)
+	model, ok := supervisorProps["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("supervisor.model must be present in the environment schema: %#v", supervisorProps)
+	}
+	if got := model["type"]; got != "string" {
+		t.Fatalf("supervisor.model type got %#v, want \"string\"", got)
+	}
+	if _, hasMin := model["minLength"]; hasMin {
+		t.Fatalf("supervisor.model must not declare minLength; empty string must stay structurally permitted: %#v", model)
+	}
+}

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -38,6 +38,11 @@ type AdapterOptions struct {
 	// supervisor is the Claude adapter pointed at GLM's endpoint, so it reuses
 	// the entire Claude review path and only redirects via the child env.
 	GLMAuthToken string
+	// Model is the exact model name Galley passes to the supervisor CLI through
+	// its native `--model` option. It is forwarded unchanged for every adapter
+	// (Codex, Claude, and GLM). Empty means Galley omits the option so the CLI
+	// uses its own default model.
+	Model string
 }
 
 // AdapterRequest is the JSON request consumed by built-in supervisor adapters.
@@ -168,19 +173,24 @@ func runCodexAdapter(ctx context.Context, opts AdapterOptions, request []byte) (
 	if err := writeSupervisorFile(schemaPath, []byte(schemas.SupervisorVerdict)); err != nil {
 		return nil, err
 	}
+	argv := []string{
+		opts.CodexBin,
+		"exec",
+		"--cd", opts.WorkDir,
+		"--sandbox", "workspace-write",
+		"--json",
+		"--output-schema", schemaPath,
+		"--output-last-message", outPath,
+	}
+	if opts.Model != "" {
+		argv = append(argv, "--model", opts.Model)
+	}
+	// `-` marks codex exec reading the prompt from stdin and must stay last.
+	argv = append(argv, "-")
 	_, err = runner.RunCommand(ctx, runner.Command{
 		WorkDir: opts.WorkDir,
-		Argv: []string{
-			opts.CodexBin,
-			"exec",
-			"--cd", opts.WorkDir,
-			"--sandbox", "workspace-write",
-			"--json",
-			"--output-schema", schemaPath,
-			"--output-last-message", outPath,
-			"-",
-		},
-		Stdin: prompt,
+		Argv:    argv,
+		Stdin:   prompt,
 	}, runner.RunOptions{Timeout: opts.Timeout, IdleTimeout: opts.IdleTimeout, StdoutPath: eventsPath})
 	if err != nil {
 		return nil, fmt.Errorf("codex supervisor failed: %w", err)
@@ -227,6 +237,12 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 		"--tools", "default",
 		"--disallowedTools", "Write,Edit,MultiEdit,NotebookEdit",
 		"--output-format", "text",
+	}
+	// glm reuses this Claude command (redirected via child env), so the native
+	// --model option applies to the Claude and GLM adapters alike; the value is
+	// a GLM model name when Provider is "glm".
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
 	}
 	if goos == "windows" {
 		systemPromptPath := filepath.Join(dir, ClaudeSupervisorSystemPromptFilename)

--- a/internal/supervisor/adapter_model_test.go
+++ b/internal/supervisor/adapter_model_test.go
@@ -1,0 +1,168 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSupervisorCLI writes a shell stub that records its argv to capturePath
+// and prints a minimal accepted verdict. The stub name (codex/claude) is the
+// caller's responsibility so a single helper serves every adapter.
+func fakeSupervisorCLI(t *testing.T, name, capturePath string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, name)
+	script := `#!/bin/sh
+printf '%s\n' "$*" > ` + capturePath + `
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat >/dev/null
+verdict='{"status":"accepted","summary":"ok","acceptance_gaps":[],"reviewed_files":["README.md"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["checked"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"medium","next_work_order":""}'
+if [ -n "$out" ]; then
+  printf '%s\n' "$verdict" > "$out"
+  printf '%s\n' '{"event":"done"}'
+else
+  printf '%s\n' "$verdict"
+fi
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// modelPair returns true when args contains the exact `--model <value>` option
+// exactly once, so a test can prove a single, well-formed option was emitted
+// rather than a duplicate or a malformed flag.
+func modelPair(args, value string) bool {
+	fields := strings.Fields(args)
+	count := 0
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] == "--model" && fields[i+1] == value {
+			count++
+		}
+	}
+	return count == 1 && strings.Count(args, "--model") == 1
+}
+
+// TestSupervisorAdaptersApplyConfiguredModel covers AC2: Codex, Claude, and GLM
+// each forward the configured model exactly once through the native
+// `--model <value>` option.
+func TestSupervisorAdaptersApplyConfiguredModel(t *testing.T) {
+	skipPOSIXFakeSupervisorOnWindows(t)
+	const model = "provider-model-x"
+	cases := []struct {
+		name     string
+		provider string
+		binName  string
+		opts     func(bin string) AdapterOptions
+	}{
+		{
+			name:     "codex",
+			provider: "codex",
+			binName:  "codex",
+			opts: func(bin string) AdapterOptions {
+				return AdapterOptions{Provider: "codex", CodexBin: bin, Model: model}
+			},
+		},
+		{
+			name:     "claude",
+			provider: "claude",
+			binName:  "claude",
+			opts: func(bin string) AdapterOptions {
+				return AdapterOptions{Provider: "claude", ClaudeBin: bin, Model: model}
+			},
+		},
+		{
+			name:     "glm",
+			provider: "glm",
+			binName:  "claude",
+			opts: func(bin string) AdapterOptions {
+				return AdapterOptions{Provider: "glm", ClaudeBin: bin, GLMAuthToken: "zai-token", Model: model}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			capturePath := filepath.Join(t.TempDir(), "args")
+			bin := fakeSupervisorCLI(t, tc.binName, capturePath)
+			opts := tc.opts(bin)
+			opts.WorkDir = t.TempDir()
+			opts.ArtifactDir = t.TempDir()
+			if _, err := RunAdapterPayload(context.Background(), opts, []byte(`{"evidence":{"task":{"id":"task"},"diff":""}}`)); err != nil {
+				t.Fatal(err)
+			}
+			args, err := os.ReadFile(capturePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !modelPair(string(args), model) {
+				t.Fatalf("%s args must include exactly one `--model %s`:\n%s", tc.name, model, args)
+			}
+		})
+	}
+}
+
+// TestSupervisorAdaptersOmitModelWhenUnset covers AC3: an omitted override
+// leaves the argv free of any `--model` option for all three adapters, so the
+// supervisor CLI keeps its own default model.
+func TestSupervisorAdaptersOmitModelWhenUnset(t *testing.T) {
+	skipPOSIXFakeSupervisorOnWindows(t)
+	cases := []struct {
+		name    string
+		binName string
+		opts    func(bin string) AdapterOptions
+	}{
+		{
+			name:    "codex",
+			binName: "codex",
+			opts:    func(bin string) AdapterOptions { return AdapterOptions{Provider: "codex", CodexBin: bin} },
+		},
+		{
+			name:    "claude",
+			binName: "claude",
+			opts:    func(bin string) AdapterOptions { return AdapterOptions{Provider: "claude", ClaudeBin: bin} },
+		},
+		{
+			name:    "glm",
+			binName: "claude",
+			opts: func(bin string) AdapterOptions {
+				return AdapterOptions{Provider: "glm", ClaudeBin: bin, GLMAuthToken: "zai-token"}
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			capturePath := filepath.Join(t.TempDir(), "args")
+			bin := fakeSupervisorCLI(t, tc.binName, capturePath)
+			opts := tc.opts(bin)
+			opts.WorkDir = t.TempDir()
+			opts.ArtifactDir = t.TempDir()
+			if _, err := RunAdapterPayload(context.Background(), opts, []byte(`{"evidence":{"task":{"id":"task"},"diff":""}}`)); err != nil {
+				t.Fatal(err)
+			}
+			args, err := os.ReadFile(capturePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(args), "--model") {
+				t.Fatalf("%s args must omit `--model` when no model is configured:\n%s", tc.name, args)
+			}
+		})
+	}
+}

--- a/plugins/galley/skills/galley/references/environment.schema.json
+++ b/plugins/galley/skills/galley/references/environment.schema.json
@@ -160,6 +160,10 @@
             "glm"
           ],
           "type": "string"
+        },
+        "model": {
+          "description": "Optional exact model name passed to the selected supervisor CLI through its native `--model` option. Accepted values are determined by the selected provider CLI; Galley forwards the string unchanged and does not validate model availability or maintain a model enum. When absent or empty, Galley omits the option and the supervisor CLI uses its own default model.",
+          "type": "string"
         }
       },
       "type": "object"

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -19,6 +19,7 @@ Backend defaults are intentionally separate:
 
 - Implementation executor default: stored in `environment.yaml` as `executor.default_cli`; unset resolves to Claude when a new task is authored.
 - Review supervisor default: optionally stored in `environment.yaml` as `supervisor.default_cli`; unset falls back to daemon startup state and then Claude.
+- Review supervisor model: optionally stored in `environment.yaml` as `supervisor.model`, an exact model override forwarded unchanged to the selected supervisor CLI's native `--model` option. Accepted values are whatever the selected provider CLI accepts; Galley does not validate them. It is independent of `supervisor.default_cli`, and when absent or empty the supervisor CLI uses its own default model.
 - Valid backends for either default are `claude`, `codex`, and `glm`. `glm` runs the Claude Code binary against GLM's Anthropic-compatible endpoint (Z.ai) and requires `glm_api_key` in `daemon.yaml`. The supervisor is the acceptance gate, so its default is the user's choice; the daemon default is `claude`.
 
 Use the bundled schemas as the profile field contract:


### PR DESCRIPTION
## Goal

Allow each repository to pin the model used by its built-in supervisor while preserving the selected supervisor CLI's default model when no override is configured.

## Acceptance Criteria

- `AC1` When `environment.yaml` specifies `supervisor.model`, Galley shall pass that exact value to every built-in supervisor evaluation for that repository.
  - Verification: Profile resolution and supervisor invocation tests; claim: the repository model override reaches the supervisor subprocess unchanged; primary failure mode: the value is ignored, replaced, or lost between profile loading and review; boundary: environment profile -> effective daemon options -> supervisor adapter; state: profile contains a model -> a task reaches review -> every supervisor try uses that model; residual: actual model availability remains the provider CLI's responsibility.
  - Status: satisfied
- `AC2` Galley shall apply a configured supervisor model through the native `--model <value>` option for Codex, Claude, and GLM supervisor adapters.
  - Verification: Focused argv tests for all three adapters; claim: each adapter includes the exact configured model once; primary failure mode: an adapter silently uses its default or emits a malformed/duplicate option; boundary: supervisor adapter command construction; state: each provider receives the same configured value -> command is built -> argv contains one matching `--model` pair; residual: none.
  - Status: satisfied
- `AC3` If `supervisor.model` is absent or empty, Galley shall omit the supervisor model option and preserve the current CLI-default behavior for Codex, Claude, and GLM.
  - Verification: Regression tests for all three supervisor adapters; claim: an omitted override does not change existing invocations; primary failure mode: Galley supplies an empty or hard-coded model; boundary: environment profile -> supervisor subprocess argv; state: no model is configured -> review starts -> argv contains no `--model` option; residual: none.
  - Status: satisfied
- `AC4` Supervisor run evidence shall identify an explicitly resolved model and shall distinguish it from using the supervisor CLI default.
  - Verification: Run-evidence tests for configured and omitted cases; claim: AFK users and later agents can determine which model setting governed review; primary failure mode: a pinned model is not observable or an omitted model is reported as pinned; boundary: effective supervisor settings -> persisted run evidence; state: configured and omitted reviews run -> evidence is written -> each records the correct model state; residual: none.
  - Status: satisfied
- `AC5` The generated environment profile schema, examples, Galley skill references, and operator documentation shall describe `supervisor.model` as an optional exact model override whose accepted values are determined by the selected provider CLI.
  - Verification: Schema generation/check, example profile validation, skill reference validation, and documentation review; claim: users and task-authoring agents can configure the feature without guessing its fallback or validation semantics; primary failure mode: the field is rejected, omitted from a contract surface, or presented as a Galley-defined enum; boundary: Go profile contract -> generated schemas/examples/docs; state: the field is added -> contract artifacts are regenerated -> all surfaces expose the same optional-string behavior; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml && ... --kind quality examples/quality-default.yaml`: passed
- `python3 -m json.tool on all schemas/plugins JSON files`: passed
- `./scripts/smoke-local.sh`: passed
- `GOOS=windows GOARCH=amd64 go build ./... && go vet ./internal/supervisor/ ./internal/daemon/ ./internal/profile/`: passed

## Key Decisions

- `D1` Which configuration surface owns the supervisor model override? -> Add optional `supervisor.model` to the repository `environment.yaml`; do not add a task YAML field or daemon CLI flag.
  - Rationale: Supervisor selection already supports a repository profile override, and this keeps the ordinary path repository-scoped without multiplying configuration precedence layers.
  - Reversibility: high
- `D2` How shall Galley validate supervisor model names? -> Accept any non-empty string and pass it unchanged to the selected provider CLI.
  - Rationale: Model availability depends on provider account and CLI configuration, so Galley cannot maintain an authoritative model enum.
  - Reversibility: high
- `executor-decision-3` Should an all-empty vs whitespace-only supervisor.model be treated as unset? -> Gate emission on `!= ""` (matching the executor runners' existing model handling); truly empty/absent omits the option.
  - Rationale: Consistent with internal/runner codex.go/claude.go which use `if opts.Model != ""`; keeps the value forwarded exactly as authored per D2 (accept any non-empty string). Whitespace handling was left to the provider CLI to avoid inventing Galley-side normalization.
  - Reversibility: high
- `executor-decision-4` How to represent the omitted-vs-pinned distinction in run evidence? -> Add `model` (empty when unpinned) plus `model_source` = environment_profile | cli_default to supervisor.json.
  - Rationale: AC4 requires distinguishing a pinned model from the CLI default; a separate source label makes the distinction explicit and unambiguous, and is additive/backward-compatible.
  - Reversibility: high
- `executor-decision-5` Should supervisor.model resolve independently of supervisor.default_cli? -> Yes — resolve model whenever env.Supervisor.Model is set, regardless of default_cli.
  - Rationale: AC1 says the model applies to every built-in supervisor evaluation for the repository; the model is orthogonal to which CLI runs, so a repo can pin a model without overriding the CLI selection.
  - Reversibility: high

## Risks

- `R1` compatibility: Adding the model field could accidentally force an override for repositories that do not configure it.
  - Mitigation: Keep the field optional and cover omitted and empty values for every supervisor adapter.
