### PR TITLE
Make quality review coverage supervisor-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.9.3 - 2026-07-11
+
 ### Changed
 
 - Packaged Claude and Codex plugins are now `0.1.22`. Environment-profile guidance uses Claude defaults and supports repository-pinned supervisor models through `supervisor.model`, with the effective setting recorded in run evidence.
+- Supervisor reviews now record quality-profile coverage by changed surface; findings drive required-dimension and weighted-score gates while executors focus on implementation and verification evidence.
 
 ## v0.9.2 - 2026-07-10
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,6 +41,8 @@ Attempt evidence includes:
 - `git_status.json`
 - `diff.patch`
 
+When the quality profile defines review dimensions, every supervisor verdict includes `quality_coverage` for each criterion and changed-surface pairing, with the repository evidence inspected. Galley requires coverage for every configured dimension and enforces the active pass policy from categorized findings before accepting.
+
 Galley also records `workspace.json` for the effective execution workspace and writes `profiles.json` when quality or environment profiles are loaded.
 
 ## Task Files

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -64,10 +64,11 @@ Supported fields:
 - `review_dimensions[].weight`: non-negative relative weight for reporting.
 - `review_dimensions[].required`: whether the dimension is mandatory.
 - `review_dimensions[].pass`: observable pass condition for the dimension.
+- When review dimensions are configured, the supervisor records `quality_coverage` for each criterion and changed-surface pairing, including the repository evidence inspected. Every configured dimension must appear, and findings categorized by dimension drive required-dimension and weighted-score policy.
 - `evidence_requirements.file_line_references`: ask for file/line evidence in review output.
 - `evidence_requirements.command_outputs`: ask for command output evidence.
 - `pass_policy.required_dimensions_must_pass`: require all mandatory dimensions to pass.
