### PR TITLE
Add executor interruption recovery tooling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
           if ! command -v "$python_bin" >/dev/null 2>&1; then
             python_bin="python"
           fi
-          "$python_bin" plugins/galley/skills/galley/scripts/test_create_task_skeleton.py
+          "$python_bin" tests/plugins/galley/skills/galley/test_create_task_skeleton.py
+          "$python_bin" tests/plugins/galley/skills/galley/test_update_task_executor.py
 
       - name: Validate JSON files
         run: |

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "category": "development",
       "source": {
         "source": "local",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Added
+
+- The Galley skill includes a helper for changing task-level executor CLI, model, and effort overrides before validation and requeue.
+
+### Changed
+
+- Packaged Claude, Codex, and Grok Galley plugins are now versioned as `0.1.26`: troubleshooting guidance routes executor interruptions through wait-or-update recovery without requiring an exact provider failure classification, and the bundled helper updates task-level executor CLI, model, and effort overrides before validation and requeue.
+
 ## v0.10.2 - 2026-07-15
 
 ### Changed

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/plugin.json
+++ b/plugins/galley/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/references/troubleshooting.md
+++ b/plugins/galley/skills/galley/references/troubleshooting.md
@@ -71,24 +71,46 @@ galley task requeue <task-id-or-task-file> --reason "retry after fixing the bloc
 
 ### Executor interruption recovery
 
-When a task is `failed` because the executor stopped before supervisor review, continue from its retained worktree and diff. Choose the recovery action by whether the executor settings need to change. Provider-specific error details improve `Cause`, `Evidence`, and the requeue reason; an exact provider failure classification is optional.
+When a task is `failed` because the executor stopped before supervisor review, continue from its retained worktree and diff. Use observed evidence to choose the recovery action:
 
-For the same executor settings, wait when the observed condition is temporary, then requeue:
+- Update task-level executor overrides when the error identifies the current CLI, model, or effort as incompatible, or when the user chooses different settings.
+- Otherwise keep the same settings; when the observed condition is temporary, wait before requeueing.
+
+Provider-specific error details improve `Cause`, `Evidence`, and the requeue reason; an exact provider failure classification is optional. Record the observed symptom and only an established cause; when the cause is not established, use `cause unknown`.
+
+For the same executor settings, inspect the task and requeue:
 
 ```bash
 galley task show <task-id>
-galley task requeue <task-id-or-task-file> --reason "retry after executor interruption: <observed cause>"
+galley task requeue <task-id-or-task-file> --reason "retry after executor interruption: <observed symptom>; cause <established cause or unknown>"
 ```
 
-To change task-level executor overrides, pass only the fields that should change. An `--unset-*` option removes that task override so runtime defaults apply. The helper changes `executor.cli`, `executor.model`, and `executor.effort`; it leaves the recovery decision to this flow.
+To change task-level executor overrides, run exactly one helper command with only the fields that should change. An `--unset-*` option removes that task override so runtime defaults apply. The helper changes `executor.cli`, `executor.model`, and `executor.effort`; it leaves the recovery decision to this flow.
+
+Use the Python launcher available on the host (`python3`, `python`, or Windows `py -3`); these examples use `python3`.
+
+To set task overrides:
 
 ```bash
-python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> \
-  --cli <cli> --model <model> --effort <effort>
-python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> \
-  --unset-model --unset-effort
+python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> --cli <cli> --model <model> --effort <effort>
+```
+
+To remove selected task overrides:
+
+```bash
+python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> --unset-model --unset-effort
+```
+
+Proceed to validation only when the selected helper command exits 0. When it exits non-zero, report its error and correct the reported file or YAML problem before rerunning the helper.
+
+```bash
 galley task validate <task-file>
-galley task requeue <task-id-or-task-file> --reason "retry with updated executor settings: <observed cause>"
+```
+
+When validation exits 0, requeue:
+
+```bash
+galley task requeue <task-id-or-task-file> --reason "retry with updated executor settings: <observed symptom>; cause <established cause or unknown>"
 ```
 
 For a weak supervisor acceptance:

--- a/plugins/galley/skills/galley/references/troubleshooting.md
+++ b/plugins/galley/skills/galley/references/troubleshooting.md
@@ -51,7 +51,7 @@ Read the files that exist. Focus on the newest attempt first.
 | task remains in `queued` | daemon stopped, concurrency limit, or queue mismatch | Check `galley daemon status`, daemon log, and the queued file path. |
 | task remains in `running` | stale claim or active attempt | Check heartbeat age and claim TTL. |
 | `needs_revision` loops | AC too broad, executor missing context, or supervisor finding unclear | Rewrite AC or add `revision_requests` with concrete next work. |
-| task failed due to usage limit or transient provider failure | executor stopped for a temporary external limit | Wait until the limit resets, then requeue with a reason. |
+| task is `failed` after the executor stopped and no supervisor verdict was produced | executor execution was interrupted before review; provider evidence may identify a temporary limit or an incompatible executor setting | Continue with Executor interruption recovery below. |
 | `accepted` with quality concerns | pass policy treats concern as non-blocking | Add quality profile or PR comment requeue with specific blocker. |
 | no diff produced | task was investigation-only or executor stopped early | Check executor result and work order. |
 | PR comments ignored | polling disabled in `environment.yaml`, auth missing, or comment ID already processed | Check `pr.comments.enabled`, `gh auth status`, and `pr.processed_comment_ids`. |
@@ -69,11 +69,26 @@ For a failed task with a clear next step:
 galley task requeue <task-id-or-task-file> --reason "retry after fixing the blocker"
 ```
 
-For usage limits or temporary provider failures:
+### Executor interruption recovery
+
+When a task is `failed` because the executor stopped before supervisor review, continue from its retained worktree and diff. Choose the recovery action by whether the executor settings need to change. Provider-specific error details improve `Cause`, `Evidence`, and the requeue reason; an exact provider failure classification is optional.
+
+For the same executor settings, wait when the observed condition is temporary, then requeue:
 
 ```bash
 galley task show <task-id>
-galley task requeue <task-id-or-task-file> --reason "retry after usage limit reset"
+galley task requeue <task-id-or-task-file> --reason "retry after executor interruption: <observed cause>"
+```
+
+To change task-level executor overrides, pass only the fields that should change. An `--unset-*` option removes that task override so runtime defaults apply. The helper changes `executor.cli`, `executor.model`, and `executor.effort`; it leaves the recovery decision to this flow.
+
+```bash
+python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> \
+  --cli <cli> --model <model> --effort <effort>
+python3 <this-skill-directory>/scripts/update_task_executor.py <task-file> \
+  --unset-model --unset-effort
+galley task validate <task-file>
+galley task requeue <task-id-or-task-file> --reason "retry with updated executor settings: <observed cause>"
 ```
 
 For a weak supervisor acceptance:

--- a/plugins/galley/skills/galley/scripts/update_task_executor.py
+++ b/plugins/galley/skills/galley/scripts/update_task_executor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Update executor overrides in an existing Galley task YAML file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from typing import Final
+
+
+FIELDS: Final = ("cli", "model", "effort")
+UNCHANGED: Final = object()
+EXECUTOR_HEADER = re.compile(r"^executor:[ \t]*(?:\{\})?[ \t]*(?:\r?\n|$)", re.MULTILINE)
+ANY_EXECUTOR_HEADER = re.compile(r"^executor:", re.MULTILINE)
+TOP_LEVEL_KEY = re.compile(r"^[A-Za-z0-9_-]+:", re.MULTILINE)
+FIELD_LINE = re.compile(r"^  (cli|model|effort):[ \t]*(.*)$")
+ANY_FIELD_LINE = re.compile(r"^\s+(cli|model|effort):")
+INSERT_BEFORE = re.compile(
+    r"^(?:preflight|decisions|risks|discussion_items|revision_requests|attempts|verification|pr):",
+    re.MULTILINE,
+)
+
+
+class UpdateError(ValueError):
+    """Raised when the canonical executor mapping cannot be updated."""
+
+
+def executor_block(text: str) -> tuple[int, int, str] | None:
+    headers = list(EXECUTOR_HEADER.finditer(text))
+    if not headers:
+        if ANY_EXECUTOR_HEADER.search(text):
+            raise UpdateError("executor must use a block mapping before it can be updated")
+        return None
+    if len(headers) > 1:
+        raise UpdateError("task contains multiple top-level executor mappings")
+
+    header = headers[0]
+    next_key = TOP_LEVEL_KEY.search(text, header.end())
+    end = next_key.start() if next_key else len(text)
+    return header.start(), end, text[header.end() : end]
+
+
+def existing_fields(body: str) -> tuple[dict[str, str], list[str]]:
+    values: dict[str, str] = {}
+    extras: list[str] = []
+    for line in body.splitlines():
+        match = FIELD_LINE.fullmatch(line)
+        if match:
+            field = match.group(1)
+            if field in values:
+                raise UpdateError(f"executor.{field} appears more than once")
+            values[field] = match.group(2)
+        elif ANY_FIELD_LINE.match(line):
+            raise UpdateError("executor fields must use two-space indentation")
+        elif line.strip():
+            extras.append(line)
+    return values, extras
+
+
+def rendered_block(values: dict[str, str], extras: list[str], newline: str) -> str:
+    lines = [f"  {field}: {values[field]}" for field in FIELDS if field in values]
+    lines.extend(extras)
+    if not lines:
+        return ""
+    return newline.join(["executor:", *lines]) + newline
+
+
+def update_executor_yaml(text: str, changes: dict[str, object]) -> str:
+    newline = "\r\n" if "\r\n" in text else "\n"
+    block = executor_block(text)
+    values, extras = existing_fields(block[2]) if block else ({}, [])
+    for field, requested in changes.items():
+        if requested is UNCHANGED:
+            continue
+        if requested is None:
+            values.pop(field, None)
+        else:
+            values[field] = json.dumps(requested, ensure_ascii=False)
+
+    rendered = rendered_block(values, extras, newline)
+    if block:
+        return text[: block[0]] + rendered + text[block[1] :]
+    if not rendered:
+        return text
+    insertion = INSERT_BEFORE.search(text)
+    at = insertion.start() if insertion else len(text)
+    return text[:at] + rendered + text[at:]
+
+
+def parse_args() -> tuple[pathlib.Path, dict[str, object]]:
+    parser = argparse.ArgumentParser(description="Update executor overrides in a Galley task YAML file.")
+    parser.add_argument("task_file", type=pathlib.Path)
+    for field in FIELDS:
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(f"--{field}", default=UNCHANGED)
+        group.add_argument(f"--unset-{field}", dest=field, action="store_const", const=None)
+    args = parser.parse_args()
+    changes = {field: getattr(args, field) for field in FIELDS}
+    if all(value is UNCHANGED for value in changes.values()):
+        parser.error("specify at least one executor field to set or unset")
+    return args.task_file, changes
+
+
+def main() -> int:
+    task_path, changes = parse_args()
+    try:
+        with task_path.open("r", encoding="utf-8", newline="") as task_file:
+            original = task_file.read()
+        updated = update_executor_yaml(original, changes)
+        if updated != original:
+            with task_path.open("w", encoding="utf-8", newline="") as task_file:
+                task_file.write(updated)
+    except (OSError, UpdateError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    state = "updated" if updated != original else "unchanged"
+    print(f"{state}: {task_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/galley/skills/galley/scripts/update_task_executor.py
+++ b/plugins/galley/skills/galley/scripts/update_task_executor.py
@@ -109,7 +109,9 @@ def main() -> int:
     try:
         with task_path.open("r", encoding="utf-8", newline="") as task_file:
             original = task_file.read()
-        updated = update_executor_yaml(original, changes)
+        bom = "\ufeff" if original.startswith("\ufeff") else ""
+        task_yaml = original[len(bom) :]
+        updated = bom + update_executor_yaml(task_yaml, changes)
         if updated != original:
             with task_path.open("w", encoding="utf-8", newline="") as task_file:
                 task_file.write(updated)

--- a/tests/plugins/galley/skills/galley/test_create_task_skeleton.py
+++ b/tests/plugins/galley/skills/galley/test_create_task_skeleton.py
@@ -23,8 +23,8 @@ import sys
 import tempfile
 
 
-SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-GENERATOR = SCRIPT_DIR / "create_task_skeleton.py"
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+GENERATOR = REPO_ROOT / "plugins" / "galley" / "skills" / "galley" / "scripts" / "create_task_skeleton.py"
 
 spec = importlib.util.spec_from_file_location("create_task_skeleton", GENERATOR)
 if spec is None or spec.loader is None:

--- a/tests/plugins/galley/skills/galley/test_update_task_executor.py
+++ b/tests/plugins/galley/skills/galley/test_update_task_executor.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Focused regression checks for update_task_executor.py."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+UPDATER = REPO_ROOT / "plugins" / "galley" / "skills" / "galley" / "scripts" / "update_task_executor.py"
+
+
+def run_updater(task_path: pathlib.Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(UPDATER), str(task_path), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def write_task(path: pathlib.Path, content: str, newline: str | None = None) -> None:
+    with path.open("w", encoding="utf-8", newline=newline) as task_file:
+        task_file.write(content)
+
+
+def test_adds_executor_block_without_interpreting_task_status(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    write_task(
+        task_path,
+        "id: task-1\nstatus: running\ngoal: demo\npreflight: {}\ndecisions: []\n",
+    )
+
+    result = run_updater(
+        task_path,
+        "--cli",
+        "codex",
+        "--model",
+        "gpt-5.4",
+        "--effort",
+        "high",
+    )
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    expected = (
+        "id: task-1\n"
+        "status: running\n"
+        "goal: demo\n"
+        "executor:\n"
+        '  cli: "codex"\n'
+        '  model: "gpt-5.4"\n'
+        '  effort: "high"\n'
+        "preflight: {}\n"
+        "decisions: []\n"
+    )
+    if task_path.read_text(encoding="utf-8") != expected:
+        raise AssertionError("executor block was not inserted before preflight")
+
+
+def test_updates_only_requested_executor_fields(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    original = (
+        "id: task-1\n"
+        "executor:\n"
+        '  cli: "claude"\n'
+        '  model: "claude-opus-4-6"\n'
+        '  effort: "high"\n'
+        "risks: []\n"
+    )
+    write_task(task_path, original)
+
+    result = run_updater(task_path, "--cli", "grok", "--unset-model")
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    expected = (
+        "id: task-1\n"
+        "executor:\n"
+        '  cli: "grok"\n'
+        '  effort: "high"\n'
+        "risks: []\n"
+    )
+    if task_path.read_text(encoding="utf-8") != expected:
+        raise AssertionError("unrequested executor fields were not preserved")
+
+
+def test_removes_empty_executor_block(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    write_task(task_path, "id: task-1\nexecutor:\n  cli: codex\nrisks: []\n")
+
+    result = run_updater(task_path, "--unset-cli")
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    if task_path.read_text(encoding="utf-8") != "id: task-1\nrisks: []\n":
+        raise AssertionError("empty executor block was not removed")
+
+
+def test_preserves_crlf_line_endings(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    write_task(task_path, "id: task-1\r\nexecutor:\r\n  cli: claude\r\nrisks: []\r\n", newline="")
+
+    result = run_updater(task_path, "--cli", "codex")
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    content = task_path.read_bytes()
+    if b"\n" in content.replace(b"\r\n", b""):
+        raise AssertionError("updater introduced non-CRLF line endings")
+
+
+def test_rejects_unsupported_inline_executor_without_writing(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    original = "id: task-1\nexecutor: {cli: claude}\nrisks: []\n"
+    write_task(task_path, original)
+
+    result = run_updater(task_path, "--cli", "codex")
+
+    if result.returncode == 0:
+        raise AssertionError("inline executor mapping must be rejected")
+    if "block mapping" not in result.stderr:
+        raise AssertionError(f"missing actionable error: {result.stderr!r}")
+    if task_path.read_text(encoding="utf-8") != original:
+        raise AssertionError("task changed after rejected input")
+
+
+def test_requires_a_requested_change(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    original = "id: task-1\nrisks: []\n"
+    write_task(task_path, original)
+
+    result = run_updater(task_path)
+
+    if result.returncode == 0:
+        raise AssertionError("updater must reject an empty change request")
+    if task_path.read_text(encoding="utf-8") != original:
+        raise AssertionError("task changed after empty request")
+
+
+def main() -> int:
+    tests = (
+        test_adds_executor_block_without_interpreting_task_status,
+        test_updates_only_requested_executor_fields,
+        test_removes_empty_executor_block,
+        test_preserves_crlf_line_endings,
+        test_rejects_unsupported_inline_executor_without_writing,
+        test_requires_a_requested_change,
+    )
+    for test in tests:
+        with tempfile.TemporaryDirectory() as tmp:
+            test(pathlib.Path(tmp))
+    print("update_task_executor.py contracts hold")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/galley/skills/galley/test_update_task_executor.py
+++ b/tests/plugins/galley/skills/galley/test_update_task_executor.py
@@ -113,6 +113,25 @@ def test_preserves_crlf_line_endings(tmpdir: pathlib.Path) -> None:
         raise AssertionError("updater introduced non-CRLF line endings")
 
 
+def test_preserves_bom_before_first_executor_block(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    original = "\ufeffexecutor:\r\n  cli: claude\r\nid: task-1\r\nrisks: []\r\n"
+    write_task(task_path, original, newline="")
+
+    result = run_updater(task_path, "--cli", "codex")
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    content = task_path.read_bytes()
+    if not content.startswith(b"\xef\xbb\xbf"):
+        raise AssertionError("UTF-8 BOM was not preserved")
+    decoded = content.decode("utf-8-sig")
+    if decoded.count("executor:") != 1:
+        raise AssertionError("executor block was duplicated")
+    if '  cli: "codex"\r\n' not in decoded:
+        raise AssertionError("executor block was not updated with CRLF preserved")
+
+
 def test_rejects_unsupported_inline_executor_without_writing(tmpdir: pathlib.Path) -> None:
     task_path = tmpdir / "task.yaml"
     original = "id: task-1\nexecutor: {cli: claude}\nrisks: []\n"
@@ -147,6 +166,7 @@ def main() -> int:
         test_updates_only_requested_executor_fields,
         test_removes_empty_executor_block,
         test_preserves_crlf_line_endings,
+        test_preserves_bom_before_first_executor_block,
         test_rejects_unsupported_inline_executor_without_writing,
         test_requires_a_requested_change,
     )


### PR DESCRIPTION
## Summary

- add a deterministic skill helper for setting or removing task-level executor CLI, model, and effort overrides without embedding task-state or provider-failure classification
- document evidence-guided recovery for executor interruptions, including same-settings retries, one-command setting updates, explicit helper and validation gates, and `cause unknown` handling
- move skill script tests out of the packaged skill, add updater coverage for line endings and UTF-8 BOM input, update CI, and synchronize packaged plugin version 0.1.26

## Testing

- `go test ./...`
- `go build -o /tmp/galley ./cmd/galley`
- `go run ./cmd/galley schema check`
- task and profile example validation
- skill script regression tests
- JSON and Claude plugin validation
- `./scripts/smoke-local.sh`
