### PR TITLE
Reduce Galley task authoring and operational configuration to meaningful user decisions by internalizing fixed AFK behavior, removing dead settings, and preserving daemon-owned lifecycle state.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "category": "development",
       "source": {
         "source": "local",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,9 @@ This project follows semantic versioning.
 
 ## Unreleased
 
-### Added
-
-- Environment profiles can provide executor CLI, model, and effort defaults. Explicit task fields override them independently for each run.
-
 ### Changed
 
-- Task executor fields are optional, each provider uses its fixed Galley prompt construction, and reused preflight evidence must match the resolved executor identity.
-- Packaged Galley plugins are version `0.1.24`. Task authoring now omits fixed AFK values (`mode`, draft `status`, worktree isolation, AFK decision policy), prompt-only execution-policy blockers, and daemon-owned lifecycle sections from new drafts while runtime resolution and lifecycle persistence stay intact. Acceptance-skeleton authoring is only `preflight.acceptance_skeleton.enabled`; quality pass policy no longer includes `unresolved_high_findings_allowed` (remove that one line from any external strict profile); daemon heartbeat cadence is derived solely as `min(claim_ttl/4, 1m)`.
+- Packaged Galley plugins are updated to version `0.1.24`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Task executor fields are optional, each provider uses its fixed Galley prompt construction, and reused preflight evidence must match the resolved executor identity.
+- Packaged Galley plugins are version `0.1.24`. Task authoring now omits fixed AFK values (`mode`, draft `status`, worktree isolation, AFK decision policy), prompt-only execution-policy blockers, and daemon-owned lifecycle sections from new drafts while runtime resolution and lifecycle persistence stay intact. Acceptance-skeleton authoring is only `preflight.acceptance_skeleton.enabled`; quality pass policy no longer includes `unresolved_high_findings_allowed` (remove that one line from any external strict profile); daemon heartbeat cadence is derived solely as `min(claim_ttl/4, 1m)`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This project follows semantic versioning.
 ### Changed
 
 - Task executor fields are optional, each provider uses its fixed Galley prompt construction, and reused preflight evidence must match the resolved executor identity.
-- Packaged Galley plugins are version `0.1.24`, combining runtime executor defaults with simplified author-owned task drafts, enabled-only acceptance-skeleton preflight, and claim-TTL-derived heartbeat cadence. Existing quality profiles must remove `pass_policy.unresolved_high_findings_allowed` before strict validation.
+- User-authored task, profile, and daemon YAML ignore unknown keys while continuing to reject missing required fields and invalid known values.
+- Packaged Galley plugins are version `0.1.24`, combining runtime executor defaults with simplified author-owned task drafts, enabled-only acceptance-skeleton preflight, and claim-TTL-derived heartbeat cadence.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Added
+
+- Environment profiles can provide executor CLI, model, and effort defaults. Explicit task fields override them independently for each run.
+
 ### Changed
 
-- Packaged Galley plugins are updated to version `0.1.24`.
+- Task executor fields are optional, each provider uses its fixed Galley prompt construction, and reused preflight evidence must match the resolved executor identity.
+- Packaged Galley plugins are version `0.1.24`, combining runtime executor defaults with simplified author-owned task drafts, enabled-only acceptance-skeleton preflight, and claim-TTL-derived heartbeat cadence. Existing quality profiles must remove `pass_policy.unresolved_high_findings_allowed` before strict validation.
 
 ### Fixed
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -211,7 +211,7 @@ If every supervisor try is killed by the idle-output watchdog, Galley records `e
 
 - Running multiple daemon processes is supported by claim conflict handling.
 - Background control uses a local PID file. Avoid sharing the same `--pid-file` across unrelated processes, and prefer one workflow root per managed daemon.
-- Running tasks heartbeat their YAML mtime while the executor loop is active. `--heartbeat-interval` defaults to `min(claim-ttl/4, 1m)`.
+- Running tasks heartbeat their YAML mtime while the executor loop is active. Heartbeat cadence is derived only from claim TTL as `min(claim_ttl / 4, 1m)`; it is not a separate daemon.yaml or CLI setting.
 - Each claimed running task records the owning daemon. On startup the daemon immediately requeues running tasks whose recorded owner is dead or cannot be verified, while leaving tasks still owned by a verified live daemon untouched.
 
 ### External Services

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -106,6 +106,8 @@ Both `galley daemon run` and `galley daemon start` create `daemon.yaml` under th
 
 CLI flags on `galley daemon run` or `galley daemon start` always override the matching `daemon.yaml` field for that run (including `--shutdown-timeout`). Anything you do not set on the CLI falls back to `daemon.yaml`; anything `daemon.yaml` does not set falls back to the built-in default.
 
+Runtime loading ignores unknown `daemon.yaml` keys while rejecting invalid values for known keys.
+
 ### Notifications
 
 The daemon can run an opt-in, best-effort command hook after a task reaches a terminal published status. Notifications are configured only in `daemon.yaml`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -211,7 +211,7 @@ If every supervisor try is killed by the idle-output watchdog, Galley records `e
 
 - Running multiple daemon processes is supported by claim conflict handling.
 - Background control uses a local PID file. Avoid sharing the same `--pid-file` across unrelated processes, and prefer one workflow root per managed daemon.
-- Running tasks heartbeat their YAML mtime while the executor loop is active. Heartbeat cadence is derived only from claim TTL as `min(claim_ttl / 4, 1m)`; it is not a separate daemon.yaml or CLI setting.
+- Running tasks refresh their YAML mtime at `min(claim_ttl / 4, 1m)` while the executor loop is active. Heartbeat cadence has no separate daemon or CLI setting.
 - Each claimed running task records the owning daemon. On startup the daemon immediately requeues running tasks whose recorded owner is dead or cannot be verified, while leaving tasks still owned by a verified live daemon untouched.
 
 ### External Services

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -69,7 +69,7 @@ Supported fields:
 - `pass_policy.required_dimensions_must_pass`: require all mandatory dimensions to pass.
 - `pass_policy.min_score`: 0-100 threshold over all configured dimension weights. A dimension contributes its weight when no finding uses its ID as `category`; total configured weight of zero scores 100.
 - `pass_policy.blocking_severities`: severities that block acceptance. Values are `critical`, `high`, `medium`, and `low`.
-- Remove `pass_policy.unresolved_high_findings_allowed` from existing profiles; strict decoding rejects it.
+- Runtime loading ignores unknown keys while rejecting missing required keys and invalid known values.
 
 Validate a quality profile:
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -69,7 +69,7 @@ Supported fields:
 - `pass_policy.required_dimensions_must_pass`: require all mandatory dimensions to pass.
 - `pass_policy.min_score`: 0-100 threshold over all configured dimension weights. A dimension contributes its weight when no finding uses its ID as `category`; total configured weight of zero scores 100.
 - `pass_policy.blocking_severities`: severities that block acceptance. Values are `critical`, `high`, `medium`, and `low`.
-- Profiles that still set `pass_policy.unresolved_high_findings_allowed` must remove that one line; strict profile decode no longer accepts it.
+- Remove `pass_policy.unresolved_high_findings_allowed` from existing profiles; strict decoding rejects it.
 
 Validate a quality profile:
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -47,7 +47,6 @@ evidence_requirements:
 pass_policy:
   required_dimensions_must_pass: true
   min_score: 85
-  unresolved_high_findings_allowed: 0
   blocking_severities:
     - critical
     - high
@@ -69,8 +68,8 @@ Supported fields:
 - `evidence_requirements.command_outputs`: ask for command output evidence.
 - `pass_policy.required_dimensions_must_pass`: require all mandatory dimensions to pass.
 - `pass_policy.min_score`: 0-100 threshold over all configured dimension weights. A dimension contributes its weight when no finding uses its ID as `category`; total configured weight of zero scores 100.
-- `pass_policy.unresolved_high_findings_allowed`: number of unresolved high findings allowed.
 - `pass_policy.blocking_severities`: severities that block acceptance. Values are `critical`, `high`, `medium`, and `low`.
+- Profiles that still set `pass_policy.unresolved_high_findings_allowed` must remove that one line; strict profile decode no longer accepts it.
 
 Validate a quality profile:
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -6,12 +6,10 @@ Use the plugin skill for normal authoring. This document is the reference for re
 
 ## Starter Template
 
-This template includes the fields needed for validation plus the runtime sections Galley updates later. Start here when writing a task by hand.
+Author only the decisions that matter. Galley applies fixed AFK defaults (`mode: afk`, draft `status`, enabled isolated worktree, `choose-smallest-reversible` ambiguity policy) when they are omitted. Daemon-owned sections (`supervisor`, `attempts`, `verification`, `pr`, and acceptance-skeleton `outputs`) appear after queueing and execution transitions.
 
 ```yaml
 id: "task-20260509-example"
-mode: "afk"
-status: "draft"
 goal: "Implement the requested repository change with evidence."
 acceptance_criteria:
   - id: "AC1"
@@ -29,27 +27,17 @@ scope:
 execution_policy:
   loop_budget: 10
   timeout_ms: 1200000
-  afk_decision_policy: "choose-smallest-reversible"
-  stop_on_destructive_operation: true
-  stop_on_missing_secret: false
-  stop_on_external_service_unavailable: false
 worktree:
-  enabled: true
   branch: "agent/task-20260509-example"
   path: "../repo.worktrees/task-20260509-example"
-supervisor:
-  review_iterations: 0
 executor:
   cli: "claude"
   effort: "high"
+preflight:
+  acceptance_skeleton:
+    enabled: false
 decisions: []
 risks: []
-attempts: []
-verification:
-  commands: []
-pr:
-  url: ""
-  status: ""
 ```
 
 Validate before queueing:
@@ -67,25 +55,24 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 ## Fields
 
 - `id`: stable task identifier. Use letters, numbers, dot, underscore, and dash.
-- `mode`: currently `afk`.
-- `status`: use `draft` before queueing. Galley updates this as the task moves through the queue.
+- `mode`: optional; defaults to `afk`.
+- `status`: optional for authors; defaults to `draft` before validation, display, and queue eligibility. Queueing persists `queued` through the normal transition.
 - `goal`: concise objective for the work.
 - `acceptance_criteria[]`: observable completion requirements with stable IDs such as `AC1`.
 - `files[]`: optional user-supplied files to place in the execution workspace.
 - `scope`: repository path, expected implementation paths, protected paths, and permission level.
-- `execution_policy`: attempt budget, timeout, and escalation behavior.
-- `worktree`: isolated branch and sibling worktree location for AFK execution.
-- `supervisor`: review loop settings.
-- `executor`: executor CLI and model settings.
-- `decisions`, `risks`, `attempts`, `verification`, `pr`: audit and runtime state updated by Galley.
+- `execution_policy`: author-chosen attempt budget and timeout only (`loop_budget`, `timeout_ms`).
+- `worktree`: isolated branch and sibling worktree location. `enabled` defaults to true for AFK; authors set `branch` and `path`.
+- `executor`: optional per-field overrides for CLI, model, and effort.
+- `preflight.acceptance_skeleton.enabled`: optional boolean that selects the fixed skeleton preflight flow.
+- `decisions`, `risks`: author and executor notes.
+- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state. Omit them from new drafts; Galley populates them during lifecycle transitions.
 
 ## Execution Policy And Executor
 
-- `execution_policy.loop_budget`: non-negative attempt count; `0` means unlimited.
-- `execution_policy.afk_decision_policy`: currently `choose-smallest-reversible`; the executor should choose the smallest reversible option when it can continue without human input.
-- `execution_policy.stop_on_destructive_operation`: stop when the task would require out-of-scope destructive work.
-- `execution_policy.stop_on_missing_secret`: stop when a required secret is unavailable and cannot be replaced by safe local evidence.
-- `execution_policy.stop_on_external_service_unavailable`: stop when a required external service is unavailable and the task cannot proceed with local substitutes.
+- `execution_policy.loop_budget`: non-negative attempt count; `0` means unlimited. Omitted values default to `10`.
+- `execution_policy.timeout_ms`: positive per-attempt timeout in milliseconds.
+- AFK decision policy is fixed to `choose-smallest-reversible` and is no longer authored. Destructive-operation, missing-secret, and external-service blockers continue through executor results and visible failure or escalation paths without task YAML booleans.
 - `executor`: optional. Each `cli`, `model`, and `effort` field resolves from the task, current `environment.yaml`, then built-in defaults (`cli: claude`, `effort: high`, CLI-default model). Environment values remain runtime-only.
 - `executor.cli`: selects `claude`, `codex`, `glm`, or `grok`. Grok uses the logged-in `grok` CLI for setup, acceptance-skeleton creation, and implementation.
 - `executor.model`: optional model override. Omit it to use the selected CLI's configured default model.
@@ -128,12 +115,11 @@ files:
 
 ```yaml
 worktree:
-  enabled: true
   branch: "agent/task-20260509-example"
   path: "../repo.worktrees/task-20260509-example"
 ```
 
-This keeps the source repository clean while the executor edits the isolated worktree.
+This keeps the source repository clean while the executor edits the isolated worktree. Omitted `worktree.enabled` defaults to true for AFK tasks.
 
 ## Acceptance Criteria
 
@@ -152,9 +138,7 @@ Example:
 
 ## Acceptance Skeleton Preflight
 
-`preflight.acceptance_skeleton` is an optional stage that creates AC-linked test skeletons before the first executor attempt. When enabled, Galley records the result and adds skeleton obligations to the executor work order.
-
-New task skeletons include the stage in its default disabled state:
+`preflight.acceptance_skeleton` is an optional stage that creates AC-linked test skeletons before the first executor attempt. Authors choose only `enabled`.
 
 ```yaml
 preflight:
@@ -164,32 +148,17 @@ preflight:
 
 Disabled preflight has the same daemon behavior as omitting `preflight` entirely. Set `enabled` to `true` when the task should create acceptance-criterion-linked skeleton files before the executor starts.
 
+When enabled:
+
+- write paths are always `scope.allowed_paths` (and remain outside `scope.forbidden_paths`)
+- every AC must produce a skeleton output or an explicit `no_skeletons` reason
+- the daemon writes runtime `outputs[]` back to the running task
+
 When a task reuses its existing worktree after a requeue, Galley reuses previously completed setup and acceptance-skeleton evidence instead of running those phases again. A new worktree, or a phase with no prior successful result, still runs normal preflight.
-
-```yaml
-preflight:
-  acceptance_skeleton:
-    enabled: true
-    required: true            # default true when enabled; require each AC to have output or no_skeletons
-    allowed_paths:            # optional; defaults to scope.allowed_paths
-      - "internal"
-    outputs:                  # daemon-owned; written after the built-in creator runs
-      - ac_id: "AC1"
-        path: "internal/foo/foo_test.go"
-        kind: "go-test"
-        purpose: "Verify the AC1 behavior boundary"
-        satisfies: "AC1's observable foo behavior"
-        integration_point: "Executor completes this skeleton before final acceptance"
-        implementation_required: true
-```
-
-The built-in creator writes AC-linked skeleton files and returns a manifest. Generated paths must be relative, inside the effective allowed paths, outside `scope.forbidden_paths`, and backed by real files.
 
 The skeleton creator follows `executor.cli` and reuses `executor.model` and `executor.effort`. The daemon supervisor backend controls only review.
 
 Required quality checks remain executor evidence for supervisor review; the skeleton stage does not add a second command-matching gate.
-
-`required: false` relaxes AC coverage: Galley no longer requires every AC to have an output or a `no_skeletons[]` reason.
 
 ## Loop Budget
 
@@ -197,7 +166,7 @@ Required quality checks remain executor evidence for supervisor review; the skel
 
 For AFK implementation tasks, `10` is the recommended default. Values below `5` are best reserved for intentionally short, low-cost runs because they can stop useful revision loops too early. Use `0` only when the user explicitly wants an unbounded run.
 
-`supervisor.review_iterations` controls supervisor-only follow-up iterations. `0` means Galley uses the supervisor as an acceptance gate after executor attempts, without additional supervisor-only review loops.
+`supervisor.review_iterations` is daemon-owned runtime state after review transitions. Authors do not set it in new drafts.
 
 ## Queue State
 
@@ -219,8 +188,6 @@ galley task show TASK_ID
 galley task requeue TASK_ID --reason "retry after transient failure"
 ```
 
-Requeue is useful for transient failures such as usage limits or temporary service errors.
+## Compatibility
 
-## Task YAML Decoding
-
-Galley decodes known task YAML fields and ignores unknown fields at runtime. Malformed YAML, incompatible top-level shape, and type mismatches in known fields still fail validation, queueing, requeueing, and daemon execution.
+Removed authoring keys such as `execution_policy.afk_decision_policy`, `execution_policy.stop_on_*`, `preflight.acceptance_skeleton.mode`, `required`, and `allowed_paths` still load through the unknown-field-tolerant task decoder and disappear on the next save. Runtime Task model fields for lifecycle state remain available to the daemon.

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -6,7 +6,7 @@ Use the plugin skill for normal authoring. This document is the reference for re
 
 ## Starter Template
 
-Author only the decisions that matter. Galley applies fixed AFK defaults (`mode: afk`, draft `status`, enabled isolated worktree, `choose-smallest-reversible` ambiguity policy) when they are omitted. Daemon-owned sections (`supervisor`, `attempts`, `verification`, `pr`, and acceptance-skeleton `outputs`) appear after queueing and execution transitions.
+This template contains author-owned fields. Galley adds fixed AFK defaults and lifecycle state during validation and execution.
 
 ```yaml
 id: "task-20260509-example"
@@ -66,13 +66,14 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `executor`: optional per-field overrides for CLI, model, and effort.
 - `preflight.acceptance_skeleton.enabled`: optional boolean that selects the fixed skeleton preflight flow.
 - `decisions`, `risks`: author and executor notes.
-- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state. Omit them from new drafts; Galley populates them during lifecycle transitions.
+- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state populated during lifecycle transitions.
 
 ## Execution Policy And Executor
 
 - `execution_policy.loop_budget`: non-negative attempt count; `0` means unlimited. Omitted values default to `10`.
 - `execution_policy.timeout_ms`: positive per-attempt timeout in milliseconds.
-- AFK decision policy is fixed to `choose-smallest-reversible` and is no longer authored. Destructive-operation, missing-secret, and external-service blockers continue through executor results and visible failure or escalation paths without task YAML booleans.
+- Galley fixes the AFK decision policy at `choose-smallest-reversible`.
+- Destructive-operation, missing-secret, and external-service blockers remain executor results; task YAML has no blocker switches.
 - `executor`: optional. Each `cli`, `model`, and `effort` field resolves from the task, current `environment.yaml`, then built-in defaults (`cli: claude`, `effort: high`, CLI-default model). Environment values remain runtime-only.
 - `executor.cli`: selects `claude`, `codex`, `glm`, or `grok`. Grok uses the logged-in `grok` CLI for setup, acceptance-skeleton creation, and implementation.
 - `executor.model`: optional model override. Omit it to use the selected CLI's configured default model.
@@ -119,7 +120,7 @@ worktree:
   path: "../repo.worktrees/task-20260509-example"
 ```
 
-This keeps the source repository clean while the executor edits the isolated worktree. Omitted `worktree.enabled` defaults to true for AFK tasks.
+Galley enables this isolated worktree for every AFK task, keeping the source repository clean.
 
 ## Acceptance Criteria
 
@@ -138,7 +139,7 @@ Example:
 
 ## Acceptance Skeleton Preflight
 
-`preflight.acceptance_skeleton` is an optional stage that creates AC-linked test skeletons before the first executor attempt. Authors choose only `enabled`.
+`preflight.acceptance_skeleton.enabled` controls AC-linked test skeleton creation before the first executor attempt.
 
 ```yaml
 preflight:
@@ -146,7 +147,7 @@ preflight:
     enabled: false
 ```
 
-Disabled preflight has the same daemon behavior as omitting `preflight` entirely. Set `enabled` to `true` when the task should create acceptance-criterion-linked skeleton files before the executor starts.
+Enable it when an integration, cross-layer, or E2E acceptance path needs a concrete file before implementation. Leave it disabled when focused tests or required checks already define the evidence path.
 
 When enabled:
 
@@ -165,8 +166,6 @@ Required quality checks remain executor evidence for supervisor review; the skel
 `execution_policy.loop_budget` is the maximum number of executor attempts. It accepts an integer greater than or equal to `0`; `0` means unlimited.
 
 For AFK implementation tasks, `10` is the recommended default. Values below `5` are best reserved for intentionally short, low-cost runs because they can stop useful revision loops too early. Use `0` only when the user explicitly wants an unbounded run.
-
-`supervisor.review_iterations` is daemon-owned runtime state after review transitions. Authors do not set it in new drafts.
 
 ## Queue State
 
@@ -190,4 +189,4 @@ galley task requeue TASK_ID --reason "retry after transient failure"
 
 ## Compatibility
 
-Removed authoring keys such as `execution_policy.afk_decision_policy`, `execution_policy.stop_on_*`, `preflight.acceptance_skeleton.mode`, `required`, and `allowed_paths` still load through the unknown-field-tolerant task decoder and disappear on the next save. Runtime Task model fields for lifecycle state remain available to the daemon.
+The tolerant decoder loads removed authoring keys (`execution_policy.afk_decision_policy`, `execution_policy.stop_on_*`, and acceptance-skeleton `mode`, `required`, and `allowed_paths`), then drops them on save. Runtime lifecycle fields remain available to the daemon.

--- a/examples/afk-task-codex.yaml
+++ b/examples/afk-task-codex.yaml
@@ -1,6 +1,4 @@
 id: "task-20260514-afk-codex-001"
-mode: "afk"
-status: "queued"
 goal: "Implement a small, self-contained maintenance task with the Codex executor and open a PR with evidence."
 acceptance_criteria:
   - id: "AC1"
@@ -18,24 +16,11 @@ scope:
 execution_policy:
   loop_budget: 10
   timeout_ms: 1200000
-  afk_decision_policy: "choose-smallest-reversible"
-  stop_on_destructive_operation: true
-  stop_on_missing_secret: false
-  stop_on_external_service_unavailable: false
 worktree:
-  enabled: true
   branch: "agent/task-20260514-afk-codex-001"
   path: "../galley.worktrees/task-20260514-afk-codex-001"
-supervisor:
-  review_iterations: 0
 executor:
   cli: "codex"
   effort: "high"
 decisions: []
 risks: []
-attempts: []
-verification:
-  commands: []
-pr:
-  url: ""
-  status: ""

--- a/examples/afk-task.yaml
+++ b/examples/afk-task.yaml
@@ -1,6 +1,4 @@
 id: "task-20260508-afk-001"
-mode: "afk"
-status: "queued"
 goal: "Implement a small, self-contained maintenance task and open a PR with evidence."
 acceptance_criteria:
   - id: "AC1"
@@ -18,50 +16,17 @@ scope:
 execution_policy:
   loop_budget: 10
   timeout_ms: 1200000
-  afk_decision_policy: "choose-smallest-reversible"
-  stop_on_destructive_operation: true
-  stop_on_missing_secret: false
-  stop_on_external_service_unavailable: false
 worktree:
-  enabled: true
   branch: "agent/task-20260508-afk-001"
   path: "../galley.worktrees/task-20260508-afk-001"
-supervisor:
-  review_iterations: 0
 executor:
   cli: "claude"
   effort: "high"
 # Optional acceptance skeleton preflight. When enabled, Galley creates
-# AC-linked test skeletons before the executor starts. It is disabled by
-# default; set `enabled` to true and optionally add `required` or
-# `allowed_paths` to opt in. See docs/task-yaml.md.
+# AC-linked test skeletons before the executor starts. Paths come from
+# scope.allowed_paths; outputs are written by the daemon.
 preflight:
   acceptance_skeleton:
     enabled: false
-# Example opt-in shape:
-#   acceptance_skeleton:
-#     enabled: true
-#     required: true
-#     # allowed_paths defaults to scope.allowed_paths when omitted.
-#     # allowed_paths:
-#     #   - "internal"
-#     # With only enabled: true, Galley runs the built-in test creator and writes
-#     # generated outputs[] plus AC verification annotations back to the running task.
-#     # outputs is daemon-owned runtime metadata, shown here only as an example
-#     # of what the built-in creator writes back before the executor starts.
-#     # outputs:
-#       - ac_id: "AC1"
-#         path: "internal/foo/foo_test.go"
-#         kind: "go-test"
-#         purpose: "Verify the AC1 behavior boundary"
-#         satisfies: "AC1 observable behavior"
-#         integration_point: "Executor completes this skeleton before acceptance"
-#         implementation_required: true
 decisions: []
 risks: []
-attempts: []
-verification:
-  commands: []
-pr:
-  url: ""
-  status: ""

--- a/examples/quality-default.yaml
+++ b/examples/quality-default.yaml
@@ -19,4 +19,7 @@ evidence_requirements:
 pass_policy:
   required_dimensions_must_pass: true
   min_score: 85
-  unresolved_high_findings_allowed: 0
+  blocking_severities:
+    - critical
+    - high
+    - medium

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -639,8 +639,13 @@ required_checks:
     preferred_commands: []
     required: true
 review_dimensions: []
+evidence_requirements:
+  file_line_references: true
+  command_outputs: true
 pass_policy:
+  required_dimensions_must_pass: true
   min_score: 85
+  blocking_severities: [high]
 `
 	if err := os.WriteFile(qualityPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -178,8 +178,7 @@ func newTaskShowCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Resolve omitted fixed authoring values (mode, draft status, worktree)
-			// so display matches validate/queue eligibility semantics.
+			// Display resolves the same fixed defaults as validation and queueing.
 			task.ApplyDefaults(&loaded)
 			item := taskSummary(path, loaded)
 			preflight := preflightSummary(loaded)

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -178,6 +178,9 @@ func newTaskShowCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Resolve omitted fixed authoring values (mode, draft status, worktree)
+			// so display matches validate/queue eligibility semantics.
+			task.ApplyDefaults(&loaded)
 			item := taskSummary(path, loaded)
 			preflight := preflightSummary(loaded)
 			if preflight != nil {
@@ -280,6 +283,7 @@ func listTaskItems(root, state string) ([]taskListItem, error) {
 				})
 				continue
 			}
+			task.ApplyDefaults(&loaded)
 			items = append(items, taskSummary(path, loaded))
 		}
 	}

--- a/internal/cli/task_omitted_status_test.go
+++ b/internal/cli/task_omitted_status_test.go
@@ -10,9 +10,6 @@ import (
 	taskpkg "github.com/shinpr/galley/internal/task"
 )
 
-// writeMinimalOmittedStatusTaskYAML writes an author-facing draft that omits
-// status (and other fixed AFK defaults) so display and queue eligibility must
-// resolve draft via ApplyDefaults.
 func writeMinimalOmittedStatusTaskYAML(t *testing.T, id string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/cli/task_omitted_status_test.go
+++ b/internal/cli/task_omitted_status_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	taskpkg "github.com/shinpr/galley/internal/task"
+)
+
+// writeMinimalOmittedStatusTaskYAML writes an author-facing draft that omits
+// status (and other fixed AFK defaults) so display and queue eligibility must
+// resolve draft via ApplyDefaults.
+func writeMinimalOmittedStatusTaskYAML(t *testing.T, id string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "task.yaml")
+	body := strings.Join([]string{
+		`id: ` + strconv.Quote(id),
+		`goal: "Omitted status display and queue persistence."`,
+		`acceptance_criteria:`,
+		`  - id: "AC1"`,
+		`    text: "observable"`,
+		`    verification: "test"`,
+		`    status: "pending"`,
+		`scope:`,
+		`  cwd: ` + strconv.Quote(dir),
+		`  allowed_paths: ["."]`,
+		`  forbidden_paths: [".env"]`,
+		`  permission: "edit"`,
+		`execution_policy:`,
+		`  loop_budget: 10`,
+		`  timeout_ms: 1000`,
+		`worktree:`,
+		`  branch: "agent/` + id + `"`,
+		`  path: "../repo.worktrees/` + id + `"`,
+		`decisions: []`,
+		`risks: []`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Criterion-level status is expected; top-level task status must stay omitted.
+	if strings.Contains(string(raw), "\nstatus:") || strings.HasPrefix(string(raw), "status:") {
+		t.Fatalf("fixture must omit top-level status, got:\n%s", raw)
+	}
+	return path
+}
+
+func TestTaskShowAndListDisplayOmittedStatusAsDraft(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const id = "task-omitted-status-display"
+	src := writeMinimalOmittedStatusTaskYAML(t, id)
+	draftPath := filepath.Join(root, "tasks", "draft", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(draftPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(draftPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	showOut, showErr, err := executeCommand("task", "show", "--root", root, id)
+	if err != nil {
+		t.Fatalf("task show: %v\nstderr=%q", err, showErr)
+	}
+	if !strings.Contains(showOut, "status: draft") {
+		t.Fatalf("task show must display omitted status as draft:\n%s", showOut)
+	}
+
+	listOut, listErr, err := executeCommand("task", "list", "--root", root)
+	if err != nil {
+		t.Fatalf("task list: %v\nstderr=%q", err, listErr)
+	}
+	if !strings.Contains(listOut, "draft\tdraft\t"+id) {
+		t.Fatalf("task list must display omitted status as draft:\n%s", listOut)
+	}
+}
+
+func TestTaskQueuePersistsQueuedStatusFromOmittedStatusDraft(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const id = "task-omitted-status-queue"
+	src := writeMinimalOmittedStatusTaskYAML(t, id)
+
+	stdout, stderr, err := executeCommand("task", "queue", "--root", root, "--reason", "persist queued status", src)
+	if err != nil {
+		t.Fatalf("task queue: %v\nstdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "queued: "+id) {
+		t.Fatalf("queue output missing queued id: %q", stdout)
+	}
+
+	// Queue may rename by source basename; also accept the standard task.yaml path.
+	queuedPath := filepath.Join(root, "tasks", "queued", filepath.Base(src))
+	if _, err := os.Stat(queuedPath); err != nil {
+		entries, readErr := os.ReadDir(filepath.Join(root, "tasks", "queued"))
+		if readErr != nil {
+			t.Fatalf("queued dir: %v (stat %s: %v)", readErr, queuedPath, err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected one queued file, got %#v (stat %s: %v)", entries, queuedPath, err)
+		}
+		queuedPath = filepath.Join(root, "tasks", "queued", entries[0].Name())
+	}
+
+	loaded, err := taskpkg.Load(queuedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Status != taskpkg.StatusQueued {
+		t.Fatalf("queued task status got %q, want %q", loaded.Status, taskpkg.StatusQueued)
+	}
+	raw, err := os.ReadFile(queuedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "status: queued") && !strings.Contains(string(raw), `status: "queued"`) {
+		t.Fatalf("queued YAML must persist status queued:\n%s", raw)
+	}
+}

--- a/internal/cli/task_show_preflight_test.go
+++ b/internal/cli/task_show_preflight_test.go
@@ -32,10 +32,8 @@ func writePreflightEnabledTask(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	loaded.Status = "running"
-	required := true
 	loaded.Preflight = &taskpkg.Preflight{AcceptanceSkeleton: &taskpkg.AcceptanceSkeletonConfig{
-		Enabled:  true,
-		Required: &required,
+		Enabled: true,
 		Outputs: []taskpkg.AcceptanceSkeletonOutputDef{{
 			ACID:                   "AC1",
 			Path:                   "internal/foo/foo_test.go",

--- a/internal/daemon/acceptance_gate_test.go
+++ b/internal/daemon/acceptance_gate_test.go
@@ -12,9 +12,6 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-// acceptanceGateTask builds a minimal task with the acceptance skeleton stage
-// enabled so evaluateAcceptanceGate exercises the skeleton branch. Coverage is
-// always required when the stage is enabled.
 func acceptanceGateTask() *task.Task {
 	return &task.Task{
 		ID:                 "acceptance-gate-test",

--- a/internal/daemon/acceptance_gate_test.go
+++ b/internal/daemon/acceptance_gate_test.go
@@ -12,17 +12,15 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-func acceptanceGateBoolPtr(b bool) *bool { return &b }
-
 // acceptanceGateTask builds a minimal task with the acceptance skeleton stage
-// enabled so evaluateAcceptanceGate exercises the skeleton branch.
-func acceptanceGateTask(required bool) *task.Task {
+// enabled so evaluateAcceptanceGate exercises the skeleton branch. Coverage is
+// always required when the stage is enabled.
+func acceptanceGateTask() *task.Task {
 	return &task.Task{
 		ID:                 "acceptance-gate-test",
 		AcceptanceCriteria: []task.AcceptanceCriterion{{ID: "AC1", Text: "x", Status: "pending"}},
 		Preflight: &task.Preflight{AcceptanceSkeleton: &task.AcceptanceSkeletonConfig{
-			Enabled:  true,
-			Required: acceptanceGateBoolPtr(required),
+			Enabled: true,
 		}},
 	}
 }
@@ -58,7 +56,7 @@ func skeletonOutput() skeletonpreflight.Output {
 func TestAcceptanceGateDowngradesOnMissingRequiredSkeletonCoverage(t *testing.T) {
 	t.Parallel()
 	runDir := writeAcceptanceGateRun(t, "completed", nil)
-	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(true), runDir)
+	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(), runDir)
 	if ok {
 		t.Fatalf("expected missing skeleton coverage to block acceptance, reason=%q", reason)
 	}
@@ -70,7 +68,7 @@ func TestAcceptanceGateDowngradesOnMissingRequiredSkeletonCoverage(t *testing.T)
 func TestAcceptanceGateAllowsWhenRequiredSkeletonCoverageExists(t *testing.T) {
 	t.Parallel()
 	runDir := writeAcceptanceGateRun(t, "completed", []skeletonpreflight.Output{skeletonOutput()})
-	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(true), runDir)
+	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(), runDir)
 	if !ok {
 		t.Fatalf("expected gate to allow acceptance, reason=%q", reason)
 	}
@@ -88,7 +86,7 @@ func TestAcceptanceGateDowngradesOnFailedPreflightResult(t *testing.T) {
 	if err := skeletonpreflight.WriteResult(runDir, res); err != nil {
 		t.Fatal(err)
 	}
-	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(true), runDir)
+	reason, ok := evaluateAcceptanceGate(acceptanceGateTask(), runDir)
 	if ok || !strings.Contains(reason, "preflight failed") {
 		t.Fatalf("ok=%v reason=%q", ok, reason)
 	}
@@ -106,7 +104,7 @@ func TestAcceptanceGateLifecycleDowngradesAcceptedVerdictBeforeFinalize(t *testi
 		t.Fatal(err)
 	}
 	runningPath := filepath.Join(runningDir, "task.yaml")
-	loaded := acceptanceGateTask(true)
+	loaded := acceptanceGateTask()
 	loaded.Status = "running"
 	loaded.Attempts = []task.Attempt{{Number: 1}}
 	if err := task.Save(runningPath, *loaded); err != nil {

--- a/internal/daemon/acceptance_skeleton_task_update_test.go
+++ b/internal/daemon/acceptance_skeleton_task_update_test.go
@@ -125,9 +125,8 @@ func TestApplyAcceptanceSkeletonResultToTaskWithDuplicatePathsPassesTaskValidate
 			Permission:     "edit",
 		},
 		ExecutionPolicy: task.ExecutionPolicy{
-			LoopBudget:        task.LoopBudget{Count: 1, Set: true},
-			TimeoutMS:         1000,
-			AFKDecisionPolicy: "choose-smallest-reversible",
+			LoopBudget: task.LoopBudget{Count: 1, Set: true},
+			TimeoutMS:  1000,
 		},
 		Worktree: task.Worktree{
 			Enabled: true,
@@ -140,7 +139,7 @@ func TestApplyAcceptanceSkeletonResultToTaskWithDuplicatePathsPassesTaskValidate
 			Model:  "opus",
 			Effort: "high",
 		},
-		Preflight: &task.Preflight{AcceptanceSkeleton: &task.AcceptanceSkeletonConfig{Enabled: true, Mode: "skeleton"}},
+		Preflight: &task.Preflight{AcceptanceSkeleton: &task.AcceptanceSkeletonConfig{Enabled: true}},
 	}
 
 	res := &skeletonpreflight.Result{Outputs: []skeletonpreflight.Output{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -174,7 +174,6 @@ type ExplicitOptions struct {
 	MaxConcurrentPerRepo   bool
 	PollInterval           bool
 	ClaimTTL               bool
-	HeartbeatInterval      bool
 	ShutdownTimeout        bool
 	IdleTimeout            bool
 	CommitOnAccept         bool
@@ -385,14 +384,13 @@ func (opts Options) withDefaults() Options {
 	if opts.IdleTimeout <= 0 {
 		opts.IdleTimeout = 10 * time.Minute
 	}
+	// Heartbeat cadence is derived only from claim_ttl: min(claim_ttl/4, 1m).
+	opts.HeartbeatInterval = opts.ClaimTTL / 4
 	if opts.HeartbeatInterval <= 0 {
-		opts.HeartbeatInterval = opts.ClaimTTL / 4
-		if opts.HeartbeatInterval <= 0 {
-			opts.HeartbeatInterval = time.Minute
-		}
-		if opts.HeartbeatInterval > time.Minute {
-			opts.HeartbeatInterval = time.Minute
-		}
+		opts.HeartbeatInterval = time.Minute
+	}
+	if opts.HeartbeatInterval > time.Minute {
+		opts.HeartbeatInterval = time.Minute
 	}
 	if opts.OpenPR && !opts.Explicit.CommitOnAccept {
 		opts.CommitOnAccept = true

--- a/internal/daemon/options_test.go
+++ b/internal/daemon/options_test.go
@@ -22,6 +22,26 @@ func TestWithDefaultsAppliesIdleTimeout(t *testing.T) {
 	}
 }
 
+func TestWithDefaultsDerivesHeartbeatFromClaimTTL(t *testing.T) {
+	t.Parallel()
+	if got := (Options{}).withDefaults().HeartbeatInterval; got != time.Minute {
+		t.Fatalf("default claim_ttl heartbeat got %s, want 1m", got)
+	}
+	if got := (Options{ClaimTTL: 2 * time.Minute}).withDefaults().HeartbeatInterval; got != 30*time.Second {
+		t.Fatalf("2m claim_ttl heartbeat got %s, want 30s", got)
+	}
+	if got := (Options{ClaimTTL: 4 * time.Minute}).withDefaults().HeartbeatInterval; got != time.Minute {
+		t.Fatalf("4m claim_ttl heartbeat got %s, want 1m", got)
+	}
+	if got := (Options{ClaimTTL: time.Hour}).withDefaults().HeartbeatInterval; got != time.Minute {
+		t.Fatalf("1h claim_ttl heartbeat got %s, want 1m", got)
+	}
+	// Leftover HeartbeatInterval is ignored; claim_ttl is the sole input.
+	if got := (Options{ClaimTTL: 2 * time.Minute, HeartbeatInterval: 5 * time.Second}).withDefaults().HeartbeatInterval; got != 30*time.Second {
+		t.Fatalf("stale HeartbeatInterval must be overwritten, got %s", got)
+	}
+}
+
 func TestPreflightDefaultsSupervisorToClaude(t *testing.T) {
 	t.Parallel()
 	opts, err := Preflight(Options{Root: t.TempDir()})

--- a/internal/daemoncmd/command.go
+++ b/internal/daemoncmd/command.go
@@ -137,8 +137,7 @@ func NewCommand(use string) *cobra.Command {
 	flags.IntVar(&opts.MaxConcurrentTasks, "max-concurrent-tasks", 1, "Maximum concurrent tasks")
 	flags.IntVar(&opts.MaxConcurrentPerRepo, "max-concurrent-per-repo", 1, "Maximum concurrent tasks per source repository; 0 disables the per-repo limit")
 	flags.DurationVar(&pollInterval, "poll-interval", 10*time.Second, "Polling interval for non-once mode")
-	flags.DurationVar(&opts.ClaimTTL, "claim-ttl", 30*time.Minute, "Recover running task and claim locks older than this duration")
-	flags.DurationVar(&opts.HeartbeatInterval, "heartbeat-interval", 0, "Running task heartbeat interval; defaults to min(claim-ttl/4, 1m)")
+	flags.DurationVar(&opts.ClaimTTL, "claim-ttl", 30*time.Minute, "Recover running task and claim locks older than this duration; also sets heartbeat cadence to min(claim-ttl/4, 1m)")
 	flags.DurationVar(&opts.ShutdownTimeout, "shutdown-timeout", 5*time.Minute, "After SIGINT/SIGTERM, let active attempts finish for this duration before canceling them")
 	flags.DurationVar(&opts.IdleTimeout, "idle-timeout", 10*time.Minute, "Kill an executor or built-in supervisor subprocess that produces no stdout/stderr output for this duration")
 	flags.StringVar(&supervisorProvider, "supervisor", "", fmt.Sprintf("Built-in supervisor adapter: %s; defaults to %s", strings.Join(daemonconfig.SupervisorCLIs(), ", "), daemon.DefaultSupervisor))
@@ -196,13 +195,6 @@ func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg da
 			opts.ClaimTTL = d
 		}
 	}
-	if !opts.Explicit.HeartbeatInterval && cfg.HeartbeatInterval != "" {
-		if d, ok, err := daemonConfigDuration("heartbeat_interval", cfg.HeartbeatInterval); err != nil {
-			return err
-		} else if ok {
-			opts.HeartbeatInterval = d
-		}
-	}
 	if !opts.Explicit.ShutdownTimeout && cfg.ShutdownTimeout != "" {
 		if d, ok, err := daemonConfigDuration("shutdown_timeout", cfg.ShutdownTimeout); err != nil {
 			return err
@@ -244,7 +236,6 @@ func explicitOptionsFromFlags(cmd *cobra.Command) daemon.ExplicitOptions {
 		MaxConcurrentPerRepo: changed("max-concurrent-per-repo"),
 		PollInterval:         changed("poll-interval"),
 		ClaimTTL:             changed("claim-ttl"),
-		HeartbeatInterval:    changed("heartbeat-interval"),
 		ShutdownTimeout:      changed("shutdown-timeout"),
 		IdleTimeout:          changed("idle-timeout"),
 		Supervisor:           changed("supervisor"),

--- a/internal/daemoncmd/command_test.go
+++ b/internal/daemoncmd/command_test.go
@@ -136,7 +136,6 @@ func TestApplyDaemonConfigFillsAbsentFlagsAndPreservesExplicit(t *testing.T) {
 		MaxConcurrentPerRepo: &two,
 		PollInterval:         "30s",
 		ClaimTTL:             "1h",
-		HeartbeatInterval:    "15s",
 		ShutdownTimeout:      "2m",
 		IdleTimeout:          "5m",
 	}
@@ -160,8 +159,12 @@ func TestApplyDaemonConfigFillsAbsentFlagsAndPreservesExplicit(t *testing.T) {
 	if opts.ShutdownTimeout != 2*time.Minute {
 		t.Fatalf("daemon.yaml shutdown_timeout not applied: %s", opts.ShutdownTimeout)
 	}
-	if opts.ClaimTTL != time.Hour || opts.HeartbeatInterval != 15*time.Second || opts.IdleTimeout != 5*time.Minute {
+	if opts.ClaimTTL != time.Hour || opts.IdleTimeout != 5*time.Minute {
 		t.Fatalf("daemon.yaml durations not applied: %#v", opts)
+	}
+	// Heartbeat is derived from claim_ttl at withDefaults time, not from config.
+	if opts.HeartbeatInterval != 0 {
+		t.Fatalf("heartbeat must not be filled from daemon.yaml; got %s", opts.HeartbeatInterval)
 	}
 	if poll != 30*time.Second {
 		t.Fatalf("daemon.yaml poll_interval not applied: %s", poll)

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -59,7 +59,6 @@ type File struct {
 	MaxConcurrentPerRepo *int   `yaml:"max_concurrent_per_repo,omitempty"`
 	PollInterval         string `yaml:"poll_interval,omitempty"`
 	ClaimTTL             string `yaml:"claim_ttl,omitempty"`
-	HeartbeatInterval    string `yaml:"heartbeat_interval,omitempty"`
 	ShutdownTimeout      string `yaml:"shutdown_timeout,omitempty"`
 	IdleTimeout          string `yaml:"idle_timeout,omitempty"`
 	// GLMAPIKey is the Z.ai token used when glm is the executor or supervisor.
@@ -147,7 +146,6 @@ func Defaults() File {
 		MaxConcurrentPerRepo: &one,
 		PollInterval:         "10s",
 		ClaimTTL:             "30m",
-		HeartbeatInterval:    "1m",
 		ShutdownTimeout:      "5m",
 		IdleTimeout:          "10m",
 		Notifications: &NotificationConfig{
@@ -202,7 +200,8 @@ func EnsureDefault(root string) (bool, error) {
 
 // Load reads daemon.yaml under root. The boolean reports whether the file was
 // present. A missing file is not an error; the caller proceeds with built-in
-// defaults.
+// defaults. Legacy heartbeat_interval keys are stripped before strict decode
+// because heartbeat cadence is derived solely from claim_ttl.
 func Load(root string) (File, bool, error) {
 	if root == "" {
 		return File{}, false, errors.New("daemonconfig: root is required")
@@ -215,6 +214,7 @@ func Load(root string) (File, bool, error) {
 		}
 		return File{}, false, fmt.Errorf("read %s: %w", path, err)
 	}
+	data = stripLegacyHeartbeatInterval(data)
 	var file File
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
@@ -225,6 +225,39 @@ func Load(root string) (File, bool, error) {
 		return File{}, true, fmt.Errorf("validate %s: %w", path, err)
 	}
 	return file, true, nil
+}
+
+// stripLegacyHeartbeatInterval drops the removed heartbeat_interval key so
+// existing daemon.yaml files created before claim_ttl-derived heartbeats keep
+// loading under KnownFields(true).
+func stripLegacyHeartbeatInterval(data []byte) []byte {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return data
+	}
+	doc := &root
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		doc = root.Content[0]
+	}
+	if doc.Kind != yaml.MappingNode {
+		return data
+	}
+	filtered := make([]*yaml.Node, 0, len(doc.Content))
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "heartbeat_interval" {
+			continue
+		}
+		filtered = append(filtered, doc.Content[i], doc.Content[i+1])
+	}
+	if len(filtered) == len(doc.Content) {
+		return data
+	}
+	doc.Content = filtered
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return data
+	}
+	return out
 }
 
 // Validate checks that the fields present in the file are well-formed. An
@@ -258,7 +291,6 @@ func (f File) Validate() error {
 	}{
 		{"poll_interval", f.PollInterval},
 		{"claim_ttl", f.ClaimTTL},
-		{"heartbeat_interval", f.HeartbeatInterval},
 		{"shutdown_timeout", f.ShutdownTimeout},
 		{"idle_timeout", f.IdleTimeout},
 	} {

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -199,7 +199,7 @@ func EnsureDefault(root string) (bool, error) {
 }
 
 // Load reads daemon.yaml under root and reports whether it was present. Missing
-// files use built-in defaults; legacy heartbeat_interval is ignored for compatibility.
+// files use built-in defaults, and unknown fields are ignored for compatibility.
 func Load(root string) (File, bool, error) {
 	if root == "" {
 		return File{}, false, errors.New("daemonconfig: root is required")
@@ -212,10 +212,8 @@ func Load(root string) (File, bool, error) {
 		}
 		return File{}, false, fmt.Errorf("read %s: %w", path, err)
 	}
-	data = stripLegacyHeartbeatInterval(data)
 	var file File
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
 	if err := decoder.Decode(&file); err != nil {
 		return File{}, true, fmt.Errorf("decode %s: %w", path, err)
 	}
@@ -223,36 +221,6 @@ func Load(root string) (File, bool, error) {
 		return File{}, true, fmt.Errorf("validate %s: %w", path, err)
 	}
 	return file, true, nil
-}
-
-func stripLegacyHeartbeatInterval(data []byte) []byte {
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		return data
-	}
-	doc := &root
-	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
-		doc = root.Content[0]
-	}
-	if doc.Kind != yaml.MappingNode {
-		return data
-	}
-	filtered := make([]*yaml.Node, 0, len(doc.Content))
-	for i := 0; i+1 < len(doc.Content); i += 2 {
-		if doc.Content[i].Value == "heartbeat_interval" {
-			continue
-		}
-		filtered = append(filtered, doc.Content[i], doc.Content[i+1])
-	}
-	if len(filtered) == len(doc.Content) {
-		return data
-	}
-	doc.Content = filtered
-	out, err := yaml.Marshal(&root)
-	if err != nil {
-		return data
-	}
-	return out
 }
 
 // Validate checks that the fields present in the file are well-formed. An

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -198,10 +198,8 @@ func EnsureDefault(root string) (bool, error) {
 	return true, nil
 }
 
-// Load reads daemon.yaml under root. The boolean reports whether the file was
-// present. A missing file is not an error; the caller proceeds with built-in
-// defaults. Legacy heartbeat_interval keys are stripped before strict decode
-// because heartbeat cadence is derived solely from claim_ttl.
+// Load reads daemon.yaml under root and reports whether it was present. Missing
+// files use built-in defaults; legacy heartbeat_interval is ignored for compatibility.
 func Load(root string) (File, bool, error) {
 	if root == "" {
 		return File{}, false, errors.New("daemonconfig: root is required")
@@ -227,9 +225,6 @@ func Load(root string) (File, bool, error) {
 	return file, true, nil
 }
 
-// stripLegacyHeartbeatInterval drops the removed heartbeat_interval key so
-// existing daemon.yaml files created before claim_ttl-derived heartbeats keep
-// loading under KnownFields(true).
 func stripLegacyHeartbeatInterval(data []byte) []byte {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {

--- a/internal/daemonconfig/config_test.go
+++ b/internal/daemonconfig/config_test.go
@@ -42,13 +42,15 @@ func TestEnsureDefaultCreatesFileWithDocumentedDefaults(t *testing.T) {
 		"max_concurrent_per_repo: 1",
 		"poll_interval: 10s",
 		"claim_ttl: 30m",
-		"heartbeat_interval: 1m",
 		"shutdown_timeout: 5m",
 		"idle_timeout: 10m",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("daemon.yaml missing %q\ncontent:\n%s", want, content)
 		}
+	}
+	if strings.Contains(content, "heartbeat_interval") {
+		t.Fatalf("daemon.yaml must not expose heartbeat_interval; cadence is derived from claim_ttl\ncontent:\n%s", content)
 	}
 }
 
@@ -87,7 +89,7 @@ func TestEnsureDefaultThenLoadRoundTripsDocumentedDefaults(t *testing.T) {
 	if file.MaxConcurrentPerRepo == nil || *file.MaxConcurrentPerRepo != 1 {
 		t.Fatalf("max_concurrent_per_repo got %#v, want 1", file.MaxConcurrentPerRepo)
 	}
-	if file.PollInterval != "10s" || file.ClaimTTL != "30m" || file.HeartbeatInterval != "1m" ||
+	if file.PollInterval != "10s" || file.ClaimTTL != "30m" ||
 		file.ShutdownTimeout != "5m" || file.IdleTimeout != "10m" {
 		t.Fatalf("duration defaults drifted: %#v", file)
 	}
@@ -156,7 +158,6 @@ max_concurrent_tasks: 4
 max_concurrent_per_repo: 2
 poll_interval: 30s
 claim_ttl: 1h
-heartbeat_interval: 15s
 shutdown_timeout: 2m
 idle_timeout: 5m
 `
@@ -179,8 +180,30 @@ idle_timeout: 5m
 	if file.MaxConcurrentPerRepo == nil || *file.MaxConcurrentPerRepo != 2 {
 		t.Fatalf("max_concurrent_per_repo got %#v", file.MaxConcurrentPerRepo)
 	}
-	if file.PollInterval != "30s" || file.ClaimTTL != "1h" || file.HeartbeatInterval != "15s" || file.ShutdownTimeout != "2m" || file.IdleTimeout != "5m" {
+	if file.PollInterval != "30s" || file.ClaimTTL != "1h" || file.ShutdownTimeout != "2m" || file.IdleTimeout != "5m" {
 		t.Fatalf("durations got %#v", file)
+	}
+}
+
+func TestLoadStripsLegacyHeartbeatInterval(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := `supervisor: claude
+claim_ttl: 1h
+heartbeat_interval: 15s
+`
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, present, err := Load(root)
+	if err != nil {
+		t.Fatalf("legacy heartbeat_interval should be stripped, got %v", err)
+	}
+	if !present {
+		t.Fatalf("expected present=true")
+	}
+	if file.ClaimTTL != "1h" {
+		t.Fatalf("claim_ttl got %q, want 1h", file.ClaimTTL)
 	}
 }
 

--- a/internal/daemonconfig/config_test.go
+++ b/internal/daemonconfig/config_test.go
@@ -185,19 +185,23 @@ idle_timeout: 5m
 	}
 }
 