-- `pass_policy.min_score`: 0-100 score threshold.
+- `pass_policy.min_score`: 0-100 threshold over all configured dimension weights. A dimension contributes its weight when no finding uses its ID as `category`; total configured weight of zero scores 100.
 - `pass_policy.unresolved_high_findings_allowed`: number of unresolved high findings allowed.
 - `pass_policy.blocking_severities`: severities that block acceptance. Values are `critical`, `high`, `medium`, and `low`.
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -144,7 +144,7 @@ func TestRunOnceUsesModelSupervisorProvider(t *testing.T) {
 	repo := initDaemonGitRepo(t)
 	promptPath, schemaPath := writeDaemonPromptFiles(t)
 	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '{\"status\":\"completed\",\"summary\":\"done\",\"files_modified\":[\"daemon-output.txt\"],\"acceptance_criteria\":[{\"id\":\"AC1\",\"status\":\"satisfied\",\"evidence\":[\"diff\"],\"notes\":\"done\"}],\"verification\":[],\"scope_expansions\":[],\"decisions\":[],\"risks\":[]}'\n")
-	codexBin := writeFakeCodexSupervisor(t, `{"status":"accepted","summary":"codex accepted","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}`)
+	codexBin := writeFakeCodexSupervisor(t, `{"status":"accepted","summary":"codex accepted","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}`)
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -795,15 +795,15 @@ done
 if [ "$supervisor" = "1" ]; then
   request="$(cat)"
   if printf '%s' "$request" | grep -q '"status":"hard_stop"'; then
-    printf '%s\n' '{"status":"hard_stop","summary":"executor reported hard_stop","acceptance_gaps":[],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"high","category":"execution","file":"","summary":"executor reported hard_stop","blocks_acceptance":true}],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
+    printf '%s\n' '{"status":"hard_stop","summary":"executor reported hard_stop","acceptance_gaps":[],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"high","category":"execution","file":"","summary":"executor reported hard_stop","blocks_acceptance":true}],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
   elif printf '%s' "$request" | grep -q '"parse_error":"'; then
-    printf '%s\n' '{"status":"needs_revision","summary":"executor result was invalid","acceptance_gaps":["executor result JSON is invalid"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"verification","file":"","summary":"executor result JSON is invalid","blocks_acceptance":true}],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Return valid structured JSON and preserve any useful workspace changes."}'
+    printf '%s\n' '{"status":"needs_revision","summary":"executor result was invalid","acceptance_gaps":["executor result JSON is invalid"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"verification","file":"","summary":"executor result JSON is invalid","blocks_acceptance":true}],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Return valid structured JSON and preserve any useful workspace changes."}'
   elif printf '%s' "$request" | grep -q '"status":"completed_with_risks"'; then
-    printf '%s\n' '{"status":"needs_revision","summary":"executor reported risks","acceptance_gaps":["executor reported risks"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"verification","file":"","summary":"executor reported risks","blocks_acceptance":true}],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Resolve the reported risks and rerun verification."}'
+    printf '%s\n' '{"status":"needs_revision","summary":"executor reported risks","acceptance_gaps":["executor reported risks"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"verification","file":"","summary":"executor reported risks","blocks_acceptance":true}],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Resolve the reported risks and rerun verification."}'
   elif printf '%s' "$request" | grep -q '"diff_dirty":false'; then
-    printf '%s\n' '{"status":"needs_revision","summary":"no repository diff was produced","acceptance_gaps":["no repository diff was produced"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"acceptance","file":"","summary":"no repository diff was produced","blocks_acceptance":true}],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Make the required repository change and return valid structured JSON."}'
+    printf '%s\n' '{"status":"needs_revision","summary":"no repository diff was produced","acceptance_gaps":["no repository diff was produced"],"reviewed_files":[],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"acceptance","file":"","summary":"no repository diff was produced","blocks_acceptance":true}],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"Make the required repository change and return valid structured JSON."}'
   else
-    printf '%s\n' '{"status":"accepted","summary":"fake claude supervisor accepted","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
+    printf '%s\n' '{"status":"accepted","summary":"fake claude supervisor accepted","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
   fi
   exit 0
 fi

--- a/internal/daemon/loop_supervisor_retry_daemon_test.go
+++ b/internal/daemon/loop_supervisor_retry_daemon_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-const fakeSupervisorAcceptedVerdict = `{"status":"accepted","summary":"codex accepted after stall","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}`
+const fakeSupervisorAcceptedVerdict = `{"status":"accepted","summary":"codex accepted after stall","acceptance_gaps":[],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["diff"]}],"findings":[],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}`
 
 // writeStallThenAcceptCodexSupervisor returns a fake `codex` binary that, on
 // its first invocation, reads the request and then produces no stdout/stderr

--- a/internal/daemon/scheduling_test.go
+++ b/internal/daemon/scheduling_test.go
@@ -354,7 +354,7 @@ func TestShutdownStopsBeforeRetryAttempt(t *testing.T) {
 	promptPath, schemaPath := writeDaemonPromptFiles(t)
 	attemptLog := filepath.Join(t.TempDir(), "attempts.log")
 	claudeBin := writeFakeClaude(t, "echo attempt >> "+attemptLog+"\nsleep 0.05\necho change >> daemon-output.txt\necho '{\"status\":\"completed\",\"summary\":\"done\",\"files_modified\":[\"daemon-output.txt\"],\"acceptance_criteria\":[{\"id\":\"AC1\",\"status\":\"satisfied\",\"evidence\":[\"diff\"],\"notes\":\"done\"}],\"verification\":[],\"scope_expansions\":[],\"decisions\":[],\"risks\":[]}'\n")
-	codexBin := writeFakeCodexSupervisor(t, `{"status":"needs_revision","summary":"codex wants retry","acceptance_gaps":["retry"],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"acceptance","file":"daemon-output.txt","summary":"retry","blocks_acceptance":true}],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"try again"}`)
+	codexBin := writeFakeCodexSupervisor(t, `{"status":"needs_revision","summary":"codex wants retry","acceptance_gaps":["retry"],"reviewed_files":["daemon-output.txt"],"acceptance_evidence":[],"findings":[{"severity":"medium","category":"acceptance","file":"daemon-output.txt","summary":"retry","blocks_acceptance":true}],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":"try again"}`)
 	queueDir := filepath.Join(root, "tasks", "queued")
 	if err := os.MkdirAll(queueDir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -198,9 +198,12 @@ func ValidateQuality(q Quality) ValidationResult {
 			result.Errors = append(result.Errors, fmt.Sprintf("%s.preferred_commands is required when check is required", prefix))
 		}
 	}
+	dimensionIDs := make(map[string]bool, len(q.ReviewDimensions))
 	for i, dim := range q.ReviewDimensions {
 		prefix := fmt.Sprintf("review_dimensions[%d]", i)
 		require(&result, dim.ID != "", "%s.id is required", prefix)
+		require(&result, !dimensionIDs[dim.ID], "%s.id %q is duplicated", prefix, dim.ID)
+		dimensionIDs[dim.ID] = true
 		require(&result, dim.Weight >= 0, "%s.weight cannot be negative", prefix)
 		require(&result, dim.Pass != "", "%s.pass is required", prefix)
 	}

--- a/internal/runner/claude_guard_plugin/embed_test.go
+++ b/internal/runner/claude_guard_plugin/embed_test.go
@@ -175,6 +175,38 @@ func TestRequireFinalJSONRejectsInvalidScopeExpansionPath(t *testing.T) {
 	}
 }
 
+func TestRequireFinalJSONRejectsEmptySupervisorQualityEvidence(t *testing.T) {
+	dir, err := Ensure(filepath.Join(t.TempDir(), "guard"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := map[string]any{
+		"status": "accepted", "summary": "done", "acceptance_gaps": []any{}, "reviewed_files": []string{"file.go"},
+		"acceptance_evidence": []any{}, "findings": []any{}, "residual_risks": []any{}, "discussion_items": []any{}, "confidence": "high", "next_work_order": "",
+		"quality_coverage": []any{map[string]any{
+			"criterion": "criterion-a", "changed_surface": "changed-surface", "evidence_checked": []string{" "},
+		}},
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookInput, err := json.Marshal(map[string]string{"last_assistant_message": string(resultJSON)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := pythonCommand(t, filepath.Join(dir, "scripts", "require-final-json.py"))
+	cmd.Env = append(os.Environ(), "GALLEY_CLAUDE_GUARD_MODE=supervisor")
+	cmd.Stdin = strings.NewReader(string(hookInput))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("guard script failed: %v\n%s", err, output)
+	}
+	if got := string(output); !strings.Contains(got, `"decision": "block"`) || !strings.Contains(got, "evidence_checked must contain non-empty strings") {
+		t.Fatalf("expected quality evidence rejection, got %s", got)
+	}
+}
+
 func pythonCommand(t *testing.T, script string) *exec.Cmd {
 	t.Helper()
 	if runtime.GOOS != "windows" {

--- a/internal/runner/claude_guard_plugin/scripts/require-final-json.py
+++ b/internal/runner/claude_guard_plugin/scripts/require-final-json.py
@@ -23,6 +23,7 @@ SUPERVISOR_TEMPLATE = """{
   "acceptance_gaps": [],
   "reviewed_files": ["path/to/file.ext"],
   "acceptance_evidence": [{"ac_id": "AC1", "evidence": ["Concrete evidence from changed files or verification output."]}],
+  "quality_coverage": [{"criterion": "configured-dimension-id", "changed_surface": "path/or/contract", "evidence_checked": ["Repository evidence inspected for this criterion and surface."]}],
   "findings": [],
   "residual_risks": [],
   "discussion_items": [],
@@ -204,6 +205,7 @@ def validate_supervisor_verdict(verdict):
         "acceptance_gaps",
         "reviewed_files",
         "acceptance_evidence",
+        "quality_coverage",
         "findings",
         "residual_risks",
         "discussion_items",
@@ -218,6 +220,7 @@ def validate_supervisor_verdict(verdict):
     require_array(verdict["acceptance_gaps"], "acceptance_gaps")
     require_array(verdict["reviewed_files"], "reviewed_files")
     require_array(verdict["acceptance_evidence"], "acceptance_evidence")
+    validate_quality_coverage_shape(verdict["quality_coverage"])
     require_array(verdict["findings"], "findings")
     require_array(verdict["residual_risks"], "residual_risks")
     require_array(verdict["discussion_items"], "discussion_items")
@@ -267,6 +270,22 @@ def validate_supervisor_verdict(verdict):
         raise ValueError("accepted verdicts require medium or high confidence")
     if verdict["status"] != "accepted" and verdict["discussion_items"]:
         raise ValueError("discussion_items are only valid for accepted verdicts")
+
+
+def validate_quality_coverage_shape(coverage):
+    require_array(coverage, "quality_coverage")
+    for index, item in enumerate(coverage):
+        require_object(item, f"quality_coverage[{index}]")
+        for field in ["criterion", "changed_surface", "evidence_checked"]:
+            if field not in item:
+                raise ValueError(f"quality_coverage[{index}].{field} is required")
+        if not isinstance(item["criterion"], str) or not item["criterion"].strip():
+            raise ValueError(f"quality_coverage[{index}].criterion must be a non-empty string")
+        if not isinstance(item["changed_surface"], str) or not item["changed_surface"].strip():
+            raise ValueError(f"quality_coverage[{index}].changed_surface must be a non-empty string")
+        require_array(item["evidence_checked"], f"quality_coverage[{index}].evidence_checked")
+        if not item["evidence_checked"] or any(not isinstance(value, str) or not value.strip() for value in item["evidence_checked"]):
+            raise ValueError(f"quality_coverage[{index}].evidence_checked must contain non-empty strings")
 
 
 def validate_creator_manifest(manifest):

--- a/internal/runner/executor_result_contract_test.go
+++ b/internal/runner/executor_result_contract_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -38,5 +40,22 @@ func TestExecutorResultValidationUsesProviderNeutralVocabulary(t *testing.T) {
 	err := (ExecutorResult{}).Validate()
 	if err == nil || !strings.Contains(err.Error(), "executor result") || strings.Contains(err.Error(), "Claude") {
 		t.Fatalf("validation error = %v", err)
+	}
+}
+
+func TestExecutorResultSchemaLeavesQualityJudgmentToSupervisor(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile(filepath.Join("..", "..", "schemas", "claude-result.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := schema.Properties["quality_coverage"]; ok {
+		t.Fatalf("executor schema must not expose supervisor quality coverage")
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -13,11 +13,18 @@ type Verdict struct {
 	AcceptanceGaps     []string             `json:"acceptance_gaps,omitempty"`
 	ReviewedFiles      []string             `json:"reviewed_files,omitempty"`
 	AcceptanceEvidence []AcceptanceEvidence `json:"acceptance_evidence,omitempty"`
+	QualityCoverage    []QualityCoverage    `json:"quality_coverage"`
 	Findings           []Finding            `json:"findings,omitempty"`
 	ResidualRisks      []string             `json:"residual_risks,omitempty"`
 	DiscussionItems    []DiscussionItem     `json:"discussion_items,omitempty"`
 	Confidence         string               `json:"confidence,omitempty"`
 	NextWorkOrder      string               `json:"next_work_order,omitempty"`
+}
+
+type QualityCoverage struct {
+	Criterion       string   `json:"criterion"`
+	ChangedSurface  string   `json:"changed_surface"`
+	EvidenceChecked []string `json:"evidence_checked"`
 }
 
 // AcceptanceEvidence links one task or revision acceptance item to concrete evidence.

--- a/internal/supervisor/verdict_validation.go
+++ b/internal/supervisor/verdict_validation.go
@@ -19,6 +19,9 @@ func ValidateVerdict(verdict Verdict) error {
 	if verdict.Confidence == "" {
 		return fmt.Errorf("supervisor verdict confidence is required")
 	}
+	if verdict.QualityCoverage == nil {
+		return fmt.Errorf("supervisor verdict quality_coverage is required")
+	}
 	if verdict.Status == "needs_revision" && verdict.NextWorkOrder == "" {
 		return fmt.Errorf("needs_revision verdict requires next_work_order")
 	}
@@ -53,6 +56,10 @@ func ValidateVerdictForEvidence(verdict Verdict, evidence Evidence) error {
 	if err := ValidateVerdict(verdict); err != nil {
 		return err
 	}
+	requireCompleteCoverage := verdict.Status == "accepted" || verdict.Status == "needs_revision"
+	if err := validateQualityCoverage(verdict.QualityCoverage, evidence.Profiles.Quality, requireCompleteCoverage); err != nil {
+		return fmt.Errorf("supervisor verdict has invalid quality coverage: %w", err)
+	}
 	if verdict.Status != "accepted" && len(verdict.DiscussionItems) > 0 {
 		return fmt.Errorf("supervisor verdict discussion_items are only valid for accepted verdicts")
 	}
@@ -82,7 +89,110 @@ func ValidateVerdictForEvidence(verdict Verdict, evidence Evidence) error {
 	if missing := missingAcceptanceEvidence(verdict, evidence); len(missing) > 0 {
 		return fmt.Errorf("accepted supervisor verdict missing acceptance evidence for %s", strings.Join(missing, ", "))
 	}
+	if err := validateAcceptedQualityCoverage(verdict, evidence.Profiles.Quality); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateAcceptedQualityCoverage(verdict Verdict, quality *profile.Quality) error {
+	if quality == nil {
+		return nil
+	}
+	if quality.PassPolicy.RequiredDimensionsMustPass {
+		for _, dimension := range quality.ReviewDimensions {
+			if dimension.Required && hasQualityFinding(verdict.Findings, dimension.ID) {
+				return fmt.Errorf("accepted supervisor verdict failed required quality criterion %q", dimension.ID)
+			}
+		}
+	}
+	if score := qualityFindingScore(verdict.Findings, quality); score < quality.PassPolicy.MinScore {
+		return fmt.Errorf("accepted supervisor verdict quality score %d is below required minimum %d", score, quality.PassPolicy.MinScore)
+	}
+	return nil
+}
+
+func validateQualityCoverage(coverage []QualityCoverage, quality *profile.Quality, requireComplete bool) error {
+	dimensions := []profile.ReviewDimension(nil)
+	if quality != nil {
+		dimensions = quality.ReviewDimensions
+	}
+	if len(dimensions) == 0 {
+		if len(coverage) > 0 {
+			return fmt.Errorf("quality_coverage contains criteria but the quality profile has no review dimensions")
+		}
+		return nil
+	}
+	expected := make(map[string]bool, len(dimensions))
+	for _, dimension := range dimensions {
+		expected[dimension.ID] = true
+	}
+	seenCriteria := make(map[string]bool, len(dimensions))
+	seenPairs := make(map[string]bool, len(coverage))
+	for i, item := range coverage {
+		if !expected[item.Criterion] {
+			return fmt.Errorf("quality_coverage[%d].criterion %q is not configured", i, item.Criterion)
+		}
+		if strings.TrimSpace(item.ChangedSurface) == "" {
+			return fmt.Errorf("quality_coverage[%d].changed_surface is required", i)
+		}
+		if !nonEmptyStrings(item.EvidenceChecked) {
+			return fmt.Errorf("quality_coverage[%d].evidence_checked requires non-empty values", i)
+		}
+		pair := item.Criterion + "\x00" + item.ChangedSurface
+		if seenPairs[pair] {
+			return fmt.Errorf("quality_coverage contains duplicate criterion and changed_surface pair %q", item.Criterion+": "+item.ChangedSurface)
+		}
+		seenPairs[pair] = true
+		seenCriteria[item.Criterion] = true
+	}
+	if requireComplete {
+		for _, dimension := range dimensions {
+			if !seenCriteria[dimension.ID] {
+				return fmt.Errorf("quality_coverage missing criterion %q", dimension.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func nonEmptyStrings(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func qualityFindingScore(findings []Finding, quality *profile.Quality) int {
+	failed := make(map[string]bool, len(findings))
+	for _, finding := range findings {
+		failed[finding.Category] = true
+	}
+	total, passed := 0, 0
+	for _, dimension := range quality.ReviewDimensions {
+		total += dimension.Weight
+		if !failed[dimension.ID] {
+			passed += dimension.Weight
+		}
+	}
+	if total == 0 {
+		return 100
+	}
+	return passed * 100 / total
+}
+
+func hasQualityFinding(findings []Finding, criterion string) bool {
+	for _, finding := range findings {
+		if finding.Category == criterion {
+			return true
+		}
+	}
+	return false
 }
 
 func missingAcceptanceEvidence(verdict Verdict, evidence Evidence) []string {

--- a/internal/supervisor/verdict_validation_test.go
+++ b/internal/supervisor/verdict_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,14 +14,14 @@ import (
 )
 
 func TestValidateVerdictRejectsNeedsRevisionWithoutWorkOrder(t *testing.T) {
-	err := ValidateVerdict(Verdict{Status: "needs_revision", Summary: "gaps", Confidence: "high"})
+	err := ValidateVerdict(Verdict{Status: "needs_revision", Summary: "gaps", Confidence: "high", QualityCoverage: []QualityCoverage{}})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
 }
 
 func TestValidateVerdictRequiresConfidence(t *testing.T) {
-	err := ValidateVerdict(Verdict{Status: "accepted", Summary: "ok"})
+	err := ValidateVerdict(Verdict{Status: "accepted", Summary: "ok", QualityCoverage: []QualityCoverage{}})
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -39,17 +40,24 @@ func TestSupervisorVerdictSchemaStatusEnumMatchesValidator(t *testing.T) {
 		Properties map[string]struct {
 			Enum []string `json:"enum"`
 		} `json:"properties"`
+		Required []string `json:"required"`
 	}
 	if err := json.Unmarshal(data, &schema); err != nil {
 		t.Fatal(err)
 	}
+	if _, ok := schema.Properties["quality_coverage"]; !ok {
+		t.Fatalf("schema missing quality_coverage property")
+	}
+	if !slices.Contains(schema.Required, "quality_coverage") {
+		t.Fatalf("schema required = %v", schema.Required)
+	}
 	got := append([]string(nil), schema.Properties["status"].Enum...)
 	for _, status := range got {
-		if err := ValidateVerdict(Verdict{Status: status, Summary: "ok", Confidence: "high", NextWorkOrder: "work"}); err != nil && status != "needs_revision" {
+		if err := ValidateVerdict(Verdict{Status: status, Summary: "ok", Confidence: "high", NextWorkOrder: "work", QualityCoverage: []QualityCoverage{}}); err != nil && status != "needs_revision" {
 			t.Fatalf("validator rejected schema status %q: %v", status, err)
 		}
 		if status == "needs_revision" {
-			if err := ValidateVerdict(Verdict{Status: status, Summary: "ok", Confidence: "high", NextWorkOrder: "work"}); err != nil {
+			if err := ValidateVerdict(Verdict{Status: status, Summary: "ok", Confidence: "high", NextWorkOrder: "work", QualityCoverage: []QualityCoverage{}}); err != nil {
 				t.Fatalf("validator rejected needs_revision with work order: %v", err)
 			}
 		}
@@ -62,6 +70,7 @@ func TestValidateVerdictForEvidenceRejectsAcceptedWithoutRepositoryReview(t *tes
 		Summary:            "ok",
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		Confidence:         "high",
+		QualityCoverage:    []QualityCoverage{},
 	}, Evidence{
 		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		DiffDirty: true,
@@ -76,10 +85,11 @@ func TestValidateVerdictForEvidenceRejectsAcceptedWithoutRepositoryReview(t *tes
 
 func TestValidateVerdictForEvidenceRejectsAcceptedWithoutACEvidence(t *testing.T) {
 	err := ValidateVerdictForEvidence(Verdict{
-		Status:        "accepted",
-		Summary:       "ok",
-		ReviewedFiles: []string{"file.go"},
-		Confidence:    "high",
+		Status:          "accepted",
+		Summary:         "ok",
+		ReviewedFiles:   []string{"file.go"},
+		Confidence:      "high",
+		QualityCoverage: []QualityCoverage{},
 	}, Evidence{
 		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		DiffDirty: true,
@@ -92,6 +102,203 @@ func TestValidateVerdictForEvidenceRejectsAcceptedWithoutACEvidence(t *testing.T
 	}
 }
 
+func TestValidateVerdictForEvidenceRejectsAcceptedWithoutQualityCoverage(t *testing.T) {
+	t.Parallel()
+	err := ValidateVerdictForEvidence(Verdict{
+		Status:             "accepted",
+		Summary:            "ok",
+		ReviewedFiles:      []string{"file.go"},
+		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
+		Confidence:         "high",
+		QualityCoverage:    []QualityCoverage{},
+	}, Evidence{
+		Task: task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
+		Profiles: profile.Bundle{Quality: &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{
+			ID: "criterion-a", Weight: 1, Required: true,
+		}}}},
+		DiffDirty: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "criterion-a") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVerdictForEvidenceAcceptsCompleteQualityCoverage(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{
+		ReviewDimensions: []profile.ReviewDimension{
+			{ID: "criterion-a", Weight: 2, Required: true},
+			{ID: "criterion-b", Weight: 1, Required: true},
+		},
+		PassPolicy: profile.PassPolicy{RequiredDimensionsMustPass: true, MinScore: 100},
+	}
+	err := ValidateVerdictForEvidence(Verdict{
+		Status:             "accepted",
+		Summary:            "ok",
+		ReviewedFiles:      []string{"file.go"},
+		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
+		QualityCoverage: []QualityCoverage{
+			{Criterion: "criterion-a", ChangedSurface: "file.go", EvidenceChecked: []string{"criterion evidence"}},
+			{Criterion: "criterion-b", ChangedSurface: "final diff", EvidenceChecked: []string{"No narrower changed surface is governed by this criterion."}},
+		},
+		Confidence: "high",
+	}, Evidence{
+		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
+		Profiles:  profile.Bundle{Quality: quality},
+		DiffDirty: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateVerdictForEvidenceRejectsNonAcceptedWithoutQualityCoverage(t *testing.T) {
+	t.Parallel()
+	err := ValidateVerdictForEvidence(Verdict{Status: "needs_revision", Summary: "gap", Confidence: "high", NextWorkOrder: "fix it", QualityCoverage: []QualityCoverage{}}, Evidence{
+		Profiles: profile.Bundle{Quality: &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a"}}}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "criterion-a") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVerdictForEvidenceAllowsIncompleteCoverageForTerminalEscalation(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a"}}}
+	for _, status := range []string{"hard_stop", "needs_supervisor_review"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateVerdictForEvidence(Verdict{
+				Status: status, Summary: "external decision required", Confidence: "high", QualityCoverage: []QualityCoverage{},
+			}, Evidence{Profiles: profile.Bundle{Quality: quality}})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateVerdictForEvidenceRejectsMalformedCoverageForTerminalEscalation(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a"}}}
+	for _, status := range []string{"hard_stop", "needs_supervisor_review"} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateVerdictForEvidence(Verdict{
+				Status: status, Summary: "external decision required", Confidence: "high",
+				QualityCoverage: []QualityCoverage{{Criterion: "criterion-a", ChangedSurface: "file.go"}},
+			}, Evidence{Profiles: profile.Bundle{Quality: quality}})
+			if err == nil || !strings.Contains(err.Error(), "evidence_checked") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateQualityCoverageRejectsInvalidAuditEntries(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a"}}}
+	valid := QualityCoverage{Criterion: "criterion-a", ChangedSurface: "file.go", EvidenceChecked: []string{"diff lines"}}
+	tests := []struct {
+		name     string
+		coverage []QualityCoverage
+		want     string
+	}{
+		{name: "unknown criterion", coverage: []QualityCoverage{{Criterion: "criterion-b", ChangedSurface: "file.go", EvidenceChecked: []string{"diff"}}}, want: "not configured"},
+		{name: "missing surface", coverage: []QualityCoverage{{Criterion: "criterion-a", EvidenceChecked: []string{"diff"}}}, want: "changed_surface"},
+		{name: "missing evidence", coverage: []QualityCoverage{{Criterion: "criterion-a", ChangedSurface: "file.go"}}, want: "evidence_checked"},
+		{name: "blank evidence", coverage: []QualityCoverage{{Criterion: "criterion-a", ChangedSurface: "file.go", EvidenceChecked: []string{" "}}}, want: "evidence_checked"},
+		{name: "duplicate pair", coverage: []QualityCoverage{valid, valid}, want: "duplicate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateQualityCoverage(tt.coverage, quality, true)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateVerdictForEvidenceAcceptsCriterionReviewedAgainstFinalDiff(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a"}}}
+	err := ValidateVerdictForEvidence(Verdict{
+		Status: "accepted", Summary: "ok", Confidence: "high", ReviewedFiles: []string{"file.go"},
+		QualityCoverage: []QualityCoverage{{Criterion: "criterion-a", ChangedSurface: "final diff", EvidenceChecked: []string{"The criterion does not govern a narrower changed surface."}}},
+	}, Evidence{Profiles: profile.Bundle{Quality: quality}, DiffDirty: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateVerdictForEvidenceRejectsFailedRequiredQualityDimension(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{
+		ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a", Weight: 1, Required: true}},
+		PassPolicy:       profile.PassPolicy{RequiredDimensionsMustPass: true},
+	}
+	err := ValidateVerdictForEvidence(Verdict{
+		Status:             "accepted",
+		Summary:            "ok",
+		ReviewedFiles:      []string{"file.go"},
+		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
+		QualityCoverage: []QualityCoverage{{
+			Criterion: "criterion-a", ChangedSurface: "file.go", EvidenceChecked: []string{"criterion is not satisfied"},
+		}},
+		Findings:   []Finding{{Severity: "low", Category: "criterion-a", Summary: "criterion is not satisfied", BlocksAcceptance: false}},
+		Confidence: "high",
+	}, Evidence{
+		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
+		Profiles:  profile.Bundle{Quality: quality},
+		DiffDirty: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "required quality criterion") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVerdictForEvidenceEnforcesQualityScore(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{
+		ReviewDimensions: []profile.ReviewDimension{
+			{ID: "criterion-a", Weight: 1},
+			{ID: "criterion-b", Weight: 3},
+		},
+		PassPolicy: profile.PassPolicy{MinScore: 50},
+	}
+	err := ValidateVerdictForEvidence(Verdict{
+		Status:             "accepted",
+		Summary:            "ok",
+		ReviewedFiles:      []string{"file.go"},
+		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
+		QualityCoverage: []QualityCoverage{
+			{Criterion: "criterion-a", ChangedSurface: "file.go", EvidenceChecked: []string{"criterion evidence"}},
+			{Criterion: "criterion-b", ChangedSurface: "file.go", EvidenceChecked: []string{"criterion gap"}},
+		},
+		Findings:   []Finding{{Severity: "low", Category: "criterion-b", Summary: "criterion gap", BlocksAcceptance: false}},
+		Confidence: "high",
+	}, Evidence{
+		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
+		Profiles:  profile.Bundle{Quality: quality},
+		DiffDirty: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "quality score 25") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestQualityFindingScoreReturnsFullScoreWhenTotalWeightIsZero(t *testing.T) {
+	t.Parallel()
+	quality := &profile.Quality{ReviewDimensions: []profile.ReviewDimension{{ID: "criterion-a", Weight: 0}}}
+	if got := qualityFindingScore([]Finding{{Category: "criterion-a"}}, quality); got != 100 {
+		t.Fatalf("score = %d, want 100", got)
+	}
+}
+
 func TestValidateVerdictForEvidenceRejectsAcceptedWithBlockingFinding(t *testing.T) {
 	err := ValidateVerdictForEvidence(Verdict{
 		Status:             "accepted",
@@ -100,6 +307,7 @@ func TestValidateVerdictForEvidenceRejectsAcceptedWithBlockingFinding(t *testing
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		Findings:           []Finding{{Severity: "medium", Category: "correctness", Summary: "ordering bug", BlocksAcceptance: false}},
 		Confidence:         "high",
+		QualityCoverage:    []QualityCoverage{},
 	}, Evidence{
 		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		DiffDirty: true,
@@ -120,6 +328,7 @@ func TestValidateVerdictForEvidenceDefaultAllowsLowSeverityFinding(t *testing.T)
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		Findings:           []Finding{{Severity: "low", Category: "style", Summary: "wording", BlocksAcceptance: false}},
 		Confidence:         "medium",
+		QualityCoverage:    []QualityCoverage{},
 	}, Evidence{
 		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		DiffDirty: true,
@@ -137,6 +346,7 @@ func TestValidateVerdictForEvidenceBlockingSeveritiesCanRequireLowSeverityFindin
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		Findings:           []Finding{{Severity: "low", Category: "style", Summary: "wording", BlocksAcceptance: false}},
 		Confidence:         "medium",
+		QualityCoverage:    []QualityCoverage{},
 	}, Evidence{
 		Task: task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		Profiles: profile.Bundle{Quality: &profile.Quality{PassPolicy: profile.PassPolicy{
@@ -160,6 +370,7 @@ func TestValidateVerdictForEvidenceRejectsBlocksAcceptanceMismatch(t *testing.T)
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		Findings:           []Finding{{Severity: "low", Category: "style", Summary: "wording", BlocksAcceptance: true}},
 		Confidence:         "medium",
+		QualityCoverage:    []QualityCoverage{},
 	}, Evidence{
 		Task:      task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		DiffDirty: true,
@@ -177,11 +388,12 @@ func TestValidateVerdictForEvidenceAllowsBlocksAcceptanceMismatchOnNeedsRevision
 	// flag: the flag is moot when the verdict is already needs_revision, and rejecting
 	// here would discard actionable next_work_order feedback and stall the AFK loop.
 	err := ValidateVerdictForEvidence(Verdict{
-		Status:        "needs_revision",
-		Summary:       "needs work",
-		NextWorkOrder: "fix the failing test",
-		Findings:      []Finding{{Severity: "medium", Category: "correctness", Summary: "bug", BlocksAcceptance: false}},
-		Confidence:    "medium",
+		Status:          "needs_revision",
+		Summary:         "needs work",
+		NextWorkOrder:   "fix the failing test",
+		Findings:        []Finding{{Severity: "medium", Category: "correctness", Summary: "bug", BlocksAcceptance: false}},
+		Confidence:      "medium",
+		QualityCoverage: []QualityCoverage{},
 	}, Evidence{
 		Task: task.Task{AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "done"}}},
 		Profiles: profile.Bundle{Quality: &profile.Quality{PassPolicy: profile.PassPolicy{
@@ -205,6 +417,7 @@ func TestValidateVerdictForEvidenceAllowsDiscussionItemsOnlyForAccepted(t *testi
 		AcceptanceEvidence: []AcceptanceEvidence{{ACID: "AC1", Evidence: []string{"diff"}}},
 		DiscussionItems:    []DiscussionItem{{Topic: "AC wording", Summary: "Future tasks could clarify value coercion."}},
 		Confidence:         "medium",
+		QualityCoverage:    []QualityCoverage{},
 	}
 	if err := ValidateVerdictForEvidence(accepted, evidence); err != nil {
 		t.Fatalf("accepted discussion item rejected: %v", err)
@@ -215,6 +428,7 @@ func TestValidateVerdictForEvidenceAllowsDiscussionItemsOnlyForAccepted(t *testi
 		DiscussionItems: []DiscussionItem{{Topic: "AC wording", Summary: "Not relevant before acceptance."}},
 		Confidence:      "medium",
 		NextWorkOrder:   "fix it",
+		QualityCoverage: []QualityCoverage{},
 	}
 	if err := ValidateVerdictForEvidence(revision, evidence); err == nil || !strings.Contains(err.Error(), "discussion_items") {
 		t.Fatalf("expected non-accepted discussion item rejection, got %v", err)

--- a/prompts/claude-executor-full.md
+++ b/prompts/claude-executor-full.md
@@ -88,11 +88,11 @@ Completion gate:
 
 ## Step 3. Map Quality Profile Rules [BLOCKING]
 
-Map required quality profile review dimensions into implementation rules before editing.
+Treat the quality profile as part of the acceptance contract. The supervisor independently evaluates the final diff against every configured review dimension and returns work for revision when the active pass policy is not satisfied. Use these conditions to shape the implementation and verification while preserving the requested core mechanism.
 
 Completion gate:
 
-- Required quality rules that affect file shape, evidence ownership, command surfaces, contract sync, test shape, or user-facing behavior are identified.
+- The implementation and verification plan accounts for the quality profile conditions that govern the expected change.
 - Any quality rule that could be misread as changing the requested core mechanism is interpreted in a way that preserves the task contract.
 
 ## Step 4. Investigate Code Context [BLOCKING]
@@ -157,7 +157,7 @@ Before returning the final JSON, verify:
 - Every extracted work-contract obligation is implemented, explicitly out of scope by higher-priority task text, or reported as `hard_stop`.
 - The final implementation preserves the task's requested core mechanism. Any implementation strategy change keeps the same mechanism and observable contract.
 - Beyond the contract shape, exact observable contract values are preserved or changed only when a higher-priority source requires or authorizes the new value, with the decision recorded in `decisions` or the blocker reported as `hard_stop`.
-- Required quality profile dimensions have concrete implementation evidence. Treat quality profile rules as coding rules during implementation and as supervisor review hints.
+- The implementation and verification address the quality profile conditions that govern the changed behavior.
 - The implementation is substantive: AC satisfaction comes from real behavior and evidence when the AC requires behavior, rather than fixed templates, metadata shells, placeholder plumbing, TODO-only files, hollow tests, or no-op behavior.
 - Verification evidence exercises the changed behavior. A focused selector that matches zero tests is skipped evidence rather than passed evidence.
 - AC-stated proof details are satisfied by evidence, recorded as bounded residual risks, or reported as `hard_stop`.

--- a/prompts/claude-supervisor-review.md
+++ b/prompts/claude-supervisor-review.md
@@ -156,6 +156,7 @@ Return one JSON object that follows the common supervisor output contract and sc
 Provider-specific field guidance:
 
 - `acceptance_evidence`: use `{ "ac_id": "...", "evidence": ["..."] }` items for every satisfied acceptance criterion and revision request.
+- `quality_coverage`: include every quality profile review dimension and changed-surface pairing, listing the repository evidence inspected. Use the criterion ID as the finding category when the evidence supports a quality failure.
 - `findings`: set `file` to the relevant path, or to an empty string when no single file applies.
 - `residual_risks`: string array only, for example `["Non-blocking uncertainty that does not require another executor attempt."]`. Use `findings` for anything that needs severity, category, file, or blocking status.
 - `discussion_items`: accepted-work reviewer notes only. Use an empty array unless the verdict is already accepted and useful non-gating context remains. Each item must use `topic`, `summary`, and `requires_human_decision`; use `summary`, not `note`.

--- a/prompts/codex-executor-full.md
+++ b/prompts/codex-executor-full.md
@@ -53,7 +53,7 @@ Follow this order for every task:
 
 1. Map the task contract. Identify the goal, acceptance criteria, allowed paths, forbidden paths, required outputs, quality rules, environment constraints, runnable verification commands, input materials, and AC-stated proof details such as primary failure modes, boundaries, state, or residuals.
 2. Classify and read input materials. Record which materials define requirements, plans, tests, quality gates, or context.
-3. Map quality profile rules into implementation rules. Preserve the requested core mechanism when quality rules affect implementation shape.
+3. Treat the quality profile as part of the acceptance contract. The supervisor independently evaluates the final diff against every configured review dimension and returns work for revision when the active pass policy is not satisfied. Use these conditions to shape the implementation and verification while preserving the requested core mechanism.
 4. Investigate repository context. Inspect relevant files, symbols, entry points, consumers, adapters, data shapes, tests, representative local patterns, and repository setup state: setup docs, environment/profile commands, package or build tool manifests, dependency manifests, lockfiles, local tool availability, and ignored dependency or build artifacts that a fresh worktree will not contain.
 5. Plan the smallest complete implementation. Map intended edits to acceptance criteria, source-material obligations, quality rules, AC-stated proof details, and verification.
 6. Implement within allowed paths by default. Make an outside-allowed edit only when the extracted work contract or a pending revision request requires it. Keep it minimal and record it in `scope_expansions` with path, reason, linked requirement, and minimality. Never modify forbidden paths. Prefer existing project patterns, structured parsers, and local helpers. Keep unrelated changes out of the diff.
@@ -64,7 +64,7 @@ Completion gates:
 
 - Step 1 is complete only after goal, acceptance criteria, expected implementation scope, forbidden paths, required outputs, verification commands or limitations, input material paths, AC-stated proof details, and applicable repository instructions or skills are identified. Load and apply any skill whose scope matches the task domain, quality profile, framework, or named workflow.
 - Step 2 is complete only after every `requirement_basis`, `execution_plan`, and `test_or_quality_basis` file was read before implementation, and each source-material obligation is recorded as product behavior, interface/runtime contract, evidence contract, non-scope constraint, quality gate, or explicit anti-goal. Any unread `context_evidence` file must have a concrete reason it does not affect the changed behavior.
-- Step 3 is complete only after required quality rules that affect file shape, evidence ownership, command surfaces, contract sync, test shape, or user-facing behavior are identified and interpreted without changing the requested core mechanism.
+- Step 3 is complete when the implementation and verification plan accounts for the quality profile conditions that govern the expected change and preserves the requested core mechanism.
 - Step 4 is complete only after files that need edits, representative local patterns, contracts, consumers, tests, and required setup commands or missing setup blockers are identified.
 - Step 5 is complete only after the plan maps intended edits to acceptance criteria, source-material obligations, required quality rules, AC-stated proof details, and verification while excluding optional flexibility unless the extracted work contract requires it.
 - Step 6 is complete only after changed files map to acceptance criteria, input-material obligations, and quality rules, and the implementation provides substantive behavior where behavior is required.
@@ -105,7 +105,7 @@ Before returning the final JSON, verify:
 - Extracted work-contract obligations are implemented, explicitly out of scope by higher-priority task text, or reported as `hard_stop`.
 - The implementation preserves the requested core mechanism and observable contract.
 - Beyond the contract shape, exact observable contract values are preserved or changed only when a higher-priority source requires or authorizes the new value, with the decision recorded in `decisions` or the blocker reported as `hard_stop`.
-- Required quality profile dimensions have concrete implementation evidence.
+- The implementation and verification address the quality profile conditions that govern the changed behavior.
 - Acceptance comes from substantive behavior and evidence, not placeholder plumbing, TODO-only files, hollow tests, or no-op behavior.
 - Verification evidence exercises the changed behavior. A focused selector that matches zero tests is recorded as skipped evidence, not passed evidence.
 - AC-stated proof details are satisfied by evidence, recorded as bounded residual risks, or reported as `hard_stop`.

--- a/prompts/codex-supervisor-review.md
+++ b/prompts/codex-supervisor-review.md
@@ -73,6 +73,7 @@ Follow the common supervisor output contract and schema. Provider-specific field
 
 - `reviewed_files`: files or contract areas inspected during repository/context review.
 - `acceptance_evidence`: one entry per task AC, plus one entry per pending revision request using `revision:<request.id>`.
+- `quality_coverage`: one entry per quality profile review dimension and changed-surface pairing, listing the repository evidence inspected. Use the criterion ID as the finding category when the evidence supports a quality failure.
 - `findings`: structured problems only. Empty array means no problems found. Set `file` to the relevant path, or to an empty string when no single file applies.
 - `residual_risks`: non-blocking concerns that do not require another executor attempt.
 - `discussion_items`: accepted-work reviewer notes only. Use an empty array unless the verdict is already accepted and useful non-gating context remains.

--- a/prompts/supervisor-review-common.md
+++ b/prompts/supervisor-review-common.md
@@ -21,18 +21,19 @@ Requirement, execution-plan, and test/quality materials can define acceptance, e
 
 Run the review in this order for every review. For behavior-changing tasks, complete the contract derivation before judging acceptance:
 
-1. Map task rules. Read task acceptance criteria, pending revision requests, source materials, quality profile, environment profile, executor result, parse/run errors, diff summary, and verification evidence.
+1. Map task rules. Read task acceptance criteria, pending revision requests, source materials, every quality profile review dimension, environment profile, executor result, parse/run errors, diff summary, and verification evidence.
 2. Inspect implementation context. Inspect changed files, then the nearest files or contract areas that define data shapes, producers, consumers, entry points, adapters, ownership, dependency direction, configuration, existing behavior, and focused tests for the changed behavior.
-3. Derive the acceptance contract for each acceptance criterion, pending revision request, and relevant adjacent case:
+3. Build a review map before judging findings. For each changed surface, map the quality profile review dimensions that govern it and the repository evidence needed to evaluate their `pass` statements. Then derive the acceptance contract for each acceptance criterion, pending revision request, and relevant adjacent case:
    - user-observable obligation;
    - affected data set, state, identity key, order, boundary, lifecycle, side effect, or external interface;
    - authoritative source for that obligation;
    - implementation path claiming to satisfy it;
    - primary failure mode that could still pass a shallow happy-path check;
    - evidence that would fail if that failure mode existed.
-4. Compare implementation and verification against the contract. Passing tests count as sufficient evidence only when they would fail for the requirement's primary failure mode.
-5. Verify candidate findings against nearby contracts and adjacent cases that share the same changed path, contract, persisted state, external boundary, replaced mechanism, or invariant.
-6. Choose the verdict from the blocking findings, pass policy, and next actor.
+4. Compare implementation and verification against the contract. Record each criterion and changed-surface pairing in `quality_coverage` with the repository evidence inspected. Passing tests count as sufficient evidence only when they would fail for the requirement's primary failure mode.
+5. Verify candidate findings against supporting and contradicting evidence, then inspect nearby contracts and adjacent cases that share the same changed path, contract, persisted state, external boundary, replaced mechanism, or invariant.
+6. Complete the review map before choosing the verdict: inspect every remaining changed file and mapped criterion/surface after any finding, and retain independently actionable findings even when another finding already blocks acceptance.
+7. Choose the verdict from the blocking findings, pass policy, and next actor.
 
 Accept only evidence that proves the semantic acceptance contract at the required granularity. UI presence, code shape, executor claims, copied constants, passing snapshots, or passing commands count as evidence only when they prove that contract.
 
@@ -41,6 +42,9 @@ Accept only evidence that proves the semantic acceptance contract at the require
 - Acceptance criteria from `task.acceptance_criteria` are authoritative. Add one `acceptance_evidence` item for every satisfied task AC.
 - Pending `task.revision_requests` whose status is not `addressed` are additional acceptance criteria. Add satisfied entries with `ac_id` equal to `revision:<id>`.
 - A missing AC result, unknown AC ID, ambiguous result, partial implementation, or unsatisfied pending revision request is an acceptance gap.
+- Return `quality_coverage` entries for every quality profile review dimension. Use one entry per criterion and changed-surface pairing so the inspected evidence remains auditable.
+- `quality_coverage` records inspected repository evidence. Express supported quality failures as findings whose `category` is the criterion ID.
+- A quality dimension fails when a finding's category equals its ID, regardless of severity. When `required_dimensions_must_pass` is enabled, a failed required dimension blocks acceptance. Always compare `min_score` with the integer percentage of total dimension weight without matching findings; when no dimensions are configured, the score is 100.
 - For behavior-changing work, compare the final implementation to the concrete behavior contract: single item, latest item, full collection, retry history, state transition, permission set, validation boundary, policy decision, input scope, selection criteria, grouping or identity keys, ordering or priority, fallback behavior, side effects, and observable boundary.
 - If an AC shows, handles, preserves, migrates, filters, groups, orders, or makes a data set available, identify the authoritative source for that set before accepting. Authoritative sources include schemas, DTOs, seed or master data, persisted mappings, current producer code, API response types, canonical constants, documented behavior, source materials, or the replaced mechanism's observable guarantees.
 - When an AC or pending revision request represents a data set, identity, mapping, ordering, or category through identifiers, keys, names, statuses, routes, feature flags, canonical lists, or persisted mappings, the `acceptance_evidence` entry must name the authoritative source inspected and state that the implementation's represented items match it. If the task AC or source material itself defines that representation, citing it as the authoritative source satisfies this requirement. If no authoritative source was inspected, record an acceptance gap instead of accepting.
@@ -79,7 +83,9 @@ Severity guide:
 
 Record concrete wrong-result conditions, contract/data-shape/entry-point inconsistencies, testable missing edge cases, misplaced requirement boundaries, conversion errors, value interpretation bugs, and likely compatibility regressions in `findings`.
 
-Set `blocks_acceptance` from `profiles.quality.pass_policy.blocking_severities`. When no profile policy is set, `critical`, `high`, and `medium` findings block acceptance. Non-blocking findings remain in `findings` with `blocks_acceptance=false`.
+Record each failed quality criterion as a finding whose `category` is that criterion's ID.
+
+`blocks_acceptance` represents only `profiles.quality.pass_policy.blocking_severities`; apply required-dimension and `min_score` gates separately when choosing the verdict. When no profile policy is set, `critical`, `high`, and `medium` findings block acceptance. Non-blocking findings remain in `findings` with `blocks_acceptance=false`.
 
 Use `residual_risks` only for non-blocking uncertainty that remains after review and does not require another executor attempt.
 
@@ -89,7 +95,7 @@ Use `discussion_items` only for accepted work after the verdict is justified. Di
 
 Use exactly one status:
 
-- `accepted`: repository evidence satisfies every task AC, every pending revision request, the active pass policy, and required verification.
+- `accepted`: repository evidence satisfies every task AC, every pending revision request, every quality profile review dimension under the active pass policy, and required verification.
 - `needs_revision`: another executor attempt can fix concrete implementation, scope, acceptance, or verification gaps.
 - `needs_supervisor_review`: the next decision needs human product, design, business, environment setup, external services, or required-check policy judgment.
 - `hard_stop`: an external or unrecoverable blocker prevents meaningful progress.
@@ -109,6 +115,7 @@ Required fields:
 - `acceptance_gaps`
 - `reviewed_files`
 - `acceptance_evidence`
+- `quality_coverage`
 - `findings`
 - `residual_risks`
 - `discussion_items`
@@ -120,6 +127,7 @@ Accepted verdicts use `medium` or `high` confidence.
 Field shapes:
 
 - `acceptance_evidence`: `[{ "ac_id": "...", "evidence": ["..."] }]`
+- `quality_coverage`: `[{ "criterion": "configured dimension ID", "changed_surface": "file, symbol, contract, or final diff when the criterion has no narrower applicable surface", "evidence_checked": ["repository evidence inspected"] }]`
 - `findings`: structured problems with severity, category, file, summary, and blocks_acceptance.
 - `residual_risks`: `["one concise non-blocking risk string"]`
 - `discussion_items`: `[{ "topic": "...", "summary": "...", "requires_human_decision": false }]`

--- a/schemas/supervisor-verdict.schema.json
+++ b/schemas/supervisor-verdict.schema.json
@@ -9,6 +9,7 @@
     "acceptance_gaps",
     "reviewed_files",
     "acceptance_evidence",
+    "quality_coverage",
     "findings",
     "residual_risks",
     "discussion_items",
@@ -42,6 +43,23 @@
           "ac_id": { "type": "string", "minLength": 1 },
           "evidence": {
             "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "quality_coverage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["criterion", "changed_surface", "evidence_checked"],
+        "properties": {
+          "criterion": { "type": "string", "minLength": 1 },
+          "changed_surface": { "type": "string", "minLength": 1 },
+          "evidence_checked": {
+            "type": "array",
+            "minItems": 1,
             "items": { "type": "string", "minLength": 1 }
           }
         }

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -16,7 +16,7 @@ cat > "$BIN_DIR/claude" <<'SH'
 #!/bin/sh
 if [ "${GALLEY_CLAUDE_GUARD_MODE:-}" = "supervisor" ]; then
   cat > /dev/null
-  echo '{"status":"accepted","summary":"smoke supervisor accepted","acceptance_gaps":[],"reviewed_files":["smoke-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["smoke-output.txt exists"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
+  echo '{"status":"accepted","summary":"smoke supervisor accepted","acceptance_gaps":[],"reviewed_files":["smoke-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["smoke-output.txt exists"]}],"quality_coverage":[],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
   exit 0
 fi
 cat > /dev/null
@@ -40,7 +40,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 cat > /dev/null
-printf '%s\n' '{"status":"accepted","summary":"smoke supervisor accepted","acceptance_gaps":[],"reviewed_files":["smoke-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["smoke-output.txt exists"]}],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}' > "$out"
+printf '%s\n' '{"status":"accepted","summary":"smoke supervisor accepted","acceptance_gaps":[],"reviewed_files":["smoke-output.txt"],"acceptance_evidence":[{"ac_id":"AC1","evidence":["smoke-output.txt exists"]}],"quality_coverage":[],"findings":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}' > "$out"
 printf '%s\n' '{"event":"done"}'
 SH
 chmod +x "$BIN_DIR/codex"


### PR DESCRIPTION
## Summary

- make quality profiles an externally enforced acceptance contract for executors
- require supervisors to report evidence coverage for every configured review dimension
- apply required-dimension, weighted-score, and severity gates consistently
- complete the mapped review before selecting a verdict

## Verification

- go test ./...
- ./scripts/smoke-local.sh
- go run ./cmd/galley schema check