-func TestLoadStripsLegacyHeartbeatInterval(t *testing.T) {
+func TestLoadIgnoresUnknownFields(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	body := `supervisor: claude
 claim_ttl: 1h
 heartbeat_interval: 15s
+future_setting: enabled
+notifications:
+  enabled: false
+  future_delivery: webhook
 `
 	if err := os.WriteFile(filepath.Join(root, Filename), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	file, present, err := Load(root)
 	if err != nil {
-		t.Fatalf("legacy heartbeat_interval should be stripped, got %v", err)
+		t.Fatalf("unknown fields should be ignored, got %v", err)
 	}
 	if !present {
 		t.Fatalf("expected present=true")
@@ -226,6 +230,18 @@ func TestLoadRejectsBadDuration(t *testing.T) {
 	}
 	if _, _, err := Load(root); err == nil {
 		t.Fatalf("expected error for invalid duration")
+	}
+}
+
+func TestLoadRejectsKnownFieldTypeMismatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte("max_concurrent_tasks: many\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := Load(root)
+	if err == nil || !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("expected known-field type error, got %v", err)
 	}
 }
 

--- a/internal/preflight/skeleton/validation.go
+++ b/internal/preflight/skeleton/validation.go
@@ -264,18 +264,14 @@ func foldPathCase(p string) string {
 	return p
 }
 
-// EffectivePreflightPaths resolves preflight allowed paths against task scope.
-// When preflight.acceptance_skeleton.allowed_paths is empty the effective set
-// equals scope.allowed_paths. Forbidden paths are always inherited from scope.
+// EffectivePreflightPaths resolves skeleton write paths from task scope.
+// Allowed paths always equal scope.allowed_paths; forbidden paths are inherited
+// from scope.forbidden_paths.
 func EffectivePreflightPaths(t task.Task) ([]string, []string, error) {
 	if t.Preflight == nil || t.Preflight.AcceptanceSkeleton == nil {
 		return nil, nil, fmt.Errorf("preflight.acceptance_skeleton is not configured")
 	}
-	cfg := t.Preflight.AcceptanceSkeleton
-	allowed := cfg.AllowedPaths
-	if len(allowed) == 0 {
-		allowed = append([]string{}, t.Scope.AllowedPaths...)
-	}
+	allowed := append([]string{}, t.Scope.AllowedPaths...)
 	forbidden := append([]string{}, t.Scope.ForbiddenPaths...)
 	return allowed, forbidden, nil
 }

--- a/internal/preflight/skeleton/validation.go
+++ b/internal/preflight/skeleton/validation.go
@@ -264,9 +264,7 @@ func foldPathCase(p string) string {
 	return p
 }
 
-// EffectivePreflightPaths resolves skeleton write paths from task scope.
-// Allowed paths always equal scope.allowed_paths; forbidden paths are inherited
-// from scope.forbidden_paths.
+// EffectivePreflightPaths returns scope paths for acceptance-skeleton writes.
 func EffectivePreflightPaths(t task.Task) ([]string, []string, error) {
 	if t.Preflight == nil || t.Preflight.AcceptanceSkeleton == nil {
 		return nil, nil, fmt.Errorf("preflight.acceptance_skeleton is not configured")

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -42,7 +42,6 @@ type EvidenceRequirements struct {
 type PassPolicy struct {
 	RequiredDimensionsMustPass bool     `yaml:"required_dimensions_must_pass" json:"required_dimensions_must_pass"`
 	MinScore                   int      `yaml:"min_score" json:"min_score"`
-	UnresolvedHighAllowed      int      `yaml:"unresolved_high_findings_allowed" json:"unresolved_high_findings_allowed"`
 	BlockingSeverities         []string `yaml:"blocking_severities" json:"blocking_severities"`
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -150,7 +150,7 @@ func (r ValidationResult) Valid() bool {
 
 func LoadQuality(path string) (Quality, error) {
 	var q Quality
-	if err := loadYAML(path, &q); err != nil {
+	if err := loadYAML(path, &q, qualitySchemaDocument()); err != nil {
 		return Quality{}, err
 	}
 	return q, nil
@@ -158,7 +158,7 @@ func LoadQuality(path string) (Quality, error) {
 
 func LoadEnvironment(path string) (Environment, error) {
 	var env Environment
-	if err := loadYAML(path, &env); err != nil {
+	if err := loadYAML(path, &env, environmentSchemaDocument()); err != nil {
 		return Environment{}, err
 	}
 	return env, nil
@@ -380,16 +380,10 @@ func UpdateEnvironmentSetup(path string, plan SetupPlan) (*SetupPlan, error) {
 	if err := enc.Close(); err != nil {
 		return nil, fmt.Errorf("flush environment profile %s: %w", path, err)
 	}
-	// Validate the rewritten bytes in memory before publication. This is the
-	// publication boundary: parse the new document with the same KnownFields
-	// decoder used by LoadEnvironment, then run ValidateEnvironment on the
-	// decoded value. If either step fails the rewrite is rejected without
-	// touching the on-disk file at path, so the original file remains the
-	// canonical state for any reader.
+	// Validate rewritten bytes with the same required-field and known-value
+	// checks as LoadEnvironment before publishing the atomic replacement.
 	var updated Environment
-	decoder := yaml.NewDecoder(bytes.NewReader(buf.Bytes()))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(&updated); err != nil {
+	if err := decodeProfileYAML(buf.Bytes(), &updated, environmentSchemaDocument()); err != nil {
 		return nil, fmt.Errorf("decode rewritten environment profile: %w", err)
 	}
 	if vr := ValidateEnvironment(updated); !vr.Valid() {
@@ -483,17 +477,115 @@ func filepathDir(path string) string {
 	return "."
 }
 
-func loadYAML(path string, out any) error {
+func loadYAML(path string, out any, schema map[string]any) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	decoder.KnownFields(true)
-	if err := decoder.Decode(out); err != nil {
+	if err := decodeProfileYAML(data, out, schema); err != nil {
 		return fmt.Errorf("decode %s: %w", path, err)
 	}
 	return nil
+}
+
+// decodeProfileYAML uses the schema to distinguish missing keys from valid zero values.
+// ValidateQuality and ValidateEnvironment own decoded-value semantics.
+func decodeProfileYAML(data []byte, out any, schema map[string]any) error {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return err
+	}
+	if err := root.Decode(out); err != nil {
+		return err
+	}
+	missing := missingRequiredYAMLFields(&root, schema, "")
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func missingRequiredYAMLFields(node *yaml.Node, schema map[string]any, path string) []string {
+	if isYAMLNull(node) {
+		node = nil
+	}
+	if node != nil && node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			node = nil
+		} else {
+			node = node.Content[0]
+		}
+	}
+
+	schemaType, _ := schema["type"].(string)
+	switch schemaType {
+	case "object":
+		if node == nil {
+			var missing []string
+			for _, key := range schemaRequiredFields(schema) {
+				missing = append(missing, yamlFieldPath(path, key))
+			}
+			return missing
+		}
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		var missing []string
+		for _, key := range schemaRequiredFields(schema) {
+			if isYAMLNull(yamlMappingValue(node, key)) {
+				missing = append(missing, yamlFieldPath(path, key))
+			}
+		}
+		properties, _ := schema["properties"].(map[string]any)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			childSchema, ok := properties[node.Content[i].Value].(map[string]any)
+			if !ok {
+				continue
+			}
+			missing = append(missing, missingRequiredYAMLFields(node.Content[i+1], childSchema, yamlFieldPath(path, node.Content[i].Value))...)
+		}
+		return missing
+	case "array":
+		if node == nil || node.Kind != yaml.SequenceNode {
+			return nil
+		}
+		itemSchema, ok := schema["items"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		var missing []string
+		for i, item := range node.Content {
+			missing = append(missing, missingRequiredYAMLFields(item, itemSchema, fmt.Sprintf("%s[%d]", path, i))...)
+		}
+		return missing
+	default:
+		return nil
+	}
+}
+
+func schemaRequiredFields(schema map[string]any) []string {
+	fields, _ := schema["required"].([]string)
+	return fields
+}
+
+func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func isYAMLNull(node *yaml.Node) bool {
+	return node == nil || node.Kind == 0 || node.Tag == "!!null"
+}
+
+func yamlFieldPath(parent, field string) string {
+	if parent == "" {
+		return field
+	}
+	return parent + "." + field
 }
 
 func require(result *ValidationResult, ok bool, format string, args ...any) {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -48,6 +48,200 @@ func TestLoadAndValidateEnvironmentExample(t *testing.T) {
 	}
 }
 
+func TestLoadProfilesIgnoreUnknownFields(t *testing.T) {
+	t.Run("quality", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "quality.yaml")
+		body := `id: compatible
+required_checks:
+  - id: tests
+    preferred_commands: ["go test ./..."]
+    required: true
+    future_check_option: enabled
+review_dimensions:
+  - id: acceptance
+    weight: 1
+    required: true
+    pass: Acceptance criteria pass.
+evidence_requirements:
+  file_line_references: true
+  command_outputs: true
+pass_policy:
+  required_dimensions_must_pass: true
+  min_score: 85
+  unresolved_high_findings_allowed: 0
+  blocking_severities: [critical, high]
+future_profile_option: enabled
+`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		quality, err := LoadQuality(path)
+		if err != nil {
+			t.Fatalf("unknown quality fields should be ignored: %v", err)
+		}
+		if result := ValidateQuality(quality); !result.Valid() {
+			t.Fatalf("quality errors got %#v", result.Errors)
+		}
+		if quality.ID != "compatible" || quality.PassPolicy.MinScore != 85 {
+			t.Fatalf("known quality fields got %#v", quality)
+		}
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "environment.yaml")
+		body := `id: compatible
+cwd: /tmp/repo
+commands:
+  test: go test ./...
+constraints:
+  network: approval_required
+  secrets_policy: never_read_env_files
+  destructive_commands: deny
+  future_constraint: enabled
+worktree:
+  cleanup: true
+  future_worktree_option: enabled
+future_profile_option: enabled
+`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		env, err := LoadEnvironment(path)
+		if err != nil {
+			t.Fatalf("unknown environment fields should be ignored: %v", err)
+		}
+		if result := ValidateEnvironment(env); !result.Valid() {
+			t.Fatalf("environment errors got %#v", result.Errors)
+		}
+		if env.ID != "compatible" || env.Commands["test"] != "go test ./..." {
+			t.Fatalf("known environment fields got %#v", env)
+		}
+	})
+}
+
+func TestLoadProfilesRejectMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		load func(string) error
+		want string
+	}{
+		{
+			name: "quality nested boolean",
+			body: `id: missing-required
+required_checks:
+  - id: tests
+    preferred_commands: ["go test ./..."]
+    required: null
+review_dimensions: []
+evidence_requirements:
+  file_line_references: true
+  command_outputs: true
+pass_policy:
+  required_dimensions_must_pass: true
+  min_score: 85
+  blocking_severities: [high]
+`,
+			load: func(path string) error {
+				_, err := LoadQuality(path)
+				return err
+			},
+			want: "required_checks[0].required",
+		},
+		{
+			name: "environment nested string",
+			body: `id: missing-required
+cwd: /tmp/repo
+constraints:
+  network: approval_required
+  destructive_commands: deny
+`,
+			load: func(path string) error {
+				_, err := LoadEnvironment(path)
+				return err
+			},
+			want: "constraints.secrets_policy",
+		},
+		{
+			name: "empty quality document",
+			body: "",
+			load: func(path string) error {
+				_, err := LoadQuality(path)
+				return err
+			},
+			want: "missing required fields: id",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "profile.yaml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := tc.load(path)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestLoadProfileRejectsKnownFieldTypeMismatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "quality.yaml")
+	body := `id: invalid-type
+required_checks: []
+review_dimensions: []
+evidence_requirements:
+  file_line_references: true
+  command_outputs: true
+pass_policy:
+  required_dimensions_must_pass: true
+  min_score: high
+  blocking_severities: [high]
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadQuality(path); err == nil || !strings.Contains(err.Error(), "cannot unmarshal") {
+		t.Fatalf("expected known-field type error, got %v", err)
+	}
+}
+
+func TestUpdateEnvironmentSetupPreservesUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "environment.yaml")
+	body := `# repository environment
+id: compatible
+cwd: /tmp/repo
+constraints:
+  network: approval_required
+  secrets_policy: never_read_env_files
+  destructive_commands: deny
+  future_constraint: enabled
+future_profile_option: enabled
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plan := SetupPlan{Commands: []SetupCommand{{Run: "go mod download", Why: "prepare dependencies"}}}
+	prior, err := UpdateEnvironmentSetup(path, plan)
+	if err != nil {
+		t.Fatalf("update setup with unknown fields: %v", err)
+	}
+	if prior != nil {
+		t.Fatalf("prior setup got %#v, want nil", prior)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{"# repository environment", "future_constraint: enabled", "future_profile_option: enabled", "run: go mod download"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("rewritten environment missing %q:\n%s", want, content)
+		}
+	}
+}
+
 func TestLoadBundleRejectsInvalidQuality(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "quality.yaml")
 	body := `id: bad
@@ -56,8 +250,13 @@ required_checks:
     preferred_commands: []
     required: true
 review_dimensions: []
+evidence_requirements:
+  file_line_references: true
+  command_outputs: true
 pass_policy:
+  required_dimensions_must_pass: true
   min_score: 85
+  blocking_severities: [high]
 `
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -14,6 +14,10 @@ const (
 )
 
 func QualityJSONSchema() ([]byte, error) {
+	return marshalSchema(qualitySchemaDocument())
+}
+
+func qualitySchemaDocument() map[string]any {
 	schema := object(
 		required("id", "required_checks", "review_dimensions", "evidence_requirements", "pass_policy"),
 		properties(map[string]any{
@@ -54,10 +58,14 @@ func QualityJSONSchema() ([]byte, error) {
 	)
 	schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
 	schema["title"] = "Galley Quality Profile YAML"
-	return marshalSchema(schema)
+	return schema
 }
 
 func EnvironmentJSONSchema() ([]byte, error) {
+	return marshalSchema(environmentSchemaDocument())
+}
+
+func environmentSchemaDocument() map[string]any {
 	schema := object(
 		// commands is not required here: ValidateEnvironment treats an empty
 		// commands map as a warning, not an error, so an editor validating
@@ -125,7 +133,7 @@ func EnvironmentJSONSchema() ([]byte, error) {
 	)
 	schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
 	schema["title"] = "Galley Environment Profile YAML"
-	return marshalSchema(schema)
+	return schema
 }
 
 func executorSchema() map[string]any {

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -43,12 +43,11 @@ func QualityJSONSchema() ([]byte, error) {
 				}),
 			),
 			"pass_policy": object(
-				required("required_dimensions_must_pass", "min_score", "unresolved_high_findings_allowed", "blocking_severities"),
+				required("required_dimensions_must_pass", "min_score", "blocking_severities"),
 				properties(map[string]any{
-					"required_dimensions_must_pass":    boolSchema("default", true),
-					"min_score":                        integerSchema("minimum", 0, "maximum", 100, "default", 85),
-					"unresolved_high_findings_allowed": integerSchema("minimum", 0, "default", 0),
-					"blocking_severities":              arraySchema(enumSchema([]string{"critical", "high", "medium", "low"}), "default", []string{"critical", "high", "medium"}),
+					"required_dimensions_must_pass": boolSchema("default", true),
+					"min_score":                     integerSchema("minimum", 0, "maximum", 100, "default", 85),
+					"blocking_severities":           arraySchema(enumSchema([]string{"critical", "high", "medium", "low"}), "default", []string{"critical", "high", "medium"}),
 				}),
 			),
 		}),

--- a/internal/task/codex_examples_and_references_test.go
+++ b/internal/task/codex_examples_and_references_test.go
@@ -30,6 +30,9 @@ func loadExampleTask(t *testing.T, rel string) Task {
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)
 	}
+	// Examples may omit fixed AFK authoring values; public validate/queue paths
+	// apply the same defaults before structural checks.
+	ApplyDefaults(&loaded)
 	return loaded
 }
 
@@ -43,6 +46,9 @@ func TestExampleAFKTaskClaudeStillValid(t *testing.T) {
 	}
 	if loaded.Executor.CLI != "claude" {
 		t.Fatalf("examples/afk-task.yaml executor.cli = %q, want %q", loaded.Executor.CLI, "claude")
+	}
+	if loaded.Mode != DefaultMode || loaded.Status != StatusDraft || !loaded.Worktree.Enabled {
+		t.Fatalf("example defaults: mode=%q status=%q enabled=%v", loaded.Mode, loaded.Status, loaded.Worktree.Enabled)
 	}
 }
 

--- a/internal/task/codex_examples_and_references_test.go
+++ b/internal/task/codex_examples_and_references_test.go
@@ -30,8 +30,7 @@ func loadExampleTask(t *testing.T, rel string) Task {
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)
 	}
-	// Examples may omit fixed AFK authoring values; public validate/queue paths
-	// apply the same defaults before structural checks.
+	// Match the defaults applied by public validation and queueing paths.
 	ApplyDefaults(&loaded)
 	return loaded
 }

--- a/internal/task/contract.go
+++ b/internal/task/contract.go
@@ -11,15 +11,13 @@ const (
 )
 
 var (
-	validModes                  = []string{"afk"}
-	validStatuses               = AllStatuses()
-	validPermissions            = []string{"read-only", "edit", "sandbox-full-access"}
-	validExecutorCLIs           = provider.ExecutorIDs()
-	validClaudeEfforts          = provider.EffortsForTransport(provider.TransportClaude)
-	validCodexEfforts           = provider.EffortsForTransport(provider.TransportCodex)
-	validAFKDecisionPolicies    = []string{"choose-smallest-reversible"}
-	validPreflightSkeletonModes = []string{"skeleton"}
-	validTaskIDPattern          = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	validModes         = []string{"afk"}
+	validStatuses      = AllStatuses()
+	validPermissions   = []string{"read-only", "edit", "sandbox-full-access"}
+	validExecutorCLIs  = provider.ExecutorIDs()
+	validClaudeEfforts = provider.EffortsForTransport(provider.TransportClaude)
+	validCodexEfforts  = provider.EffortsForTransport(provider.TransportCodex)
+	validTaskIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 )
 
 // ExecutorCLIEnum returns the supported executor.cli values in the stable order

--- a/internal/task/defaults.go
+++ b/internal/task/defaults.go
@@ -5,16 +5,38 @@ import "github.com/shinpr/galley/internal/profile"
 // DefaultLoopBudget is the retry budget used when a task omits execution_policy.loop_budget.
 const DefaultLoopBudget = 10
 
+// DefaultMode is the sole supported task execution mode.
+const DefaultMode = "afk"
+
+// DefaultAFKDecisionPolicy is the fixed AFK ambiguity policy applied when a
+// draft omits execution_policy.afk_decision_policy (the field is no longer
+// authored; work orders still surface this constant).
+const DefaultAFKDecisionPolicy = "choose-smallest-reversible"
+
 // DefaultExecutorCLI is the fallback implementation backend.
 const DefaultExecutorCLI = "claude"
 
 // DefaultExecutorEffort is the fallback implementation effort.
 const DefaultExecutorEffort = "high"
 
-// ApplyDefaults fills task-owned defaults; executor fields resolve at run time.
+// ApplyDefaults fills fixed and omitted authoring values needed before
+// validation, display, queue eligibility, and command decisions. Executor
+// fields still resolve at run time; daemon-owned lifecycle fields are not
+// invented here.
 func ApplyDefaults(t *Task) {
+	if t.Mode == "" {
+		t.Mode = DefaultMode
+	}
+	if t.Status == "" {
+		t.Status = StatusDraft
+	}
 	if !t.ExecutionPolicy.LoopBudget.Set {
 		t.ExecutionPolicy.LoopBudget = LoopBudget{Count: DefaultLoopBudget, Set: true}
+	}
+	// AFK execution always uses an isolated worktree. bool cannot distinguish
+	// omit from false, so the fixed path always enables worktree isolation.
+	if t.Mode == DefaultMode {
+		t.Worktree.Enabled = true
 	}
 }
 

--- a/internal/task/defaults.go
+++ b/internal/task/defaults.go
@@ -8,9 +8,7 @@ const DefaultLoopBudget = 10
 // DefaultMode is the sole supported task execution mode.
 const DefaultMode = "afk"
 
-// DefaultAFKDecisionPolicy is the fixed AFK ambiguity policy applied when a
-// draft omits execution_policy.afk_decision_policy (the field is no longer
-// authored; work orders still surface this constant).
+// DefaultAFKDecisionPolicy is the fixed ambiguity policy rendered in AFK work orders.
 const DefaultAFKDecisionPolicy = "choose-smallest-reversible"
 
 // DefaultExecutorCLI is the fallback implementation backend.
@@ -19,10 +17,8 @@ const DefaultExecutorCLI = "claude"
 // DefaultExecutorEffort is the fallback implementation effort.
 const DefaultExecutorEffort = "high"
 
-// ApplyDefaults fills fixed and omitted authoring values needed before
-// validation, display, queue eligibility, and command decisions. Executor
-// fields still resolve at run time; daemon-owned lifecycle fields are not
-// invented here.
+// ApplyDefaults resolves fixed authoring values before validation, display, and
+// queue decisions. Executor defaults remain runtime-owned.
 func ApplyDefaults(t *Task) {
 	if t.Mode == "" {
 		t.Mode = DefaultMode

--- a/internal/task/defaults_test.go
+++ b/internal/task/defaults_test.go
@@ -1,0 +1,113 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplyDefaultsFillsFixedAuthoringValues(t *testing.T) {
+	t.Parallel()
+	tk := Task{
+		ID:   "task-defaults-001",
+		Goal: "goal",
+		AcceptanceCriteria: []AcceptanceCriterion{{
+			ID: "AC1", Text: "text", Verification: "verify", Status: "pending",
+		}},
+		Scope: Scope{
+			CWD: t.TempDir(), AllowedPaths: []string{"."}, Permission: "edit",
+		},
+		ExecutionPolicy: ExecutionPolicy{TimeoutMS: 1000},
+		Worktree:        Worktree{Branch: "agent/task-defaults-001", Path: "../repo.worktrees/task"},
+	}
+	ApplyDefaults(&tk)
+	if tk.Mode != DefaultMode {
+		t.Fatalf("mode got %q, want %q", tk.Mode, DefaultMode)
+	}
+	if tk.Status != StatusDraft {
+		t.Fatalf("status got %q, want %q", tk.Status, StatusDraft)
+	}
+	if !tk.Worktree.Enabled {
+		t.Fatal("worktree.enabled should default to true for AFK")
+	}
+	if !tk.ExecutionPolicy.LoopBudget.Set || tk.ExecutionPolicy.LoopBudget.Count != DefaultLoopBudget {
+		t.Fatalf("loop_budget got %#v, want set count=%d", tk.ExecutionPolicy.LoopBudget, DefaultLoopBudget)
+	}
+}
+
+func TestLoadAndValidateAcceptsMinimalDraft(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	path := filepath.Join(dir, "minimal.yaml")
+	body := strings.Join([]string{
+		`id: "task-minimal-001"`,
+		`goal: "Implement a small change."`,
+		`acceptance_criteria:`,
+		`  - id: "AC1"`,
+		`    text: "observable"`,
+		`    verification: "test"`,
+		`    status: "pending"`,
+		`scope:`,
+		`  cwd: "` + cwd + `"`,
+		`  allowed_paths: ["."]`,
+		`  forbidden_paths: [".env"]`,
+		`  permission: "edit"`,
+		`execution_policy:`,
+		`  loop_budget: 10`,
+		`  timeout_ms: 1000`,
+		`worktree:`,
+		`  branch: "agent/task-minimal-001"`,
+		`  path: "../repo.worktrees/task-minimal-001"`,
+		`decisions: []`,
+		`risks: []`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := LoadAndValidate(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Valid() {
+		t.Fatalf("minimal draft should validate, got %v", result.Errors)
+	}
+	if result.Task.Mode != DefaultMode {
+		t.Fatalf("mode got %q, want %q", result.Task.Mode, DefaultMode)
+	}
+	if result.Task.Status != StatusDraft {
+		t.Fatalf("status got %q, want %q", result.Task.Status, StatusDraft)
+	}
+	if !result.Task.Worktree.Enabled {
+		t.Fatal("worktree should be enabled after defaults")
+	}
+}
+
+func TestWorkOrderUsesFixedAFKDecisionPolicy(t *testing.T) {
+	t.Parallel()
+	tk := Task{
+		ID:   "task-wo-001",
+		Mode: "afk",
+		Goal: "goal",
+		AcceptanceCriteria: []AcceptanceCriterion{{
+			ID: "AC1", Text: "text", Verification: "verify", Status: "pending",
+		}},
+		Scope: Scope{
+			CWD: "/tmp/repo", AllowedPaths: []string{"."}, Permission: "edit",
+		},
+		ExecutionPolicy: ExecutionPolicy{
+			LoopBudget: LoopBudget{Count: 3, Set: true},
+			TimeoutMS:  1000,
+		},
+		Worktree: Worktree{Enabled: true, Branch: "agent/task-wo-001", Path: "../repo.worktrees/task"},
+	}
+	text := RenderWorkOrder(tk)
+	if !strings.Contains(text, "AFK decision policy: `"+DefaultAFKDecisionPolicy+"`") {
+		t.Fatalf("work order missing fixed AFK decision policy:\n%s", text)
+	}
+	if strings.Contains(text, "stop_on_") {
+		t.Fatalf("work order must not surface removed stop_on_* knobs:\n%s", text)
+	}
+}

--- a/internal/task/defaults_test.go
+++ b/internal/task/defaults_test.go
@@ -3,6 +3,7 @@ package task
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -50,7 +51,7 @@ func TestLoadAndValidateAcceptsMinimalDraft(t *testing.T) {
 		`    verification: "test"`,
 		`    status: "pending"`,
 		`scope:`,
-		`  cwd: "` + cwd + `"`,
+		`  cwd: ` + strconv.Quote(cwd),
 		`  allowed_paths: ["."]`,
 		`  forbidden_paths: [".env"]`,
 		`  permission: "edit"`,

--- a/internal/task/defaults_test.go
+++ b/internal/task/defaults_test.go
@@ -105,7 +105,7 @@ func TestWorkOrderUsesFixedAFKDecisionPolicy(t *testing.T) {
 		Worktree: Worktree{Enabled: true, Branch: "agent/task-wo-001", Path: "../repo.worktrees/task"},
 	}
 	text := RenderWorkOrder(tk)
-	if !strings.Contains(text, "AFK decision policy: `"+DefaultAFKDecisionPolicy+"`") {
+	if !strings.Contains(text, "AFK decision policy: `choose-smallest-reversible`") {
 		t.Fatalf("work order missing fixed AFK decision policy:\n%s", text)
 	}
 	if strings.Contains(text, "stop_on_") {

--- a/internal/task/example_schema_parity_test.go
+++ b/internal/task/example_schema_parity_test.go
@@ -12,9 +12,6 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys ensures checked-in
-// examples satisfy the generated schema required-key contract so authoring
-// samples stay aligned with schema generation.
 func TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys(t *testing.T) {
 	t.Parallel()
 	root := repoRootFromTestFile(t)
@@ -41,7 +38,6 @@ func TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys(t *testing.T) {
 				t.Fatalf("parse example YAML: %v", err)
 			}
 			assertRequiredSchemaKeys(t, "", doc, taskSchemaDoc)
-			// Author-facing examples omit fixed defaults and lifecycle sections.
 			for _, key := range []string{"mode", "status", "supervisor", "attempts", "verification", "pr"} {
 				if _, ok := doc[key]; ok {
 					t.Fatalf("%s must omit author-facing lifecycle/default field %q", rel, key)
@@ -133,8 +129,7 @@ func assertRequiredSchemaKeys(t *testing.T, path string, doc map[string]any, sch
 	}
 }
 
-// staleNestedDraftYAMLFields are parent/child pairs that must not appear as
-// normally indented draft YAML shapes in packaged authoring guidance.
+// staleNestedDraftYAMLFields lists removed parent/child authoring shapes.
 var staleNestedDraftYAMLFields = []struct {
 	parent string
 	child  string
@@ -146,14 +141,8 @@ var staleNestedDraftYAMLFields = []struct {
 	{parent: "worktree", child: "enabled"},
 }
 
-// containsNormallyIndentedNestedYAMLKey reports whether text contains a YAML
-// parent mapping with a more-indented child key line:
-//
-//	parent:
-//	  child: ...
-//
-// Dotted prose mentions (worktree.enabled) and the same child key under a
-// different parent (preflight.acceptance_skeleton.enabled) do not match.
+// containsNormallyIndentedNestedYAMLKey matches a child nested under a named
+// parent, excluding dotted prose and the same child under another parent.
 func containsNormallyIndentedNestedYAMLKey(text, parent, child string) bool {
 	lines := strings.Split(text, "\n")
 	for i, line := range lines {
@@ -295,9 +284,6 @@ func TestContainsNormallyIndentedNestedYAMLKey(t *testing.T) {
 	}
 }
 
-// TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance
-// searches skill-bundled authoring guidance for stale fixed/runtime fields that
-// must not be instructed as new-draft authoring surface.
 func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *testing.T) {
 	t.Parallel()
 	root := repoRootFromTestFile(t)
@@ -308,7 +294,6 @@ func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *t
 	}
 	text := string(raw)
 
-	// Draft shapes live under Step 7; Field Guidance is nested inside that step.
 	commonShapes := sectionBetween(text, "## Step 7: Fill Skeleton With Schema", "## Step 8: Validate And Repair")
 	if commonShapes == "" {
 		t.Fatal("could not locate Step 7 common shapes guidance")
@@ -326,13 +311,11 @@ func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *t
 			t.Fatalf("task-authoring draft guidance still authors nested %s.%s YAML", pair.parent, pair.child)
 		}
 	}
-	// Retained authoring surface must stay present; the nested guard targets
-	// parent-scoped keys, so acceptance_skeleton.enabled is not treated as stale.
+	// The parent-scoped guard must retain acceptance_skeleton.enabled.
 	if !strings.Contains(fieldGuidance, "preflight.acceptance_skeleton.enabled") {
 		t.Fatal("task-authoring Field Guidance must retain preflight.acceptance_skeleton.enabled")
 	}
 
-	// Other stale top-level draft shapes / fixed defaults (not nested pairs).
 	staleDraftYAML := []string{
 		"\nverification:\n  commands:",
 		"\nattempts:",
@@ -369,12 +352,12 @@ func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *t
 	}
 
 	for _, want := range []string{
-		"Omit `mode`, `status`, `worktree.enabled`",
-		"daemon-owned lifecycle sections",
-		"Do not author `worktree.enabled`",
+		"Galley owns `mode`, `status`, `worktree.enabled`",
+		"lifecycle sections",
+		"Galley always enables AFK isolation",
 	} {
 		if !strings.Contains(fieldGuidance, want) {
-			t.Fatalf("task-authoring Field Guidance missing omit guidance %q", want)
+			t.Fatalf("task-authoring Field Guidance missing ownership guidance %q", want)
 		}
 	}
 }

--- a/internal/task/example_schema_parity_test.go
+++ b/internal/task/example_schema_parity_test.go
@@ -1,0 +1,396 @@
+package task
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/profile"
+	"go.yaml.in/yaml/v3"
+)
+
+// TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys ensures checked-in
+// examples satisfy the generated schema required-key contract so authoring
+// samples stay aligned with schema generation.
+func TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys(t *testing.T) {
+	t.Parallel()
+	root := repoRootFromTestFile(t)
+
+	taskSchema, err := TaskJSONSchema()
+	if err != nil {
+		t.Fatalf("TaskJSONSchema: %v", err)
+	}
+	var taskSchemaDoc map[string]any
+	if err := json.Unmarshal(taskSchema, &taskSchemaDoc); err != nil {
+		t.Fatalf("parse task schema: %v", err)
+	}
+
+	for _, rel := range []string{"examples/afk-task.yaml", "examples/afk-task-codex.yaml"} {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+			raw, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var doc map[string]any
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("parse example YAML: %v", err)
+			}
+			assertRequiredSchemaKeys(t, "", doc, taskSchemaDoc)
+			// Author-facing examples omit fixed defaults and lifecycle sections.
+			for _, key := range []string{"mode", "status", "supervisor", "attempts", "verification", "pr"} {
+				if _, ok := doc[key]; ok {
+					t.Fatalf("%s must omit author-facing lifecycle/default field %q", rel, key)
+				}
+			}
+			if wt, ok := doc["worktree"].(map[string]any); ok {
+				if _, has := wt["enabled"]; has {
+					t.Fatalf("%s must omit worktree.enabled", rel)
+				}
+			}
+			if pol, ok := doc["execution_policy"].(map[string]any); ok {
+				for _, key := range []string{
+					"afk_decision_policy",
+					"stop_on_destructive_operation",
+					"stop_on_missing_secret",
+					"stop_on_external_service_unavailable",
+				} {
+					if _, has := pol[key]; has {
+						t.Fatalf("%s must omit removed execution_policy field %q", rel, key)
+					}
+				}
+			}
+		})
+	}
+
+	qualitySchema, err := profile.QualityJSONSchema()
+	if err != nil {
+		t.Fatalf("QualityJSONSchema: %v", err)
+	}
+	var qualitySchemaDoc map[string]any
+	if err := json.Unmarshal(qualitySchema, &qualitySchemaDoc); err != nil {
+		t.Fatalf("parse quality schema: %v", err)
+	}
+	qualityPath := filepath.Join(root, "examples/quality-default.yaml")
+	raw, err := os.ReadFile(qualityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var qualityDoc map[string]any
+	if err := yaml.Unmarshal(raw, &qualityDoc); err != nil {
+		t.Fatalf("parse quality example: %v", err)
+	}
+	assertRequiredSchemaKeys(t, "", qualityDoc, qualitySchemaDoc)
+
+	quality, err := profile.LoadQuality(qualityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result := profile.ValidateQuality(quality); !result.Valid() {
+		t.Fatalf("quality-default validation failed: %#v", result.Errors)
+	}
+	wantSeverities := []string{"critical", "high", "medium"}
+	if !reflect.DeepEqual(quality.PassPolicy.BlockingSeverities, wantSeverities) {
+		t.Fatalf("quality-default blocking_severities got %#v, want %#v (schema default)", quality.PassPolicy.BlockingSeverities, wantSeverities)
+	}
+	if strings.Contains(string(raw), "unresolved_high_findings_allowed") {
+		t.Fatal("quality-default must not retain removed unresolved_high_findings_allowed")
+	}
+}
+
+func assertRequiredSchemaKeys(t *testing.T, path string, doc map[string]any, schema map[string]any) {
+	t.Helper()
+	required, _ := schema["required"].([]any)
+	props, _ := schema["properties"].(map[string]any)
+	for _, rawKey := range required {
+		key, ok := rawKey.(string)
+		if !ok {
+			continue
+		}
+		fieldPath := key
+		if path != "" {
+			fieldPath = path + "." + key
+		}
+		value, present := doc[key]
+		if !present {
+			t.Fatalf("example missing required schema key %q", fieldPath)
+		}
+		childSchema, ok := props[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		if childSchema["type"] == "object" {
+			childDoc, ok := value.(map[string]any)
+			if !ok {
+				t.Fatalf("example %q must be an object for schema parity", fieldPath)
+			}
+			assertRequiredSchemaKeys(t, fieldPath, childDoc, childSchema)
+		}
+	}
+}
+
+// staleNestedDraftYAMLFields are parent/child pairs that must not appear as
+// normally indented draft YAML shapes in packaged authoring guidance.
+var staleNestedDraftYAMLFields = []struct {
+	parent string
+	child  string
+}{
+	{parent: "execution_policy", child: "afk_decision_policy"},
+	{parent: "execution_policy", child: "stop_on_destructive_operation"},
+	{parent: "execution_policy", child: "stop_on_missing_secret"},
+	{parent: "execution_policy", child: "stop_on_external_service_unavailable"},
+	{parent: "worktree", child: "enabled"},
+}
+
+// containsNormallyIndentedNestedYAMLKey reports whether text contains a YAML
+// parent mapping with a more-indented child key line:
+//
+//	parent:
+//	  child: ...
+//
+// Dotted prose mentions (worktree.enabled) and the same child key under a
+// different parent (preflight.acceptance_skeleton.enabled) do not match.
+func containsNormallyIndentedNestedYAMLKey(text, parent, child string) bool {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		parentIndent, parentContent, ok := splitYAMLIndent(line)
+		if !ok || !isYAMLMappingKey(parentContent, parent) {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			childIndent, childContent, childOK := splitYAMLIndent(lines[j])
+			if !childOK {
+				continue
+			}
+			if childIndent <= parentIndent {
+				break
+			}
+			if isYAMLMappingKey(childContent, child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func splitYAMLIndent(line string) (indent int, content string, ok bool) {
+	if strings.TrimSpace(line) == "" {
+		return 0, "", false
+	}
+	trimmed := strings.TrimLeft(line, " \t")
+	if strings.HasPrefix(trimmed, "#") {
+		return 0, "", false
+	}
+	return len(line) - len(trimmed), trimmed, true
+}
+
+func isYAMLMappingKey(content, key string) bool {
+	prefix := key + ":"
+	if content == prefix {
+		return true
+	}
+	return strings.HasPrefix(content, prefix+" ") || strings.HasPrefix(content, prefix+"\t")
+}
+
+func TestContainsNormallyIndentedNestedYAMLKey(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		text   string
+		parent string
+		child  string
+		want   bool
+	}{
+		{
+			name:   "rejects worktree.enabled draft shape",
+			text:   "worktree:\n  enabled: true\n  branch: agent/x\n  path: ../repo.worktrees/x\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   true,
+		},
+		{
+			name:   "rejects execution_policy.afk_decision_policy",
+			text:   "execution_policy:\n  loop_budget: 10\n  timeout_ms: 1000\n  afk_decision_policy: escalate\n",
+			parent: "execution_policy",
+			child:  "afk_decision_policy",
+			want:   true,
+		},
+		{
+			name:   "rejects execution_policy.stop_on_destructive_operation",
+			text:   "execution_policy:\n  stop_on_destructive_operation: true\n  stop_on_missing_secret: true\n",
+			parent: "execution_policy",
+			child:  "stop_on_destructive_operation",
+			want:   true,
+		},
+		{
+			name:   "rejects execution_policy.stop_on_missing_secret",
+			text:   "execution_policy:\n  loop_budget: 10\n  stop_on_missing_secret: true\n",
+			parent: "execution_policy",
+			child:  "stop_on_missing_secret",
+			want:   true,
+		},
+		{
+			name:   "rejects execution_policy.stop_on_external_service_unavailable",
+			text:   "execution_policy:\n  stop_on_external_service_unavailable: true\n",
+			parent: "execution_policy",
+			child:  "stop_on_external_service_unavailable",
+			want:   true,
+		},
+		{
+			name:   "allows retained preflight.acceptance_skeleton.enabled",
+			text:   "preflight:\n  acceptance_skeleton:\n    enabled: true\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   false,
+		},
+		{
+			name:   "allows acceptance_skeleton.enabled under its own parent",
+			text:   "preflight:\n  acceptance_skeleton:\n    enabled: true\n",
+			parent: "acceptance_skeleton",
+			child:  "enabled",
+			want:   true,
+		},
+		{
+			name:   "ignores prose dotted path mentions",
+			text:   "Omit `mode`, `status`, `worktree.enabled`, and AFK decision policy.\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   false,
+		},
+		{
+			name:   "ignores worktree without enabled child",
+			text:   "worktree:\n  branch: agent/x\n  path: ../repo.worktrees/x\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   false,
+		},
+		{
+			name:   "ignores key prefix collisions",
+			text:   "worktree:\n  enabled_extra: true\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   false,
+		},
+		{
+			name:   "stops at sibling blocks",
+			text:   "worktree:\n  branch: agent/x\nother:\n  enabled: true\n",
+			parent: "worktree",
+			child:  "enabled",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := containsNormallyIndentedNestedYAMLKey(tc.text, tc.parent, tc.child)
+			if got != tc.want {
+				t.Fatalf("containsNormallyIndentedNestedYAMLKey(%q, %q) = %v, want %v\ntext:\n%s", tc.parent, tc.child, got, tc.want, tc.text)
+			}
+		})
+	}
+}
+
+// TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance
+// searches skill-bundled authoring guidance for stale fixed/runtime fields that
+// must not be instructed as new-draft authoring surface.
+func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *testing.T) {
+	t.Parallel()
+	root := repoRootFromTestFile(t)
+	path := filepath.Join(root, "plugins/galley/skills/galley/references/task-authoring.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+
+	// Draft shapes live under Step 7; Field Guidance is nested inside that step.
+	commonShapes := sectionBetween(text, "## Step 7: Fill Skeleton With Schema", "## Step 8: Validate And Repair")
+	if commonShapes == "" {
+		t.Fatal("could not locate Step 7 common shapes guidance")
+	}
+	fieldGuidance := sectionBetween(text, "## Field Guidance", "## Step 8: Validate And Repair")
+	if fieldGuidance == "" {
+		fieldGuidance = sectionBetween(commonShapes, "## Field Guidance", "")
+	}
+	if fieldGuidance == "" {
+		t.Fatal("could not locate Field Guidance section")
+	}
+
+	for _, pair := range staleNestedDraftYAMLFields {
+		if containsNormallyIndentedNestedYAMLKey(commonShapes, pair.parent, pair.child) {
+			t.Fatalf("task-authoring draft guidance still authors nested %s.%s YAML", pair.parent, pair.child)
+		}
+	}
+	// Retained authoring surface must stay present; the nested guard targets
+	// parent-scoped keys, so acceptance_skeleton.enabled is not treated as stale.
+	if !strings.Contains(fieldGuidance, "preflight.acceptance_skeleton.enabled") {
+		t.Fatal("task-authoring Field Guidance must retain preflight.acceptance_skeleton.enabled")
+	}
+
+	// Other stale top-level draft shapes / fixed defaults (not nested pairs).
+	staleDraftYAML := []string{
+		"\nverification:\n  commands:",
+		"\nattempts:",
+		"\npr:\n",
+		"\nmode: \"afk\"",
+		"\nmode: afk",
+		"\nstatus: \"draft\"",
+		"\nstatus: draft",
+		"\nsupervisor:\n",
+	}
+	for _, needle := range staleDraftYAML {
+		if strings.Contains(commonShapes, needle) {
+			t.Fatalf("task-authoring common shapes/field guidance still authors stale draft YAML %q", strings.TrimSpace(needle))
+		}
+	}
+
+	staleFieldBullets := []string{
+		"- `mode`:",
+		"- `status`:",
+		"- `supervisor.review_iterations`:",
+		"- `worktree.enabled`:",
+		"- `execution_policy.afk_decision_policy`:",
+		"- `execution_policy.stop_on_destructive_operation`:",
+		"- `execution_policy.stop_on_missing_secret`:",
+		"- `execution_policy.stop_on_external_service_unavailable`:",
+		"- `attempts`:",
+		"- `verification`:",
+		"- `pr`:",
+	}
+	for _, needle := range staleFieldBullets {
+		if strings.Contains(fieldGuidance, needle) {
+			t.Fatalf("task-authoring Field Guidance still instructs authoring stale field %q", needle)
+		}
+	}
+
+	for _, want := range []string{
+		"Omit `mode`, `status`, `worktree.enabled`",
+		"daemon-owned lifecycle sections",
+		"Do not author `worktree.enabled`",
+	} {
+		if !strings.Contains(fieldGuidance, want) {
+			t.Fatalf("task-authoring Field Guidance missing omit guidance %q", want)
+		}
+	}
+}
+
+func sectionBetween(text, start, end string) string {
+	i := strings.Index(text, start)
+	if i < 0 {
+		return ""
+	}
+	rest := text[i:]
+	if end == "" {
+		return rest
+	}
+	j := strings.Index(rest[len(start):], end)
+	if j < 0 {
+		return rest
+	}
+	return rest[:len(start)+j]
+}

--- a/internal/task/example_schema_parity_test.go
+++ b/internal/task/example_schema_parity_test.go
@@ -352,13 +352,16 @@ func TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance(t *t
 	}
 
 	for _, want := range []string{
-		"Galley owns `mode`, `status`, `worktree.enabled`",
-		"lifecycle sections",
-		"Galley always enables AFK isolation",
+		"resolves them as AFK drafts",
+		"worktree isolation and the fixed decision policy",
+		"persists queued status and other lifecycle state",
 	} {
-		if !strings.Contains(fieldGuidance, want) {
-			t.Fatalf("task-authoring Field Guidance missing ownership guidance %q", want)
+		if !strings.Contains(commonShapes, want) {
+			t.Fatalf("task-authoring Step 7 missing ownership guidance %q", want)
 		}
+	}
+	if !strings.Contains(fieldGuidance, "Galley always enables AFK isolation") {
+		t.Fatal("task-authoring Field Guidance must state that Galley enables AFK isolation")
 	}
 }
 

--- a/internal/task/executor_schema_parity_test.go
+++ b/internal/task/executor_schema_parity_test.go
@@ -138,9 +138,8 @@ func runtimeTaskExecutorValid(c executorFieldCase) bool {
 			Permission:   "edit",
 		},
 		ExecutionPolicy: ExecutionPolicy{
-			LoopBudget:        LoopBudget{Count: 1, Set: true},
-			TimeoutMS:         1000,
-			AFKDecisionPolicy: "choose-smallest-reversible",
+			LoopBudget: LoopBudget{Count: 1, Set: true},
+			TimeoutMS:  1000,
 		},
 		Worktree: Worktree{
 			Enabled: true,

--- a/internal/task/preflight_validation_test.go
+++ b/internal/task/preflight_validation_test.go
@@ -27,9 +27,8 @@ func baseValidPreflightTask(t *testing.T) Task {
 			Permission:     "edit",
 		},
 		ExecutionPolicy: ExecutionPolicy{
-			LoopBudget:        LoopBudget{Count: 1, Set: true},
-			TimeoutMS:         1000,
-			AFKDecisionPolicy: "choose-smallest-reversible",
+			LoopBudget: LoopBudget{Count: 1, Set: true},
+			TimeoutMS:  1000,
 		},
 		Worktree: Worktree{
 			Enabled: true,
@@ -53,44 +52,48 @@ func TestPreflightValidationAbsentIsValid(t *testing.T) {
 	}
 }
 
-func TestPreflightValidationModeRejectsUnknown(t *testing.T) {
+func TestPreflightValidationEnabledOnlyIsValid(t *testing.T) {
 	tk := baseValidPreflightTask(t)
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
 		Enabled: true,
-		Mode:    "deadbeef",
 	}}
 	res := ValidateStructural(tk)
-	if res.Valid() {
-		t.Fatalf("expected validation error for unknown mode, got none")
-	}
-	if !containsErr(res.Errors, "preflight.acceptance_skeleton.mode") {
-		t.Fatalf("expected mode validation error, got %v", res.Errors)
+	if !res.Valid() {
+		t.Fatalf("expected enabled-only preflight to validate, got %v", res.Errors)
 	}
 }
 
-func TestPreflightValidationAllowedPathOutsideScopeIsRejected(t *testing.T) {
+func TestPreflightValidationOutputOutsideScopeIsRejected(t *testing.T) {
 	tk := baseValidPreflightTask(t)
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
-		Enabled:      true,
-		Mode:         "skeleton",
-		AllowedPaths: []string{"outside"},
+		Enabled: true,
+		Outputs: []AcceptanceSkeletonOutputDef{{
+			ACID:    "AC1",
+			Path:    "outside/foo_test.go",
+			Kind:    "go-test",
+			Purpose: "verify AC1",
+		}},
 	}}
 	res := ValidateStructural(tk)
 	if res.Valid() {
 		t.Fatalf("expected validation error, got none")
 	}
 	if !containsErr(res.Errors, "must be inside scope.allowed_paths") {
-		t.Fatalf("expected allowed_paths error, got %v", res.Errors)
+		t.Fatalf("expected scope.allowed_paths error, got %v", res.Errors)
 	}
 }
 
-func TestPreflightValidationAllowedPathForbiddenIsRejected(t *testing.T) {
+func TestPreflightValidationOutputForbiddenIsRejected(t *testing.T) {
 	tk := baseValidPreflightTask(t)
 	tk.Scope.AllowedPaths = []string{"."}
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
-		Enabled:      true,
-		Mode:         "skeleton",
-		AllowedPaths: []string{".env"},
+		Enabled: true,
+		Outputs: []AcceptanceSkeletonOutputDef{{
+			ACID:    "AC1",
+			Path:    ".env/secret_test.go",
+			Kind:    "go-test",
+			Purpose: "verify AC1",
+		}},
 	}}
 	res := ValidateStructural(tk)
 	if res.Valid() {
@@ -98,19 +101,6 @@ func TestPreflightValidationAllowedPathForbiddenIsRejected(t *testing.T) {
 	}
 	if !containsErr(res.Errors, "must not be inside scope.forbidden_paths") {
 		t.Fatalf("expected forbidden_paths error, got %v", res.Errors)
-	}
-}
-
-func TestPreflightValidationAllowedSubsetAccepted(t *testing.T) {
-	tk := baseValidPreflightTask(t)
-	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
-		Enabled:      true,
-		Mode:         "skeleton",
-		AllowedPaths: []string{"internal"},
-	}}
-	res := ValidateStructural(tk)
-	if !res.Valid() {
-		t.Fatalf("expected valid preflight, got %v", res.Errors)
 	}
 }
 
@@ -122,7 +112,6 @@ func TestPreflightValidationDuplicateOutputPathsAcrossACsAccepted(t *testing.T) 
 	}
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
 		Enabled: true,
-		Mode:    "skeleton",
 		Outputs: []AcceptanceSkeletonOutputDef{
 			{
 				ACID:    "AC1",
@@ -157,7 +146,6 @@ func TestPreflightValidationDuplicateOutputPathsSeparatorEquivalentAccepted(t *t
 	}
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
 		Enabled: true,
-		Mode:    "skeleton",
 		Outputs: []AcceptanceSkeletonOutputDef{
 			{
 				ACID:    "AC1",
@@ -187,7 +175,6 @@ func TestPreflightValidationDuplicateOutputPathStillEnforcesSafetyChecks(t *test
 	}
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
 		Enabled: true,
-		Mode:    "skeleton",
 		Outputs: []AcceptanceSkeletonOutputDef{
 			{
 				ACID:    "AC1",
@@ -227,7 +214,6 @@ func TestPreflightValidationDuplicateOutputPathStillEnforcesPathSafety(t *testin
 	}
 	tk.Preflight = &Preflight{AcceptanceSkeleton: &AcceptanceSkeletonConfig{
 		Enabled: true,
-		Mode:    "skeleton",
 		Outputs: []AcceptanceSkeletonOutputDef{
 			{
 				ACID:    "AC1",
@@ -264,12 +250,11 @@ func TestAcceptanceSkeletonConfigDefaults(t *testing.T) {
 	}
 	cfg := &AcceptanceSkeletonConfig{Enabled: true}
 	if !cfg.IsRequired() {
-		t.Fatalf("enabled config should default to required")
+		t.Fatalf("enabled config should always be required")
 	}
-	val := false
-	cfg.Required = &val
+	cfg.Enabled = false
 	if cfg.IsRequired() {
-		t.Fatalf("explicit false required should override default")
+		t.Fatalf("disabled config should not be required")
 	}
 }
 

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -37,8 +37,7 @@ func queue(path string, opts QueueOptions, readTaskID func(string) (string, erro
 	if err != nil {
 		return QueueResult{}, err
 	}
-	// Defaults must run before queue eligibility so omitted status resolves to
-	// draft and fixed AFK authoring values are present for validation.
+	// Resolve omitted status before checking queue eligibility.
 	ApplyDefaults(&loaded)
 	if !CanQueue(loaded.Status) {
 		return QueueResult{}, fmt.Errorf("task %s status %q cannot be queued with task queue; use task requeue for reviewed tasks", loaded.ID, loaded.Status)

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -37,11 +37,13 @@ func queue(path string, opts QueueOptions, readTaskID func(string) (string, erro
 	if err != nil {
 		return QueueResult{}, err
 	}
+	// Defaults must run before queue eligibility so omitted status resolves to
+	// draft and fixed AFK authoring values are present for validation.
+	ApplyDefaults(&loaded)
 	if !CanQueue(loaded.Status) {
 		return QueueResult{}, fmt.Errorf("task %s status %q cannot be queued with task queue; use task requeue for reviewed tasks", loaded.ID, loaded.Status)
 	}
 	ResolveFileSources(path, &loaded)
-	ApplyDefaults(&loaded)
 	loaded.Status = StatusQueued
 	validation := Validate(loaded)
 	if !validation.Valid() {

--- a/internal/task/schema.go
+++ b/internal/task/schema.go
@@ -7,13 +7,8 @@ import (
 	"github.com/shinpr/galley/internal/provider"
 )
 
-// TaskJSONSchema returns the task YAML JSON Schema generated from the task
-// contract used by structural validation.
-//
-// Author-required fields are the retained authoring surface. mode, status, and
-// worktree.enabled default at runtime; supervisor, attempts, verification, pr,
-// and acceptance-skeleton outputs remain optional properties for daemon-owned
-// lifecycle persistence.
+// TaskJSONSchema returns the generated schema for author input and persisted
+// lifecycle state. Fixed defaults and daemon-owned fields remain optional.
 func TaskJSONSchema() ([]byte, error) {
 	schema := object(
 		required("id", "goal", "acceptance_criteria", "scope", "execution_policy", "worktree", "decisions", "risks"),
@@ -105,7 +100,6 @@ func worktreeSchema() map[string]any {
 	return object(
 		required("branch", "path"),
 		properties(map[string]any{
-			// enabled defaults to true for AFK tasks; retained for runtime YAML.
 			"enabled": map[string]any{"type": "boolean"},
 			"branch":  stringSchema("minLength", 1),
 			"path":    stringSchema("minLength", 1),
@@ -260,7 +254,6 @@ func preflightSchema() map[string]any {
 				required("enabled"),
 				properties(map[string]any{
 					"enabled": map[string]any{"type": "boolean"},
-					// outputs is daemon-owned runtime metadata written after the creator runs.
 					"outputs": arraySchema(preflightOutputSchema()),
 				}),
 			),

--- a/internal/task/schema.go
+++ b/internal/task/schema.go
@@ -9,9 +9,14 @@ import (
 
 // TaskJSONSchema returns the task YAML JSON Schema generated from the task
 // contract used by structural validation.
+//
+// Author-required fields are the retained authoring surface. mode, status, and
+// worktree.enabled default at runtime; supervisor, attempts, verification, pr,
+// and acceptance-skeleton outputs remain optional properties for daemon-owned
+// lifecycle persistence.
 func TaskJSONSchema() ([]byte, error) {
 	schema := object(
-		required("id", "mode", "status", "goal", "acceptance_criteria", "scope", "execution_policy", "worktree", "supervisor", "decisions", "risks", "attempts", "verification", "pr"),
+		required("id", "goal", "acceptance_criteria", "scope", "execution_policy", "worktree", "decisions", "risks"),
 		properties(map[string]any{
 			"$schema": map[string]any{"const": "https://json-schema.org/draft/2020-12/schema"},
 		}),
@@ -88,22 +93,19 @@ func scopeSchema() map[string]any {
 
 func executionPolicySchema() map[string]any {
 	return object(
-		required("loop_budget", "timeout_ms", "afk_decision_policy", "stop_on_destructive_operation", "stop_on_missing_secret", "stop_on_external_service_unavailable"),
+		required("loop_budget", "timeout_ms"),
 		properties(map[string]any{
-			"loop_budget":                          integerSchema("minimum", 0),
-			"timeout_ms":                           integerSchema("minimum", 1),
-			"afk_decision_policy":                  enumSchema(validAFKDecisionPolicies),
-			"stop_on_destructive_operation":        map[string]any{"type": "boolean"},
-			"stop_on_missing_secret":               map[string]any{"type": "boolean"},
-			"stop_on_external_service_unavailable": map[string]any{"type": "boolean"},
+			"loop_budget": integerSchema("minimum", 0),
+			"timeout_ms":  integerSchema("minimum", 1),
 		}),
 	)
 }
 
 func worktreeSchema() map[string]any {
 	return object(
-		required("enabled", "branch", "path"),
+		required("branch", "path"),
 		properties(map[string]any{
+			// enabled defaults to true for AFK tasks; retained for runtime YAML.
 			"enabled": map[string]any{"type": "boolean"},
 			"branch":  stringSchema("minLength", 1),
 			"path":    stringSchema("minLength", 1),
@@ -257,11 +259,9 @@ func preflightSchema() map[string]any {
 			"acceptance_skeleton": object(
 				required("enabled"),
 				properties(map[string]any{
-					"enabled":       map[string]any{"type": "boolean"},
-					"mode":          enumSchema(validPreflightSkeletonModes),
-					"required":      map[string]any{"type": "boolean"},
-					"allowed_paths": arraySchema(stringSchema("minLength", 1)),
-					"outputs":       arraySchema(preflightOutputSchema()),
+					"enabled": map[string]any{"type": "boolean"},
+					// outputs is daemon-owned runtime metadata written after the creator runs.
+					"outputs": arraySchema(preflightOutputSchema()),
 				}),
 			),
 		}),

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -37,12 +37,11 @@ type Preflight struct {
 
 // AcceptanceSkeletonConfig configures the optional acceptance skeleton
 // preflight stage that materializes AC-linked test skeletons in the worktree
-// before the first executor attempt.
+// before the first executor attempt. Authors only set enabled; allowed paths
+// come from scope.allowed_paths, coverage is always required when enabled, and
+// outputs are daemon-owned runtime metadata written after the creator runs.
 type AcceptanceSkeletonConfig struct {
-	Enabled      bool     `yaml:"enabled" json:"enabled"`
-	Mode         string   `yaml:"mode,omitempty" json:"mode,omitempty"`
-	Required     *bool    `yaml:"required,omitempty" json:"required,omitempty"`
-	AllowedPaths []string `yaml:"allowed_paths,omitempty" json:"allowed_paths,omitempty"`
+	Enabled bool `yaml:"enabled" json:"enabled"`
 	// Outputs is daemon-owned runtime metadata. Authors opt in with enabled:true;
 	// the built-in creator writes these bindings back before the executor runs.
 	Outputs []AcceptanceSkeletonOutputDef `yaml:"outputs,omitempty" json:"outputs,omitempty"`
@@ -70,16 +69,9 @@ func (c *AcceptanceSkeletonConfig) IsEnabled() bool {
 }
 
 // IsRequired reports whether the stage requires every AC to have a skeleton
-// output or no_skeletons reason.
-// Defaults to true when the stage is enabled.
+// output or no_skeletons reason. Coverage is always required when enabled.
 func (c *AcceptanceSkeletonConfig) IsRequired() bool {
-	if c == nil || !c.Enabled {
-		return false
-	}
-	if c.Required == nil {
-		return true
-	}
-	return *c.Required
+	return c != nil && c.Enabled
 }
 
 // InputFile describes a source file Galley should place in the execution workspace.
@@ -108,14 +100,13 @@ type Scope struct {
 	Permission     string   `yaml:"permission" json:"permission"`
 }
 
-// ExecutionPolicy describes loop, timeout, and escalation behavior.
+// ExecutionPolicy describes the author-chosen loop and timeout budget.
+// AFK decision policy and blocker handling are fixed Galley behavior, not
+// task YAML knobs; destructive, secret, and external-service blockers still
+// surface through executor results and visible failure or escalation paths.
 type ExecutionPolicy struct {
-	LoopBudget                       LoopBudget `yaml:"loop_budget" json:"loop_budget"`
-	TimeoutMS                        int        `yaml:"timeout_ms" json:"timeout_ms"`
-	AFKDecisionPolicy                string     `yaml:"afk_decision_policy" json:"afk_decision_policy"`
-	StopOnDestructiveOperation       bool       `yaml:"stop_on_destructive_operation" json:"stop_on_destructive_operation"`
-	StopOnMissingSecret              bool       `yaml:"stop_on_missing_secret" json:"stop_on_missing_secret"`
-	StopOnExternalServiceUnavailable bool       `yaml:"stop_on_external_service_unavailable" json:"stop_on_external_service_unavailable"`
+	LoopBudget LoopBudget `yaml:"loop_budget" json:"loop_budget"`
+	TimeoutMS  int        `yaml:"timeout_ms" json:"timeout_ms"`
 }
 
 // LoopBudget is a non-negative attempt count. A count of zero means unlimited.

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -35,15 +35,10 @@ type Preflight struct {
 	AcceptanceSkeleton *AcceptanceSkeletonConfig `yaml:"acceptance_skeleton,omitempty" json:"acceptance_skeleton,omitempty"`
 }
 
-// AcceptanceSkeletonConfig configures the optional acceptance skeleton
-// preflight stage that materializes AC-linked test skeletons in the worktree
-// before the first executor attempt. Authors only set enabled; allowed paths
-// come from scope.allowed_paths, coverage is always required when enabled, and
-// outputs are daemon-owned runtime metadata written after the creator runs.
+// AcceptanceSkeletonConfig enables preflight. Paths and AC coverage are fixed;
+// Outputs is daemon-written runtime state.
 type AcceptanceSkeletonConfig struct {
-	Enabled bool `yaml:"enabled" json:"enabled"`
-	// Outputs is daemon-owned runtime metadata. Authors opt in with enabled:true;
-	// the built-in creator writes these bindings back before the executor runs.
+	Enabled bool                          `yaml:"enabled" json:"enabled"`
 	Outputs []AcceptanceSkeletonOutputDef `yaml:"outputs,omitempty" json:"outputs,omitempty"`
 }
 
@@ -68,8 +63,7 @@ func (c *AcceptanceSkeletonConfig) IsEnabled() bool {
 	return c != nil && c.Enabled
 }
 
-// IsRequired reports whether the stage requires every AC to have a skeleton
-// output or no_skeletons reason. Coverage is always required when enabled.
+// IsRequired reports whether AC coverage is required.
 func (c *AcceptanceSkeletonConfig) IsRequired() bool {
 	return c != nil && c.Enabled
 }
@@ -100,10 +94,8 @@ type Scope struct {
 	Permission     string   `yaml:"permission" json:"permission"`
 }
 
-// ExecutionPolicy describes the author-chosen loop and timeout budget.
-// AFK decision policy and blocker handling are fixed Galley behavior, not
-// task YAML knobs; destructive, secret, and external-service blockers still
-// surface through executor results and visible failure or escalation paths.
+// ExecutionPolicy contains author-selected attempt and timeout budgets; AFK
+// decisions and blocker handling are fixed runtime behavior.
 type ExecutionPolicy struct {
 	LoopBudget LoopBudget `yaml:"loop_budget" json:"loop_budget"`
 	TimeoutMS  int        `yaml:"timeout_ms" json:"timeout_ms"`

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -308,8 +308,6 @@ func validatePreflight(result *ValidationResult, t Task) {
 	validatePreflightOutputs(result, t, cfg, "preflight.acceptance_skeleton")
 }
 
-// validatePreflightOutputs validates each daemon-written skeleton output
-// against the AC list and scope.allowed_paths.
 func validatePreflightOutputs(result *ValidationResult, t Task, cfg *AcceptanceSkeletonConfig, prefix string) {
 	if len(cfg.Outputs) == 0 {
 		return

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -203,12 +203,6 @@ func validateExecutionPolicy(result *ValidationResult, t Task) {
 	}
 	require(result, budget.Count >= 0, "execution_policy.loop_budget must be >= 0; use 0 for unlimited")
 	require(result, t.ExecutionPolicy.TimeoutMS > 0, "execution_policy.timeout_ms must be positive")
-	if t.Mode == "afk" {
-		require(result, t.ExecutionPolicy.AFKDecisionPolicy != "", "execution_policy.afk_decision_policy is required for AFK tasks")
-		if t.ExecutionPolicy.AFKDecisionPolicy != "" {
-			require(result, slices.Contains(validAFKDecisionPolicies, t.ExecutionPolicy.AFKDecisionPolicy), "execution_policy.afk_decision_policy must be one of: %s", strings.Join(validAFKDecisionPolicies, ", "))
-		}
-	}
 }
 
 func validateWorktree(result *ValidationResult, t Task) {
@@ -311,40 +305,11 @@ func validatePreflight(result *ValidationResult, t Task) {
 	if cfg == nil {
 		return
 	}
-	prefix := "preflight.acceptance_skeleton"
-	if cfg.Mode != "" {
-		require(result, slices.Contains(validPreflightSkeletonModes, cfg.Mode), "%s.mode must be one of: %s", prefix, strings.Join(validPreflightSkeletonModes, ", "))
-	}
-	if !cfg.Enabled {
-		// When the section is disabled, fields like allowed_paths still validate
-		// statically so authors who later toggle enabled get immediate feedback.
-	}
-	for i, p := range cfg.AllowedPaths {
-		field := fmt.Sprintf("%s.allowed_paths[%d]", prefix, i)
-		validateRelativePath(result, field, p)
-		if p == "" {
-			continue
-		}
-		if filepath.IsAbs(p) {
-			continue
-		}
-		clean := normalizeLogicalPath(p)
-		if logicalPathEscapes(clean) {
-			continue
-		}
-		if !pathAllowedByScope(p, t.Scope.AllowedPaths) {
-			result.Errors = append(result.Errors, fmt.Sprintf("%s value %q must be inside scope.allowed_paths", field, p))
-		}
-		if pathForbiddenByScope(p, t.Scope.ForbiddenPaths) {
-			result.Errors = append(result.Errors, fmt.Sprintf("%s value %q must not be inside scope.forbidden_paths", field, p))
-		}
-	}
-	validatePreflightOutputs(result, t, cfg, prefix)
+	validatePreflightOutputs(result, t, cfg, "preflight.acceptance_skeleton")
 }
 
-// validatePreflightOutputs validates each declared skeleton output against
-// the AC list and scope. Effective allowed paths are preflight.allowed_paths
-// when present, else scope.allowed_paths.
+// validatePreflightOutputs validates each daemon-written skeleton output
+// against the AC list and scope.allowed_paths.
 func validatePreflightOutputs(result *ValidationResult, t Task, cfg *AcceptanceSkeletonConfig, prefix string) {
 	if len(cfg.Outputs) == 0 {
 		return
@@ -352,10 +317,6 @@ func validatePreflightOutputs(result *ValidationResult, t Task, cfg *AcceptanceS
 	acIDs := map[string]bool{}
 	for _, ac := range t.AcceptanceCriteria {
 		acIDs[ac.ID] = true
-	}
-	effectiveAllowed := cfg.AllowedPaths
-	if len(effectiveAllowed) == 0 {
-		effectiveAllowed = t.Scope.AllowedPaths
 	}
 	// Multiple skeleton outputs may share the same normalized path because a
 	// single test file naturally covers more than one acceptance criterion.
@@ -377,8 +338,8 @@ func validatePreflightOutputs(result *ValidationResult, t Task, cfg *AcceptanceS
 			if !filepath.IsAbs(out.Path) {
 				clean := normalizeLogicalPath(out.Path)
 				if !logicalPathEscapes(clean) {
-					if !pathAllowedByScope(out.Path, effectiveAllowed) {
-						result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must be inside the effective preflight allowed paths", field, out.Path))
+					if !pathAllowedByScope(out.Path, t.Scope.AllowedPaths) {
+						result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must be inside scope.allowed_paths", field, out.Path))
 					}
 					if pathForbiddenByScope(out.Path, t.Scope.ForbiddenPaths) {
 						result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must not be inside scope.forbidden_paths", field, out.Path))

--- a/internal/task/validate_test.go
+++ b/internal/task/validate_test.go
@@ -175,19 +175,9 @@ func TestValidateStructuralRejectsInvalidCases(t *testing.T) {
 			want: "files[0].destination must not be within scope.forbidden_paths",
 		},
 		{
-			name: "invalid afk policy",
-			mutate: func(task *Task) {
-				task.Mode = "afk"
-				task.ExecutionPolicy.AFKDecisionPolicy = "ask-human"
-				task.Worktree = Worktree{Enabled: true, Branch: "agent/test", Path: "../repo.worktrees/test"}
-			},
-			want: "execution_policy.afk_decision_policy must be one of",
-		},
-		{
 			name: "invalid worktree branch",
 			mutate: func(task *Task) {
 				task.Mode = "afk"
-				task.ExecutionPolicy.AFKDecisionPolicy = "choose-smallest-reversible"
 				task.Worktree = Worktree{Enabled: true, Branch: "-bad", Path: "../repo.worktrees/test"}
 			},
 			want: "worktree.branch must be a valid git branch name",
@@ -196,7 +186,6 @@ func TestValidateStructuralRejectsInvalidCases(t *testing.T) {
 			name: "source repo internal worktree path",
 			mutate: func(task *Task) {
 				task.Mode = "afk"
-				task.ExecutionPolicy.AFKDecisionPolicy = "choose-smallest-reversible"
 				task.Worktree = Worktree{Enabled: true, Branch: "agent/test", Path: "worktrees/test"}
 			},
 			want: "worktree.path must point to a sibling path outside scope.cwd",
@@ -205,7 +194,6 @@ func TestValidateStructuralRejectsInvalidCases(t *testing.T) {
 			name: "parent worktree path",
 			mutate: func(task *Task) {
 				task.Mode = "afk"
-				task.ExecutionPolicy.AFKDecisionPolicy = "choose-smallest-reversible"
 				task.Worktree = Worktree{Enabled: true, Branch: "agent/test", Path: "../../worktrees/test"}
 			},
 			want: `worktree.path contains parent traversal path "../../worktrees/test"`,
@@ -214,7 +202,6 @@ func TestValidateStructuralRejectsInvalidCases(t *testing.T) {
 			name: "afk human decision missing chosen",
 			mutate: func(task *Task) {
 				task.Mode = "afk"
-				task.ExecutionPolicy.AFKDecisionPolicy = "choose-smallest-reversible"
 				task.Worktree = Worktree{Enabled: true, Branch: "agent/test", Path: "../repo.worktrees/test"}
 				task.Decisions = []Decision{{ID: "D1", NeedsHumanReview: true}}
 			},
@@ -257,7 +244,6 @@ func TestValidateStructuralAcceptsSiblingWorktreePath(t *testing.T) {
 	t.Parallel()
 	task := validTask(t)
 	task.Mode = "afk"
-	task.ExecutionPolicy.AFKDecisionPolicy = "choose-smallest-reversible"
 	task.Worktree = Worktree{Enabled: true, Branch: "agent/test", Path: "../repo.worktrees/test"}
 
 	result := ValidateStructural(task)
@@ -355,9 +341,8 @@ func validTask(t *testing.T) Task {
 			Permission:   "edit",
 		},
 		ExecutionPolicy: ExecutionPolicy{
-			LoopBudget:        LoopBudget{Count: 3, Set: true},
-			TimeoutMS:         600000,
-			AFKDecisionPolicy: "choose-smallest-reversible",
+			LoopBudget: LoopBudget{Count: 3, Set: true},
+			TimeoutMS:  600000,
 		},
 		Worktree: Worktree{
 			Enabled: true,

--- a/internal/task/validate_windows_compat_test.go
+++ b/internal/task/validate_windows_compat_test.go
@@ -193,18 +193,6 @@ func TestValidateRelativePathRejectsWindowsAbsoluteFormsOnNonWindowsHost(t *test
 			wantSub: "files[0].destination contains absolute path",
 		},
 		{
-			name: "preflight.acceptance_skeleton.allowed_paths",
-			mutate: func(task *Task, p string) {
-				task.Preflight = &Preflight{
-					AcceptanceSkeleton: &AcceptanceSkeletonConfig{
-						Enabled:      true,
-						AllowedPaths: []string{p},
-					},
-				}
-			},
-			wantSub: "preflight.acceptance_skeleton.allowed_paths[0] contains absolute path",
-		},
-		{
 			name: "preflight.acceptance_skeleton.outputs[].path",
 			mutate: func(task *Task, p string) {
 				task.Preflight = &Preflight{

--- a/internal/task/workorder.go
+++ b/internal/task/workorder.go
@@ -40,7 +40,7 @@ func RenderWorkOrderWithProfiles(t Task, profiles profile.Bundle) string {
 	fmt.Fprintf(&b, "- loop budget: `%v`\n", t.ExecutionPolicy.LoopBudget)
 	fmt.Fprintf(&b, "- timeout ms: `%d`\n", t.ExecutionPolicy.TimeoutMS)
 	if t.Mode == "afk" {
-		fmt.Fprintf(&b, "- AFK decision policy: `%s`\n", t.ExecutionPolicy.AFKDecisionPolicy)
+		fmt.Fprintf(&b, "- AFK decision policy: `%s`\n", DefaultAFKDecisionPolicy)
 	}
 	renderProfileContext(&b, profiles)
 	renderPreflightObligations(&b, t)

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/plugin.json
+++ b/plugins/galley/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/handoff-and-queueing.md
+++ b/plugins/galley/skills/galley/references/handoff-and-queueing.md
@@ -97,7 +97,7 @@ Trust boundary:
 | `scope.cwd must be an absolute path` | Replace with the absolute target repo path. |
 | `scope.allowed_paths must contain at least one relative path` | Add the narrowest relative path set. |
 | `acceptance_criteria must contain at least one criterion` | Add ACs with `id`, `text`, `verification`, and `status`. |
-| `worktree.enabled must be true for AFK tasks` | Omit `worktree.enabled` (Galley defaults it to true) or ensure the task is not forcing isolation off. |
+| `worktree.enabled must be true for AFK tasks` | Leave `worktree.enabled` unset; Galley enables AFK isolation. |
 | `worktree.branch is required for AFK tasks` | Add a valid branch such as `agent/<task-id>`. |
 | `worktree.path must point to a sibling path outside scope.cwd` | Use a relative sibling path such as `../<repo-name>.worktrees/<task-name>`. |
 | `files[n].source is required` | Add the source path or remove the file entry. |

--- a/plugins/galley/skills/galley/references/handoff-and-queueing.md
+++ b/plugins/galley/skills/galley/references/handoff-and-queueing.md
@@ -97,7 +97,7 @@ Trust boundary:
 | `scope.cwd must be an absolute path` | Replace with the absolute target repo path. |
 | `scope.allowed_paths must contain at least one relative path` | Add the narrowest relative path set. |
 | `acceptance_criteria must contain at least one criterion` | Add ACs with `id`, `text`, `verification`, and `status`. |
-| `worktree.enabled must be true for AFK tasks` | Set `worktree.enabled: true`. |
+| `worktree.enabled must be true for AFK tasks` | Omit `worktree.enabled` (Galley defaults it to true) or ensure the task is not forcing isolation off. |
 | `worktree.branch is required for AFK tasks` | Add a valid branch such as `agent/<task-id>`. |
 | `worktree.path must point to a sibling path outside scope.cwd` | Use a relative sibling path such as `../<repo-name>.worktrees/<task-name>`. |
 | `files[n].source is required` | Add the source path or remove the file entry. |

--- a/plugins/galley/skills/galley/references/handoff-and-queueing.md
+++ b/plugins/galley/skills/galley/references/handoff-and-queueing.md
@@ -97,7 +97,6 @@ Trust boundary:
 | `scope.cwd must be an absolute path` | Replace with the absolute target repo path. |
 | `scope.allowed_paths must contain at least one relative path` | Add the narrowest relative path set. |
 | `acceptance_criteria must contain at least one criterion` | Add ACs with `id`, `text`, `verification`, and `status`. |
-| `worktree.enabled must be true for AFK tasks` | Leave `worktree.enabled` unset; Galley enables AFK isolation. |
 | `worktree.branch is required for AFK tasks` | Add a valid branch such as `agent/<task-id>`. |
 | `worktree.path must point to a sibling path outside scope.cwd` | Use a relative sibling path such as `../<repo-name>.worktrees/<task-name>`. |
 | `files[n].source is required` | Add the source path or remove the file entry. |

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -38,6 +38,8 @@ galley profile validate --kind quality <profile.yaml>
 galley profile validate --kind environment <profile.yaml>
 ```
 
+Runtime loading ignores unknown profile keys while rejecting missing required keys and invalid known values.
+
 ## Authoring Flow
 
 1. Explain the two profiles before reading or writing them:

--- a/plugins/galley/skills/galley/references/profile-authoring.md
+++ b/plugins/galley/skills/galley/references/profile-authoring.md
@@ -150,7 +150,6 @@ evidence_requirements:
 pass_policy:
   required_dimensions_must_pass: true
   min_score: 85
-  unresolved_high_findings_allowed: 0
   blocking_severities:
     - critical
     - high

--- a/plugins/galley/skills/galley/references/quality.schema.json
+++ b/plugins/galley/skills/galley/references/quality.schema.json
@@ -54,17 +54,11 @@
         "required_dimensions_must_pass": {
           "default": true,
           "type": "boolean"
-        },
-        "unresolved_high_findings_allowed": {
-          "default": 0,
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": [
         "required_dimensions_must_pass",
         "min_score",
-        "unresolved_high_findings_allowed",
         "blocking_severities"
       ],
       "type": "object"

--- a/plugins/galley/skills/galley/references/setup.md
+++ b/plugins/galley/skills/galley/references/setup.md
@@ -141,3 +141,4 @@ Explicit Claude supervisor:
 For a single queue drain, use the same command shape with `run --once` instead of `start`.
 
 Repository profiles under the Galley root are loaded automatically from `scope.cwd`.
+Unknown `daemon.yaml` keys are ignored at runtime; invalid values for known keys still fail startup.

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -138,7 +138,7 @@ galley daemon status --output json
 
 Interpret daemon-dependent settings before asking:
 
-- If a verified daemon is already running, use its current daemon settings as the execution condition. Present supervisor, concurrency, polling interval, claim TTL, heartbeat interval, and shutdown timeout as current daemon state, not user-selectable task options.
+- If a verified daemon is already running, use its current daemon settings as the execution condition. Present supervisor, concurrency, polling interval, claim TTL (which also sets heartbeat cadence to `min(claim_ttl/4, 1m)`), and shutdown timeout as current daemon state, not user-selectable task options.
 - Repository operation settings come from `environment.yaml`: PR creation, PR base branch, PR comment polling/replies, and worktree cleanup.
 - Galley-owned required-check execution settings also come from `environment.yaml`: `required_checks.shell` controls the shell Galley uses when it runs `quality.required_checks` after an executor attempt.
 - Repository executor defaults come from `environment.yaml`. Read its executor block, resolve CLI, model, and effort independently using task override, environment value, then built-in default, and present each effective value with its source. Confirm that the effective effort is valid for the effective CLI before approval; model names remain CLI-owned. Record a task override only when the user requests one.
@@ -150,7 +150,7 @@ Then propose execution settings with user-facing explanations and choices. Treat
 
 Execution-setting content requirements:
 
-- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, AC test skeleton preflight, and blocking severity policy.
+- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, and AC test skeleton preflight (`enabled` only). Mode, status, worktree isolation, and AFK decision policy are fixed Galley defaults; daemon-owned lifecycle sections are omitted from drafts.
 - Environment profile settings: PR behavior, PR base branch, PR comments, worktree cleanup, and required-check shell from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work. Required-check shell controls Galley's own `quality.required_checks` execution, not executor/supervisor-internal commands or daemon startup flags.
 - Effective executor: present CLI, model, and effort with `task`, `environment`, or `built-in` as the source of each value. Show an omitted model as `CLI default`. Validate effort against the effective CLI before approval. GLM requires `glm_api_key`; Grok requires its authenticated CLI.
 - Executor model override (`executor.model`): omit it by default so the selected CLI uses its configured default model. If the user names a model, record that exact value. If the user is unsure or the model name was inferred, do not guess; offer a small runtime smoke check before queueing because available model names depend on the user's account, provider, CLI configuration, and CLI version.
@@ -203,7 +203,7 @@ Use `--committed-file SOURCE=DESTINATION` only when the supplied file is intenti
 
 Edit the generated skeleton fields instead of replacing the whole file. Use `references/task.schema.json` as the field contract. Keep optional runtime arrays empty until a valid structured entry is needed.
 
-Common shapes:
+Common shapes (author-facing only). Omit fixed AFK defaults (`mode`, draft `status`, `worktree.enabled`, AFK decision policy), removed blocker booleans (`stop_on_*`), and daemon-owned lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`) from new drafts:
 
 ```yaml
 acceptance_criteria:
@@ -226,20 +226,13 @@ risks:
     detail: "What could go wrong."
     mitigation: "How the executor should prevent or detect it."
     human_review_suggested: false
-
-verification:
-  commands:
-    - cmd: "<repo test command>"
-      status: pending
-      output_excerpt: ""
 ```
 
-Use `decisions: []`, `risks: []`, and `verification.commands: []` when those entries are not necessary.
+Use `decisions: []` and `risks: []` when those entries are not necessary. Do not seed empty `attempts`, top-level `verification`, or `pr` blocks in drafts.
 
 ## Field Guidance
 
-- `mode`: use `afk` for daemon execution.
-- `status`: write new tasks as `draft`; `galley task queue` writes the queued copy with `status: queued`.
+- Omit `mode`, `status`, `worktree.enabled`, AFK decision policy, and daemon-owned lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`) from new drafts. Galley defaults mode to `afk`, omitted status to `draft` for validate/show/list/queue eligibility, enables worktree isolation for AFK, and persists `status: queued` when queueing.
 - `scope.permission`: prefer broad operations inside the isolated worktree (`sandbox-full-access`) for AFK implementation tasks; use investigation only (`read-only`) for review tasks; use normal edits (`edit`) when broad sandbox authority is unnecessary or unavailable.
 - `allowed_paths`: choose the narrowest expected implementation paths that cover approved edits and any reference-file destinations. This is the review baseline for scope expansion, not an absolute executor stop; `forbidden_paths` defines protected paths that must not be changed.
 - `executor.cli` / `model` / `effort`: write only values the user explicitly pins and preserve existing pins. Omitted fields inherit the current environment, then `cli: claude`, `effort: high`, and the CLI-default model. Use exact user-provided model names. Galley owns prompt transport, so task YAML contains only these three executor fields.
@@ -251,8 +244,7 @@ Use `decisions: []`, `risks: []`, and `verification.commands: []` when those ent
 - `files[].commit`: use `false` for context-only inputs; use `true` only when the supplied file is intentionally part of the final branch.
 - `execution_policy.loop_budget`: use `10` as the ordinary-task baseline for AFK implementation so Galley can complete corrective loops. Increase it for broader or more uncertain tasks. Use less than `5` only when the user explicitly wants a short, low-cost run; use `0` only when the user explicitly requests an unbounded loop.
 - Blocking severity is enforced by the resolved quality profile and supervisor policy, not by a top-level task schema field. Show the current profile threshold in execution settings and the final queue summary. Use profile authoring when the user wants to change repository-wide blocking severities. Record task-specific review preferences in `decisions` only as guidance.
-- `worktree.path`: use a sibling path outside the source repo, such as `../<repo-name>.worktrees/<short-name>`.
-- `supervisor.review_iterations`: start at `0`; Galley increments it when reviewed work is requeued.
+- `worktree.branch` / `worktree.path`: set the isolated branch and a sibling path outside the source repo, such as `../<repo-name>.worktrees/<short-name>`. Do not author `worktree.enabled`; AFK isolation is fixed on.
 
 ## Step 8: Validate And Repair
 

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -150,13 +150,16 @@ Then propose execution settings with user-facing explanations and choices. Treat
 
 Execution-setting content requirements:
 
-- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, and AC test skeleton preflight (`enabled` only). Mode, status, worktree isolation, and AFK decision policy are fixed Galley defaults; daemon-owned lifecycle sections are omitted from drafts.
+- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, and AC test skeleton preflight (`enabled` only). Galley owns mode, status, worktree isolation, AFK decision policy, and lifecycle state.
 - Environment profile settings: PR behavior, PR base branch, PR comments, worktree cleanup, and required-check shell from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work. Required-check shell controls Galley's own `quality.required_checks` execution, not executor/supervisor-internal commands or daemon startup flags.
 - Effective executor: present CLI, model, and effort with `task`, `environment`, or `built-in` as the source of each value. Show an omitted model as `CLI default`. Validate effort against the effective CLI before approval. GLM requires `glm_api_key`; Grok requires its authenticated CLI.
 - Executor model override (`executor.model`): omit it by default so the selected CLI uses its configured default model. If the user names a model, record that exact value. If the user is unsure or the model name was inferred, do not guess; offer a small runtime smoke check before queueing because available model names depend on the user's account, provider, CLI configuration, and CLI version.
 - Supervisor: present the current daemon supervisor when verified. Otherwise present `claude`, `codex`, `glm`, or `grok`; the default is Claude. The supervisor controls review only and is independent from `executor.cli`.
 - Daemon concurrency: present planned or current `max_concurrent_tasks` and `max_concurrent_per_repo`. Explain that default or low concurrency fits a single heavy task, while higher values are available for parallel execution.
-- AC test skeleton preflight (`preflight.acceptance_skeleton.enabled`): include it as one Task YAML execution setting with only `enabled` or `disabled`. Enable it only when pre-created tests add value beyond asking the executor to write tests during implementation: they should anchor an integration, cross-layer, or E2E acceptance path that is likely to be missed, weakened, or deferred without a concrete skeleton in the worktree. Keep it disabled when the executor can write focused unit or package tests as part of the normal implementation, or when existing required checks already provide concrete verification guidance. If ACs are unclear, use the value-first AC authoring steps in `references/authoring-quality.md` before choosing this setting. When enabled, let the skeleton creator derive test kind, path, and content; it runs on the effective executor backend, not the daemon supervisor backend.
+- AC test skeleton preflight (`preflight.acceptance_skeleton.enabled`): present one of these values:
+  - `enabled`: an integration, cross-layer, or E2E acceptance path needs a concrete file before implementation.
+  - `disabled`: focused tests or required checks already define the evidence path.
+- Preflight prerequisite and ownership: clarify unclear ACs with `references/authoring-quality.md` before choosing. When enabled, Galley derives the kind, path, and content on the effective executor backend.
 - For each user-changeable setting, include the recommended or current value, why it fits the current task, and practical alternatives.
 - For settings stored outside task YAML, name the change path, such as `environment.yaml` edits or daemon restart with different flags.
 
@@ -201,9 +204,9 @@ Use `--committed-file SOURCE=DESTINATION` only when the supplied file is intenti
 
 ## Step 7: Fill Skeleton With Schema
 
-Edit the generated skeleton fields instead of replacing the whole file. Use `references/task.schema.json` as the field contract. Keep optional runtime arrays empty until a valid structured entry is needed.
+Edit the generated skeleton fields instead of replacing the whole file. Use `references/task.schema.json` as the field contract.
 
-Common shapes (author-facing only). Omit fixed AFK defaults (`mode`, draft `status`, `worktree.enabled`, AFK decision policy), removed blocker booleans (`stop_on_*`), and daemon-owned lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`) from new drafts:
+New drafts contain author-owned fields. Galley supplies fixed AFK defaults and lifecycle state. Common authoring shapes:
 
 ```yaml
 acceptance_criteria:
@@ -228,11 +231,11 @@ risks:
     human_review_suggested: false
 ```
 
-Use `decisions: []` and `risks: []` when those entries are not necessary. Do not seed empty `attempts`, top-level `verification`, or `pr` blocks in drafts.
+Use `decisions: []` and `risks: []` when empty. Galley creates `attempts`, top-level `verification`, and `pr` after lifecycle transitions.
 
 ## Field Guidance
 
-- Omit `mode`, `status`, `worktree.enabled`, AFK decision policy, and daemon-owned lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`) from new drafts. Galley defaults mode to `afk`, omitted status to `draft` for validate/show/list/queue eligibility, enables worktree isolation for AFK, and persists `status: queued` when queueing.
+- Galley owns `mode`, `status`, `worktree.enabled`, AFK decision policy, and lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`). It resolves drafts as AFK with isolated worktrees and persists `status: queued` when queueing.
 - `scope.permission`: prefer broad operations inside the isolated worktree (`sandbox-full-access`) for AFK implementation tasks; use investigation only (`read-only`) for review tasks; use normal edits (`edit`) when broad sandbox authority is unnecessary or unavailable.
 - `allowed_paths`: choose the narrowest expected implementation paths that cover approved edits and any reference-file destinations. This is the review baseline for scope expansion, not an absolute executor stop; `forbidden_paths` defines protected paths that must not be changed.
 - `executor.cli` / `model` / `effort`: write only values the user explicitly pins and preserve existing pins. Omitted fields inherit the current environment, then `cli: claude`, `effort: high`, and the CLI-default model. Use exact user-provided model names. Galley owns prompt transport, so task YAML contains only these three executor fields.
@@ -244,7 +247,7 @@ Use `decisions: []` and `risks: []` when those entries are not necessary. Do not
 - `files[].commit`: use `false` for context-only inputs; use `true` only when the supplied file is intentionally part of the final branch.
 - `execution_policy.loop_budget`: use `10` as the ordinary-task baseline for AFK implementation so Galley can complete corrective loops. Increase it for broader or more uncertain tasks. Use less than `5` only when the user explicitly wants a short, low-cost run; use `0` only when the user explicitly requests an unbounded loop.
 - Blocking severity is enforced by the resolved quality profile and supervisor policy, not by a top-level task schema field. Show the current profile threshold in execution settings and the final queue summary. Use profile authoring when the user wants to change repository-wide blocking severities. Record task-specific review preferences in `decisions` only as guidance.
-- `worktree.branch` / `worktree.path`: set the isolated branch and a sibling path outside the source repo, such as `../<repo-name>.worktrees/<short-name>`. Do not author `worktree.enabled`; AFK isolation is fixed on.
+- `worktree.branch` / `worktree.path`: set the isolated branch and a sibling path outside the source repo, such as `../<repo-name>.worktrees/<short-name>`. Galley always enables AFK isolation.
 
 ## Step 8: Validate And Repair
 

--- a/plugins/galley/skills/galley/references/task-authoring.md
+++ b/plugins/galley/skills/galley/references/task-authoring.md
@@ -150,15 +150,15 @@ Then propose execution settings with user-facing explanations and choices. Treat
 
 Execution-setting content requirements:
 
-- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, and AC test skeleton preflight (`enabled` only). Galley owns mode, status, worktree isolation, AFK decision policy, and lifecycle state.
+- Task YAML settings: optional executor overrides, edit authority, retry budget, per-attempt timeout, and AC test skeleton preflight (`enabled` only). Galley owns fixed AFK and lifecycle values.
 - Environment profile settings: PR behavior, PR base branch, PR comments, worktree cleanup, and required-check shell from the current `environment.yaml`; create missing profiles through `references/profile-authoring.md` before queueing ordinary implementation work. Required-check shell controls Galley's own `quality.required_checks` execution, not executor/supervisor-internal commands or daemon startup flags.
 - Effective executor: present CLI, model, and effort with `task`, `environment`, or `built-in` as the source of each value. Show an omitted model as `CLI default`. Validate effort against the effective CLI before approval. GLM requires `glm_api_key`; Grok requires its authenticated CLI.
 - Executor model override (`executor.model`): omit it by default so the selected CLI uses its configured default model. If the user names a model, record that exact value. If the user is unsure or the model name was inferred, do not guess; offer a small runtime smoke check before queueing because available model names depend on the user's account, provider, CLI configuration, and CLI version.
 - Supervisor: present the current daemon supervisor when verified. Otherwise present `claude`, `codex`, `glm`, or `grok`; the default is Claude. The supervisor controls review only and is independent from `executor.cli`.
 - Daemon concurrency: present planned or current `max_concurrent_tasks` and `max_concurrent_per_repo`. Explain that default or low concurrency fits a single heavy task, while higher values are available for parallel execution.
 - AC test skeleton preflight (`preflight.acceptance_skeleton.enabled`): present one of these values:
-  - `enabled`: an integration, cross-layer, or E2E acceptance path needs a concrete file before implementation.
-  - `disabled`: focused tests or required checks already define the evidence path.
+  - `enabled`: a pre-created integration, cross-layer, or E2E skeleton adds protection beyond executor-authored tests because the acceptance path is likely to be missed, weakened, or deferred.
+  - `disabled`: executor-authored focused unit or package tests, or existing required checks, already define the evidence path.
 - Preflight prerequisite and ownership: clarify unclear ACs with `references/authoring-quality.md` before choosing. When enabled, Galley derives the kind, path, and content on the effective executor backend.
 - For each user-changeable setting, include the recommended or current value, why it fits the current task, and practical alternatives.
 - For settings stored outside task YAML, name the change path, such as `environment.yaml` edits or daemon restart with different flags.
@@ -206,7 +206,7 @@ Use `--committed-file SOURCE=DESTINATION` only when the supplied file is intenti
 
 Edit the generated skeleton fields instead of replacing the whole file. Use `references/task.schema.json` as the field contract.
 
-New drafts contain author-owned fields. Galley supplies fixed AFK defaults and lifecycle state. Common authoring shapes:
+New drafts contain author-owned fields. Galley resolves them as AFK drafts with worktree isolation and the fixed decision policy, then persists queued status and other lifecycle state during transitions. Common authoring shapes:
 
 ```yaml
 acceptance_criteria:
@@ -235,7 +235,6 @@ Use `decisions: []` and `risks: []` when empty. Galley creates `attempts`, top-l
 
 ## Field Guidance
 
-- Galley owns `mode`, `status`, `worktree.enabled`, AFK decision policy, and lifecycle sections (`supervisor`, `attempts`, top-level `verification`, `pr`). It resolves drafts as AFK with isolated worktrees and persists `status: queued` when queueing.
 - `scope.permission`: prefer broad operations inside the isolated worktree (`sandbox-full-access`) for AFK implementation tasks; use investigation only (`read-only`) for review tasks; use normal edits (`edit`) when broad sandbox authority is unnecessary or unavailable.
 - `allowed_paths`: choose the narrowest expected implementation paths that cover approved edits and any reference-file destinations. This is the review baseline for scope expansion, not an absolute executor stop; `forbidden_paths` defines protected paths that must not be changed.
 - `executor.cli` / `model` / `effort`: write only values the user explicitly pins and preserve existing pins. Omitted fields inherit the current environment, then `cli: claude`, `effort: high`, and the CLI-default model. Use exact user-provided model names. Galley owns prompt transport, so task YAML contains only these three executor fields.

--- a/plugins/galley/skills/galley/references/task.schema.json
+++ b/plugins/galley/skills/galley/references/task.schema.json
@@ -168,24 +168,9 @@
     "execution_policy": {
       "additionalProperties": false,
       "properties": {
-        "afk_decision_policy": {
-          "enum": [
-            "choose-smallest-reversible"
-          ],
-          "type": "string"
-        },
         "loop_budget": {
           "minimum": 0,
           "type": "integer"
-        },
-        "stop_on_destructive_operation": {
-          "type": "boolean"
-        },
-        "stop_on_external_service_unavailable": {
-          "type": "boolean"
-        },
-        "stop_on_missing_secret": {
-          "type": "boolean"
         },
         "timeout_ms": {
           "minimum": 1,
@@ -194,11 +179,7 @@
       },
       "required": [
         "loop_budget",
-        "timeout_ms",
-        "afk_decision_policy",
-        "stop_on_destructive_operation",
-        "stop_on_missing_secret",
-        "stop_on_external_service_unavailable"
+        "timeout_ms"
       ],
       "type": "object"
     },
@@ -422,21 +403,8 @@
         "acceptance_skeleton": {
           "additionalProperties": false,
           "properties": {
-            "allowed_paths": {
-              "items": {
-                "minLength": 1,
-                "type": "string"
-              },
-              "type": "array"
-            },
             "enabled": {
               "type": "boolean"
-            },
-            "mode": {
-              "enum": [
-                "skeleton"
-              ],
-              "type": "string"
             },
             "outputs": {
               "items": {
@@ -483,9 +451,6 @@
                 "type": "object"
               },
               "type": "array"
-            },
-            "required": {
-              "type": "boolean"
             }
           },
           "required": [
@@ -684,7 +649,6 @@
         }
       },
       "required": [
-        "enabled",
         "branch",
         "path"
       ],
@@ -693,19 +657,13 @@
   },
   "required": [
     "id",
-    "mode",
-    "status",
     "goal",
     "acceptance_criteria",
     "scope",
     "execution_policy",
     "worktree",
-    "supervisor",
     "decisions",
-    "risks",
-    "attempts",
-    "verification",
-    "pr"
+    "risks"
   ],
   "title": "Galley Task YAML",
   "type": "object"

--- a/plugins/galley/skills/galley/scripts/create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/create_task_skeleton.py
@@ -19,24 +19,18 @@ SCHEMA_PATH = SCRIPT_DIR.parent / "references" / "task.schema.json"
 VALID_EXECUTOR_CLIS = {"claude", "codex", "glm", "grok"}
 ROOT_ORDER = [
     "id",
-    "mode",
-    "status",
     "goal",
     "acceptance_criteria",
     "scope",
     "files",
     "execution_policy",
     "worktree",
-    "supervisor",
     "executor",
     "preflight",
     "decisions",
     "risks",
     "discussion_items",
     "revision_requests",
-    "attempts",
-    "verification",
-    "pr",
 ]
 
 
@@ -226,8 +220,15 @@ def main() -> int:
         return 2
 
     task["id"] = task_id
-    task["mode"] = "afk"
-    task["status"] = "draft"
+    # mode, status, worktree.enabled, and AFK decision policy are fixed runtime
+    # defaults applied by Galley when omitted. Daemon-owned lifecycle sections
+    # (supervisor, attempts, verification, pr) are omitted from author drafts.
+    task.pop("mode", None)
+    task.pop("status", None)
+    task.pop("supervisor", None)
+    task.pop("attempts", None)
+    task.pop("verification", None)
+    task.pop("pr", None)
     task["goal"] = "TODO: replace with one concrete outcome."
     task["acceptance_criteria"] = [
         {
@@ -246,29 +247,21 @@ def main() -> int:
     task["execution_policy"] = {
         "loop_budget": args.loop_budget,
         "timeout_ms": 1800000,
-        "afk_decision_policy": "choose-smallest-reversible",
-        "stop_on_destructive_operation": True,
-        "stop_on_missing_secret": True,
-        "stop_on_external_service_unavailable": True,
     }
     task["worktree"] = {
-        "enabled": True,
         "branch": f"agent/{task_id}",
         "path": f"../{cwd.name}.worktrees/{task_id}",
     }
-    task["supervisor"] = {"review_iterations": 0}
     if args.executor_cli:
         task["executor"] = {"cli": args.executor_cli}
+    else:
+        task.pop("executor", None)
     # Emit the AC test skeleton preflight stage explicitly disabled by default so
-    # the generated YAML shows the runtime gate. Only `enabled` is written; any
-    # enabled-only fields (mode, required, allowed_paths, outputs) stay omitted
-    # until the author opts in by flipping enabled to true.
+    # the generated YAML shows the author opt-in. Only `enabled` is authored;
+    # outputs are daemon-owned runtime metadata.
     task["preflight"] = {"acceptance_skeleton": {"enabled": False}}
     task["decisions"] = []
     task["risks"] = []
-    task["attempts"] = []
-    task["verification"] = {"commands": []}
-    task["pr"] = {"url": "", "status": "", "processed_comment_ids": []}
 
     file_entries: list[dict[str, Any]] = []
     for source, destination in args.reference_file:

--- a/plugins/galley/skills/galley/scripts/create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/create_task_skeleton.py
@@ -220,9 +220,7 @@ def main() -> int:
         return 2
 
     task["id"] = task_id
-    # mode, status, worktree.enabled, and AFK decision policy are fixed runtime
-    # defaults applied by Galley when omitted. Daemon-owned lifecycle sections
-    # (supervisor, attempts, verification, pr) are omitted from author drafts.
+    # Galley supplies fixed defaults and lifecycle fields after authoring.
     task.pop("mode", None)
     task.pop("status", None)
     task.pop("supervisor", None)
@@ -256,9 +254,7 @@ def main() -> int:
         task["executor"] = {"cli": args.executor_cli}
     else:
         task.pop("executor", None)
-    # Emit the AC test skeleton preflight stage explicitly disabled by default so
-    # the generated YAML shows the author opt-in. Only `enabled` is authored;
-    # outputs are daemon-owned runtime metadata.
+    # Expose the author preflight choice; Galley owns its runtime outputs.
     task["preflight"] = {"acceptance_skeleton": {"enabled": False}}
     task["decisions"] = []
     task["risks"] = []

--- a/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
@@ -89,12 +89,25 @@ def main() -> int:
         "  acceptance_skeleton:\n    enabled: false\n",
         "preflight.acceptance_skeleton.enabled: false",
     )
+    assert_contains(yaml_text, "execution_policy:\n", "execution_policy block")
+    assert_contains(yaml_text, "  loop_budget:", "loop_budget")
+    assert_contains(yaml_text, "  timeout_ms:", "timeout_ms")
+
+    # Fixed AFK values and daemon-owned lifecycle sections stay out of drafts.
+    assert_not_matches(yaml_text, r"^mode:", "mode in default skeleton")
+    assert_not_matches(yaml_text, r"^status:", "status in default skeleton")
+    assert_not_matches(yaml_text, r"^supervisor:", "supervisor in default skeleton")
+    assert_not_matches(yaml_text, r"^attempts:", "attempts in default skeleton")
+    assert_not_matches(yaml_text, r"^verification:", "verification in default skeleton")
+    assert_not_matches(yaml_text, r"^pr:", "pr in default skeleton")
+    assert_not_matches(yaml_text, r"^worktree:\n(?:  .+\n)*?  enabled:", "worktree.enabled in default skeleton")
+    assert_not_matches(yaml_text, r"afk_decision_policy", "afk_decision_policy in default skeleton")
+    assert_not_matches(yaml_text, r"stop_on_", "stop_on_* in default skeleton")
 
     # Default skeleton must not include enabled-only runtime fields.
     assert_not_matches(yaml_text, r"^    outputs:", "outputs[] in default skeleton")
     assert_not_matches(yaml_text, r"^    required:", "required in default skeleton")
     assert_not_matches(yaml_text, r"^    allowed_paths:", "allowed_paths in default skeleton")
-    assert_not_matches(yaml_text, r"^    mode:", "mode in default skeleton")
     if generated_executor_cli(yaml_text) is not None:
         raise SystemExit("regression: default skeleton must inherit executor.cli at run time")
     assert_not_matches(yaml_text, r"^\s+max_budget_usd:", "executor.max_budget_usd in default skeleton")

--- a/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
+++ b/plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
@@ -93,7 +93,6 @@ def main() -> int:
     assert_contains(yaml_text, "  loop_budget:", "loop_budget")
     assert_contains(yaml_text, "  timeout_ms:", "timeout_ms")
 
-    # Fixed AFK values and daemon-owned lifecycle sections stay out of drafts.
     assert_not_matches(yaml_text, r"^mode:", "mode in default skeleton")
     assert_not_matches(yaml_text, r"^status:", "status in default skeleton")
     assert_not_matches(yaml_text, r"^supervisor:", "supervisor in default skeleton")
@@ -104,7 +103,6 @@ def main() -> int:
     assert_not_matches(yaml_text, r"afk_decision_policy", "afk_decision_policy in default skeleton")
     assert_not_matches(yaml_text, r"stop_on_", "stop_on_* in default skeleton")
 
-    # Default skeleton must not include enabled-only runtime fields.
     assert_not_matches(yaml_text, r"^    outputs:", "outputs[] in default skeleton")
     assert_not_matches(yaml_text, r"^    required:", "required in default skeleton")
     assert_not_matches(yaml_text, r"^    allowed_paths:", "allowed_paths in default skeleton")

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -56,8 +56,6 @@ git -C "$REPO_DIR" commit -m initial >/dev/null
 
 cat > "$WORKFLOW_DIR/tasks/draft/smoke.yaml" <<YAML
 id: "task-smoke"
-mode: "afk"
-status: "draft"
 goal: "Create a smoke output file."
 acceptance_criteria:
   - id: "AC1"
@@ -73,28 +71,15 @@ scope:
 execution_policy:
   loop_budget: 1
   timeout_ms: 120000
-  afk_decision_policy: "choose-smallest-reversible"
-  stop_on_destructive_operation: true
-  stop_on_missing_secret: false
-  stop_on_external_service_unavailable: false
 worktree:
-  enabled: true
   branch: "agent/smoke"
   path: "../worktrees/smoke"
-supervisor:
-  review_iterations: 0
 executor:
   cli: "claude"
   model: "opus"
   effort: "high"
 decisions: []
 risks: []
-attempts: []
-verification:
-  commands: []
-pr:
-  url: ""
-  status: ""
 YAML
 
 "$TMP_DIR/galley" task validate "$WORKFLOW_DIR/tasks/draft/smoke.yaml" >/dev/null


### PR DESCRIPTION
## Goal

Reduce Galley task authoring and operational configuration to meaningful user decisions by internalizing fixed AFK behavior, removing dead settings, and preserving daemon-owned lifecycle state.

## Acceptance Criteria

- `AC1` When a draft omits `mode`, `execution_policy.afk_decision_policy`, and `worktree.enabled`, Galley shall apply `afk`, `choose-smallest-reversible`, and an enabled isolated worktree before validation and execution.
  - Verification: Focused task defaulting, schema, work-order, and worktree lifecycle tests; claim: omitted fixed authoring fields preserve the sole AFK execution path; primary failure mode: omission fails validation, changes the decision policy, or disables worktree isolation; boundary: draft YAML -> task defaults -> work order and worktree preparation; state: fixed fields absent -> validate and queue -> AFK, choose-smallest-reversible, and enabled worktree behavior; residual: `worktree.branch` and `worktree.path` remain authored.
  - Status: satisfied
- `AC2` The authored `execution_policy` contract shall contain only `loop_budget` and `timeout_ms`; destructive-operation, missing-secret, and external-service blockers shall continue through the existing executor result and visible failure or escalation paths.
  - Verification: Contract, schema, skeleton, and work-order tests plus existing blocker lifecycle tests; claim: blocker behavior remains visible after the three prompt-only booleans are removed; primary failure mode: a removed boolean is still authored or blocker handling disappears from executor results and task evidence; boundary: draft execution policy -> executor work order -> task failure or escalation evidence; state: minimal policy plus each blocker result -> daemon processing -> existing visible outcome; residual: none.
  - Status: satisfied
- `AC3` The authored acceptance-skeleton contract shall contain only `preflight.acceptance_skeleton.enabled`; `enabled: true` shall use `scope.allowed_paths`, require every AC to produce a skeleton or an explicit no-skeleton reason, and let the daemon populate runtime `outputs`.
  - Verification: Enabled and disabled preflight contract and lifecycle tests; claim: one boolean selects a fixed, complete, daemon-owned skeleton flow; primary failure mode: authored `mode`, `required`, `allowed_paths`, or `outputs` changes execution, the effective paths differ from `scope.allowed_paths`, or an AC lacks both output and reason; boundary: draft preflight input -> queue -> skeleton result persistence; state: enabled false -> stage skipped; enabled true with mixed AC outcomes -> scope-derived complete result and daemon-written outputs; residual: none.
  - Status: satisfied
- `AC4` When an authored task omits `status`, Galley shall resolve it to `draft` before task validation, display, and queue eligibility checks, and queueing shall persist `status: queued` through the existing transition.
  - Verification: Focused defaulting plus task validate, show, and queue tests; claim: draft status is implicit for authors but explicit once lifecycle processing begins; primary failure mode: an omitted status is rejected, displayed as empty, or cannot queue; boundary: minimal draft YAML -> load/default -> CLI validation, display, and queue; state: status absent -> validate/show/queue -> draft semantics followed by persisted queued status; residual: none.
  - Status: satisfied
- `AC5` New draft skeletons and authoring guidance shall omit `supervisor`, `attempts`, `verification`, and `pr`, while the runtime Task model and serialized lifecycle files shall retain those sections and populate them only when their existing queue, review, verification, or PR transitions produce data.
  - Verification: One minimal lifecycle test covering queue, executor/supervisor evidence, requeue, PR update, and archive plus task show assertions; claim: daemon-owned state is absent from author input and remains available to runtime consumers; primary failure mode: a draft requires empty runtime sections, a transition loses persisted state, or task show loses produced evidence; boundary: minimal draft -> queued/running/done or failed task files -> CLI inspection; state: runtime sections absent -> lifecycle transitions -> only produced sections contain data; residual: runtime fields remain in the Go Task and persisted YAML contracts.
  - Status: satisfied
- `AC6` Task 1's executor contract shall remain intact: authored tasks may omit `executor` or override any subset of `cli`, `model`, and `effort`; each field shall resolve at run start by `task -> environment -> built-in` precedence, authored task files shall retain only authored overrides, and effective run and supervisor evidence shall contain the resolved executor.
  - Verification: Existing executor resolution, runtime/schema parity, three-role daemon lifecycle, requeue freshness, effective evidence, skeleton, and authoring-skill tests; claim: Task 2 preserves executor authority and per-run freshness from Task 1; primary failure mode: omission stops inheriting, one source replaces the entire executor block, resolved values are written back as overrides, or evidence contains unresolved values; boundary: authored task plus environment -> setup/skeleton/implementation and run/supervisor evidence; state: omitted and partial overrides plus an environment change before requeue -> each run -> current independent values with unchanged authored overrides; residual: provider model names remain CLI-owned.
  - Status: satisfied
- `AC7` The quality profile contract shall omit `pass_policy.unresolved_high_findings_allowed`, and supervisor verdict decisions shall continue to use `required_dimensions_must_pass`, `min_score`, and `blocking_severities` with unchanged outcomes.
  - Verification: Profile struct, runtime/schema parity, maintained profile, docs, and supervisor decision tests; claim: removing the unused field preserves the active pass policy; primary failure mode: the field remains on a current surface, an acceptance consumer is discovered, or equivalent verdict input changes outcome; boundary: quality YAML -> resolved pass policy -> supervisor verdict decision; state: maintained profile without the field -> validation and representative verdicts -> unchanged active gates; residual: external strict profiles containing the removed key require manual removal, recorded in R1.
  - Status: satisfied
- `AC8` Daemon heartbeat cadence shall be derived as `min(claim_ttl / 4, 1 minute)` from `claim_ttl`; daemon configuration, CLI help, and startup options shall expose `claim_ttl` as the sole heartbeat recovery input while stale-claim recovery behavior remains unchanged.
  - Verification: Daemon option defaulting, daemon.yaml decode/schema, CLI help/flag, scheduler, and claim recovery tests; claim: one recovery input produces a safe deterministic heartbeat cadence; primary failure mode: `heartbeat_interval` remains configurable, representative TTL values derive the wrong cadence, or stale recovery changes; boundary: daemon configuration and CLI -> options -> heartbeat scheduler and claim recovery; state: claim TTL below, equal to, and above four minutes -> startup -> one-quarter cadence capped at one minute; residual: none.
  - Status: satisfied
- `AC9` Published task and profile authoring surfaces shall contain only the retained fields defined by AC1 through AC8, while the runtime-only fields named in AC3 and AC5 remain available to daemon persistence; old task YAML keys removed by this task shall continue to load through the existing unknown-field-tolerant decoder and shall disappear on the next save.
  - Verification: Exact field-list assertions for Go contracts and generated/bundled schemas, focused searches across skeletons, examples, docs, skills, smoke fixtures, and tests, existing unknown-field decode/save coverage, and all repository required checks; claim: authoring surface shrinks without deleting runtime state or adding compatibility machinery; primary failure mode: a removed authoring key remains published, a runtime-owned field is deleted, old task YAML fails to load, or a save republishes an ignored key; boundary: source contracts -> generated/package surfaces and old YAML -> load/save; state: current and old-shaped tasks -> generate, validate, load, and save -> retained authoring contract plus preserved runtime state; residual: none.
  - Status: satisfied
- `AC10` Every versioned Galley plugin and marketplace manifest shall advance together from `0.1.23` to `0.1.24`, including `.claude-plugin/marketplace.json`, `.grok-plugin/marketplace.json`, `plugins/galley/plugin.json`, `plugins/galley/.claude-plugin/plugin.json`, and `plugins/galley/.codex-plugin/plugin.json`; Unreleased shall contain one concise plugin-release entry covering Task 1 runtime executor defaults and Task 2 authoring simplification.
  - Verification: Manifest JSON validation, exact `0.1.24` comparison across all named files, and CHANGELOG review; claim: one deferred patch release publishes the combined installed-skill contract; primary failure mode: a named manifest remains at `0.1.23`, versions diverge, or the release note omits either task; boundary: bundled skill change -> versioned distribution manifests and Unreleased notes; state: Task 2 complete -> one patch update -> all named versions and the combined entry agree; residual: `.agents/plugins/marketplace.json` has no version field and requires JSON validation only.
  - Status: satisfied

## Final Verification

- `<galley:setup:grok>`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool on schemas and plugin/marketplace JSON manifests`: passed
- `go test ./internal/cli/ -count=1 -run 'TestTaskShowAndListDisplayOmittedStatusAsDraft|TestTaskQueuePersistsQueuedStatusFromOmittedStatusDraft'`: passed
- `go test ./internal/task/ -count=1 -run 'TestMaintainedExamplesMatchGeneratedSchemaRequiredKeys|TestPackagedTaskAuthoringOmitsStaleFixedRuntimeFieldsFromDraftGuidance|TestApplyDefaults|TestLoadAndValidateAcceptsMinimalDraft|TestExampleAFK'`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley-test ./cmd/galley && /tmp/galley-test schema check`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `bash scripts/smoke-local.sh`: passed
- `grok`: passed
- `gofmt -w internal/task/example_schema_parity_test.go internal/daemon/options_test.go internal/cli/task_omitted_status_test.go && gofmt -l internal/task/example_schema_parity_test.go internal/daemon/options_test.go internal/cli/task_omitted_status_test.go`: passed
- `go test ./internal/task/ -run 'TestContainsNormallyIndentedNestedYAMLKey|TestPackagedTaskAuthoring|TestMaintainedExamples' -count=1`: passed
- `go test ./... -count=1`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate <rewritten examples/afk-task.yaml> && go run ./cmd/galley task validate <rewritten examples/afk-task-codex.yaml> && go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 plugins/galley/skills/galley/scripts/test_create_task_skeleton.py`: passed
- `python3 -m json.tool schemas/*.schema.json plugins/galley/**/plugin.json plugins/galley/skills/galley/references/*.schema.json .claude-plugin/marketplace.json .grok-plugin/marketplace.json .agents/plugins/marketplace.json >/dev/null`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Where should omitted fixed authoring values be resolved? -> Extend the existing `task.ApplyDefaults` path for values needed before validation or command decisions, and retain the existing lifecycle transitions as the only writers of daemon-owned state.
  - Rationale: Task 1 established runtime defaulting as the authority boundary; using that path keeps draft simplification separate from persisted lifecycle state.
  - Reversibility: high
- `D2` Should removed task fields receive dedicated migration handling? -> Use the existing unknown-field-tolerant task decoder and normal save path as the complete compatibility behavior for removed task keys.
  - Rationale: Existing decode and save behavior accepts old task input while publishing only the current contract.
  - Reversibility: high
- `D3` Which state fields remain part of the runtime task contract? -> Retain `status`, `supervisor`, `attempts`, `verification`, `pr`, and acceptance-skeleton `outputs` in the Go Task model and persisted YAML; omit them only from new draft skeletons and authoring guidance, except that authors continue to choose `preflight.acceptance_skeleton.enabled`.
  - Rationale: These fields are produced and consumed by queue, daemon, review, evidence, PR, inspection, and archive transitions rather than by task authors.
  - Reversibility: high
- `executor-decision-4` How should worktree.enabled omission vs false be handled given bool zero-value? -> Always set Worktree.Enabled=true in ApplyDefaults for AFK mode
  - Rationale: AFK isolation is a fixed product path; YAML cannot distinguish omit from false, and validation already requires isolation.
  - Reversibility: high
- `executor-decision-5` How to keep existing daemon.yaml files with heartbeat_interval loading after field removal? -> Strip heartbeat_interval before KnownFields decode; never apply it; derive only from claim_ttl
  - Rationale: Galley-created daemon.yaml files historically contained the key; hard failure would brick upgrades, while strip preserves claim_ttl as sole recovery input.
  - Reversibility: high
- `executor-decision-6` Where should omitted draft status be resolved for display? -> ApplyDefaults on task show and task list load paths in addition to validate/queue
  - Rationale: AC4 requires draft before display as well as validation and queue eligibility.
  - Reversibility: high
- `executor-decision-7` Should quality-default.yaml reintroduce blocking_severities or make the schema field optional? -> Add the documented default blocking_severities list [critical, high, medium] to the example
  - Rationale: Work order prefers the documented default list; generated QualityJSONSchema still requires blocking_severities with that default.
  - Reversibility: high
- `executor-decision-8` Where should example/schema parity and stale authoring guidance assertions live? -> internal/task/example_schema_parity_test.go beside existing example/schema reference tests
  - Rationale: Keeps authoring-surface contract checks near TaskJSONSchema and skill reference paths without adding a new package or dependency.
  - Reversibility: high
- `executor-decision-9` How should omitted-status CLI behavior be proven? -> Dedicated CLI tests writing minimal YAML without top-level status, then asserting show/list draft and queued persistence
  - Rationale: Matches public CLI surfaces requested in the work order and exercises ApplyDefaults on show/list plus Queue status write-through.
  - Reversibility: high
- `executor-decision-10` How should the packaged-guidance guard detect stale nested draft YAML without rejecting preflight.acceptance_skeleton.enabled? -> Parent-scoped normally-indented nested key detector (parent then more-indented child key lines) with table-driven cases, then apply to real guidance
  - Rationale: Bare `enabled: true` matches any retained enabled field. Parent scoping rejects worktree.enabled and execution_policy.* while leaving acceptance_skeleton.enabled instructable.
  - Reversibility: high
- `executor-decision-11` Which newly added test comments should remain after the boundary-label cleanup? -> Remove pure boundary/format narration; keep non-obvious HeartbeatInterval overwrite and queue-rename contract comments
  - Rationale: Work order asked to drop redundant boundary labels and narration that only restates adjacent code, while retaining public-contract rationale.
  - Reversibility: high

## Risks

- `R1` compatibility: External quality profiles that still contain `pass_policy.unresolved_high_findings_allowed` will fail strict profile decoding after AC7 removes the field.
  - Mitigation: Document the one-line manual removal in the concise Unreleased entry and keep maintained profiles and examples valid under the generated schema.
