### PR TITLE
Stop executor provider or runtime interruptions before normal Supervisor review, preserve partial work and run evidence, and let operators resume the retained worktree through the existing requeue workflow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Executor provider or runtime interruptions now stop before supervisor review instead of consuming the revision loop. Galley decides whether an attempt reached a normal provider terminal (Claude/GLM successful result events, Codex `turn.completed`, Grok `EndTurn`) from runner state and machine-readable provider output, never from the exit code or error text alone. An interruption publishes the task to `tasks/failed/` with status `failed`, records `supervisor_verdict: not_reviewed` and `error_kind: executor_interrupted`, preserves the worktree and run evidence (including a new `executor_terminal.json` decision record), and is resumable with `galley task requeue`. Parse or schema-validation failures after a normal terminal keep the existing supervisor correction loop.
+- `galley task show` surfaces an executor interruption, its evidence directory and retained provider detail, and the recovery action (resolve the cause, then requeue).
+
 ## v0.10.2 - 2026-07-15
 
 ### Changed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -194,7 +194,7 @@ Galley uses two timeout concepts:
 - `--idle-timeout`: kills executor or built-in supervisor subprocesses that stop producing output.
 - `execution_policy.timeout_ms`: bounds the total wall-clock duration of one executor attempt.
 
-Executor idle timeouts are recorded as `error_kind: idle_timeout` and as `idle_timed_out: true` in run evidence, then the task loop continues according to the task loop budget.
+An executor idle timeout, total timeout, start failure, or kill is an interruption: it stops before supervisor review rather than continuing the loop. The task moves to `tasks/failed/` with status `failed`, the attempt records `supervisor_verdict: not_reviewed` and `error_kind: executor_interrupted` (with the diagnostic cause, such as `idle_timeout` or `timed_out`, retained in the message), and run evidence keeps `idle_timed_out: true` where applicable. Galley preserves the worktree and evidence so the task can be requeued. See [Supervision → Executor Interruptions](supervision.md#executor-interruptions).
 
 Built-in supervisor subprocess failures caused by idle timeout, total timeout, or forced kill are retried up to two additional times inside the same executor attempt. Each try writes evidence under `runs/<run-id>/attempt-N/supervisor-try-<M>/`.
 
@@ -215,6 +215,7 @@ If every supervisor try is killed by the idle-output watchdog, Galley records `e
 - Background control uses a local PID file. Avoid sharing the same `--pid-file` across unrelated processes, and prefer one workflow root per managed daemon.
 - Running tasks refresh their YAML mtime at `min(claim_ttl / 4, 1m)` while the executor loop is active. Heartbeat cadence has no separate daemon or CLI setting.
 - Each claimed running task records the owning daemon. On startup the daemon immediately requeues running tasks whose recorded owner is dead or cannot be verified, while leaving tasks still owned by a verified live daemon untouched.
+- An executor provider or runtime interruption publishes the task to `tasks/failed/` with its worktree and run evidence preserved, without a supervisor verdict. Inspect it with `galley task show TASK_ID`, resolve the interruption cause, then run `galley task requeue TASK_ID` to reuse the retained (dirty) worktree and continue from the preserved changes.
 
 ### External Services
 

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -47,11 +47,20 @@ For implementation tasks, the supervisor should reject a no-diff result unless t
 | `completed` with blockers that require human judgment about product, design, environment, external services, or required-check policy | `tasks/failed/` with status `needs_supervisor_review` |
 | `completed` with an external or unrecoverable blocker that prevents meaningful progress | `tasks/failed/` with status `failed` |
 | `completed_with_risks` | retry, then `tasks/failed/` with status `needs_supervisor_review` |
-| Parse failure or schema validation failure | retry, then `tasks/failed/` with status `needs_supervisor_review` |
+| Parse or schema validation failure after a normal provider terminal | retry, then `tasks/failed/` with status `needs_supervisor_review` |
+| Executor provider or runtime interruption (no normal provider terminal) | `tasks/failed/` with status `failed`, without supervisor review or retry |
 | Two consecutive attempts with no git diff | stop early as a no-progress safeguard |
 | `hard_stop` | `tasks/failed/` with status `failed`, without retry |
 
 `needs_supervisor_review` is a task state, not a daemon process failure. `galley daemon run --once` can exit 0 after recording that state.
+
+## Executor Interruptions
+
+When an executor process ends, Galley first decides whether the attempt reached a normal provider terminal. The decision uses only the runner state and the provider's machine-readable completion marker — Claude and GLM successful result events, Codex `turn.completed`, and Grok `EndTurn` — and never the process exit code or error-text matching alone. A start failure, timeout, idle timeout, kill, explicit failed terminal (Codex `turn.failed`, Grok non-`EndTurn`, a Claude/GLM API-error result), or any output without a reliable normal terminal is an interruption.
+
+An interrupted attempt stops before the supervisor: Galley does not invoke the supervisor and does not start another executor attempt in the same run, regardless of loop budget or whether the worktree has a diff. The task moves to `tasks/failed/` with status `failed` and the latest attempt records `supervisor_verdict: not_reviewed` and an executor-owned `error_kind: executor_interrupted`, distinct from an ordinary completed-result failure. Galley captures the command plan, run result, raw provider output, git status, diff, and an `executor_terminal.json` decision record before publishing the failed task, and preserves the worktree with its tracked and untracked changes.
+
+`galley task show TASK_ID` surfaces the interruption, its evidence directory, and any retained provider detail (structured status, code, stop reason, session ID, or message; unavailable detail falls back to a generic reason). Resolve the interruption cause, then run `galley task requeue TASK_ID` to reuse the retained worktree and start a fresh executor attempt from the preserved changes.
 
 `completed_with_risks` means the executor believes the implementation is coherent, but verification limits, assumptions, or residual risks still need supervisor attention.
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -187,6 +187,8 @@ galley task show TASK_ID
 galley task requeue TASK_ID --reason "retry after transient failure"
 ```
 
+An executor provider or runtime interruption records the latest `attempts[]` entry with `supervisor_verdict: not_reviewed` and `error.kind: executor_interrupted`, distinct from an ordinary completed-result failure that a supervisor reviewed. The task lands in `tasks/failed/` with status `failed` and its worktree and run evidence preserved. `galley task requeue TASK_ID` reuses the retained dirty worktree so the next executor continues from the preserved tracked and untracked changes. See [Supervision → Executor Interruptions](supervision.md#executor-interruptions).
+
 ## Compatibility
 
 The tolerant decoder loads removed authoring keys (`execution_policy.afk_decision_policy`, `execution_policy.stop_on_*`, and acceptance-skeleton `mode`, `required`, and `allowed_paths`), then drops them on save. Runtime lifecycle fields remain available to the daemon.

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -220,6 +220,9 @@ func newTaskShowCommand() *cobra.Command {
 						if last.Error.ArtifactDir != "" {
 							fmt.Fprintf(cmd.OutOrStdout(), "%s_error_artifact_dir: %s\n", prefix, last.Error.ArtifactDir)
 						}
+						if last.Error.Kind == task.AttemptKindExecutorInterrupted {
+							fmt.Fprintf(cmd.OutOrStdout(), "%s_recovery: executor interrupted before supervisor review; partial work and run evidence are preserved. Resolve the interruption cause, then run `galley task requeue %s` to reuse the retained worktree and start a fresh executor attempt.\n", prefix, loaded.ID)
+						}
 					}
 				}
 				if len(loaded.Risks) > 0 {

--- a/internal/cli/task_show_interrupted_test.go
+++ b/internal/cli/task_show_interrupted_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	taskpkg "github.com/shinpr/galley/internal/task"
+)
+
+func writeInterruptedTask(t *testing.T, root, artifactDir, message string) {
+	t.Helper()
+	taskPath := writeCLITaskYAML(t)
+	loaded, err := taskpkg.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Status = taskpkg.StatusFailed
+	loaded.Attempts = []taskpkg.Attempt{{
+		Number:            1,
+		ClaudeStatus:      "interrupted",
+		SupervisorVerdict: taskpkg.AttemptVerdictNotReviewed,
+		Summary:           message,
+		Error: &taskpkg.AttemptError{
+			Phase:       "executor",
+			Kind:        taskpkg.AttemptKindExecutorInterrupted,
+			Message:     message,
+			ArtifactDir: artifactDir,
+		},
+	}}
+	// The daemon records the interruption recovery action as a task risk
+	// mitigation; mirror it here so the JSON consumer assertion is meaningful.
+	loaded.Risks = []taskpkg.Risk{{
+		ID:                   "executor-interrupted-1",
+		Type:                 "partial_verification",
+		Detail:               message,
+		Mitigation:           "Resolve the interruption cause, then run `galley task requeue` to reuse the retained worktree and start a fresh executor attempt.",
+		HumanReviewSuggested: true,
+	}}
+	dst := filepath.Join(root, "tasks", "failed", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := taskpkg.Save(dst, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTaskShowSurfacesExecutorInterruption(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")
+	message := "Executor interrupted before supervisor review (provider_api_error). provider status=error_during_execution session_id=sess-9 message=rate limited."
+	writeInterruptedTask(t, root, artifactDir, message)
+
+	stdout, stderr, err := executeCommand("task", "show", "--root", root, "task-cli-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr got %q", stderr)
+	}
+	for _, want := range []string{
+		"status: failed",
+		"latest_supervisor_verdict: not_reviewed",
+		"latest_error_kind: executor_interrupted",
+		"session_id=sess-9",
+		"latest_error_artifact_dir: " + artifactDir,
+		"latest_recovery:",
+		"galley task requeue task-cli-test",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestTaskShowJSONRetainsInterruptionEvidence(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")
+	writeInterruptedTask(t, root, artifactDir, "Executor interrupted before supervisor review (idle_timeout).")
+
+	stdout, _, err := executeCommand("task", "show", "--root", root, "-o", "json", "task-cli-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Task taskpkg.Task `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("decode task show json: %v", err)
+	}
+	if len(payload.Task.Attempts) != 1 {
+		t.Fatalf("attempts = %#v", payload.Task.Attempts)
+	}
+	att := payload.Task.Attempts[0]
+	if att.Error == nil || att.Error.Kind != taskpkg.AttemptKindExecutorInterrupted || att.Error.ArtifactDir != artifactDir {
+		t.Fatalf("interruption error not retained in json: %#v", att.Error)
+	}
+	foundRecovery := false
+	for _, r := range payload.Task.Risks {
+		if strings.Contains(strings.ToLower(r.Mitigation), "requeue") {
+			foundRecovery = true
+		}
+	}
+	if !foundRecovery {
+		t.Fatalf("expected a requeue recovery mitigation among risks: %#v", payload.Task.Risks)
+	}
+}

--- a/internal/daemon/acceptance_skeleton_creator_codex_daemon_test.go
+++ b/internal/daemon/acceptance_skeleton_creator_codex_daemon_test.go
@@ -75,6 +75,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '`+fakeCodexTurnCompleted+`'
     ;;
 esac
 `)

--- a/internal/daemon/attempt_error.go
+++ b/internal/daemon/attempt_error.go
@@ -3,11 +3,203 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shinpr/galley/internal/runner"
 	"github.com/shinpr/galley/internal/task"
 )
+
+// executorInterruptedError signals that an executor attempt was interrupted
+// (provider or runtime failure) before it reached a normal provider terminal.
+// The loop uses it to stop before supervisor review and publish the retained
+// task to tasks/failed without inventing a verdict.
+type executorInterruptedError struct {
+	Reason string
+	Err    error
+}
+
+func (e *executorInterruptedError) Error() string {
+	if e == nil {
+		return "executor interrupted"
+	}
+	reason := e.Reason
+	if reason == "" {
+		reason = runner.TerminalReasonUnknown
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("executor interrupted (%s): %s", reason, e.Err.Error())
+	}
+	return fmt.Sprintf("executor interrupted (%s)", reason)
+}
+
+func (e *executorInterruptedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func asExecutorInterrupted(err error) (*executorInterruptedError, bool) {
+	var ie *executorInterruptedError
+	if errors.As(err, &ie) {
+		return ie, true
+	}
+	return nil, false
+}
+
+// appendInterruptedAttempt records the executor-owned interruption: a
+// not_reviewed attempt with a distinct executor_interrupted error, a failed
+// verification entry, and a recovery risk. It sets status failed so the retained
+// worktree and evidence are published for requeue.
+func appendInterruptedAttempt(loaded *task.Task, outcome attemptOutcome, attemptDir string) *executorInterruptedError {
+	reason := outcome.Terminal.Reason
+	if reason == "" {
+		reason = runner.TerminalReasonUnknown
+	}
+	message := interruptionMessage(outcome, reason)
+	loaded.Attempts = append(loaded.Attempts, task.Attempt{
+		Number:            len(loaded.Attempts) + 1,
+		StartedAt:         outcome.Started.Format(time.RFC3339Nano),
+		CompletedAt:       outcome.Completed.Format(time.RFC3339Nano),
+		ClaudeStatus:      interruptedExecutorStatus(outcome.RunResult, outcome.RunErr),
+		SupervisorVerdict: task.AttemptVerdictNotReviewed,
+		Summary:           message,
+		Error: &task.AttemptError{
+			Phase:       "executor",
+			Kind:        task.AttemptKindExecutorInterrupted,
+			Message:     message,
+			ArtifactDir: attemptDir,
+		},
+	})
+	loaded.Verification.Commands = append(loaded.Verification.Commands, task.VerificationCommand{
+		Cmd:           executorVerificationCmd(outcome.CLI),
+		Status:        "failed",
+		OutputExcerpt: interruptionEvidenceExcerpt(outcome, reason, attemptDir),
+	})
+	appendRisk(loaded, "executor-interrupted", "partial_verification", message,
+		"Partial work and run evidence are preserved in the retained worktree and attempt directory; resolve the interruption cause, then run `galley task requeue` to reuse the worktree and start a fresh executor attempt.", true)
+	appendInterruptedArtifactRisks(loaded, outcome)
+	loaded.Status = task.StatusFailed
+	return &executorInterruptedError{Reason: reason, Err: outcome.RunErr}
+}
+
+// interruptedArtifactRequeueMitigation is the shared recovery guidance for every
+// interruption-path artifact capture failure: the retained worktree still holds
+// the underlying changes and a requeue reuses it.
+const interruptedArtifactRequeueMitigation = "The retained worktree still holds the underlying changes; resolve the cause, then run `galley task requeue` to reuse the worktree and start a fresh executor attempt."
+
+// appendInterruptedArtifactRisks records a distinct risk for each attempt
+// artifact whose write failed on the interruption path, so operators know
+// exactly which evidence is missing. The git status/diff capture failure keeps
+// the dedicated "interrupted-diff-capture" ID and raw error detail.
+func appendInterruptedArtifactRisks(loaded *task.Task, outcome attemptOutcome) {
+	if outcome.RunResultErr != nil {
+		appendRisk(loaded, "interrupted-artifact-capture", "partial_verification",
+			"run_result.json could not be written: "+outcome.RunResultErr.Error(), interruptedArtifactRequeueMitigation, true)
+	}
+	if outcome.TerminalErr != nil {
+		appendRisk(loaded, "interrupted-artifact-capture", "partial_verification",
+			"executor_terminal.json could not be written: "+outcome.TerminalErr.Error(), interruptedArtifactRequeueMitigation, true)
+	}
+	if outcome.GrokMetaErr != nil {
+		appendRisk(loaded, "interrupted-artifact-capture", "partial_verification",
+			"grok_completion.json could not be written: "+outcome.GrokMetaErr.Error(), interruptedArtifactRequeueMitigation, true)
+	}
+	if outcome.ResultErr != nil {
+		appendRisk(loaded, "interrupted-artifact-capture", "partial_verification",
+			"executor_result.json could not be written: "+outcome.ResultErr.Error(), interruptedArtifactRequeueMitigation, true)
+	}
+	if outcome.StagingErr != nil {
+		appendRisk(loaded, "interrupted-review-staging", "partial_verification",
+			"review staging failed: "+outcome.StagingErr.Error(), interruptedArtifactRequeueMitigation, true)
+	}
+	if outcome.DiffErr != nil {
+		appendRisk(loaded, "interrupted-diff-capture", "partial_verification", outcome.DiffErr.Error(),
+			"Some git status/diff evidence could not be written for this interrupted attempt; the retained worktree still holds the changes. Resolve the cause, then run `galley task requeue` to reuse the worktree.", true)
+	}
+}
+
+// interruptionEvidenceExcerpt lists which attempt artifacts were preserved and
+// which were not, so `galley task show` never claims an artifact a write failure
+// prevented persisting. It reports real per-artifact status because the runner
+// outcome and terminal survive every failure.
+func interruptionEvidenceExcerpt(outcome attemptOutcome, reason, attemptDir string) string {
+	preserved, failed := interruptionArtifactStatus(outcome)
+	excerpt := fmt.Sprintf("executor interrupted (%s); preserved under %s: %s", reason, attemptDir, strings.Join(preserved, ", "))
+	if len(failed) > 0 {
+		excerpt += "; not captured: " + strings.Join(failed, "; ")
+	}
+	return excerpt
+}
+
+func interruptionArtifactStatus(outcome attemptOutcome) (preserved, failed []string) {
+	appendArtifact := func(name string, err error) {
+		if err == nil {
+			preserved = append(preserved, name)
+			return
+		}
+		failed = append(failed, fmt.Sprintf("%s (%s)", name, err.Error()))
+	}
+	appendArtifact("raw provider output", outcome.RawOutputErr)
+	appendArtifact("run_result.json", outcome.RunResultErr)
+	appendArtifact("executor_terminal.json", outcome.TerminalErr)
+	if outcome.CLI == "grok" {
+		appendArtifact("grok_completion.json", outcome.GrokMetaErr)
+	}
+	if outcome.ParseErr == nil {
+		appendArtifact("executor_result.json", outcome.ResultErr)
+	}
+	if outcome.StagingErr != nil {
+		failed = append(failed, "review staging ("+outcome.StagingErr.Error()+")")
+	}
+	appendArtifact("git_status.json", outcome.GitStatusErr)
+	appendArtifact("diff.patch", outcome.DiffPatchErr)
+	return preserved, failed
+}
+
+// interruptionMessage renders a concise, operator-facing interruption summary.
+// Provider detail is appended when available and otherwise falls back to the
+// generic reason without changing routing.
+func interruptionMessage(outcome attemptOutcome, reason string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Executor interrupted before supervisor review (%s).", reason)
+	detail := outcome.Terminal.Detail
+	var parts []string
+	if detail.Status != "" {
+		parts = append(parts, "status="+detail.Status)
+	}
+	if detail.Code != "" {
+		parts = append(parts, "code="+detail.Code)
+	}
+	if detail.StopReason != "" {
+		parts = append(parts, "stop_reason="+detail.StopReason)
+	}
+	if detail.SessionID != "" {
+		parts = append(parts, "session_id="+detail.SessionID)
+	}
+	if detail.Message != "" {
+		parts = append(parts, "message="+detail.Message)
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(&b, " provider %s.", strings.Join(parts, " "))
+	} else if outcome.RunErr != nil {
+		fmt.Fprintf(&b, " %s.", outcome.RunErr.Error())
+	}
+	return b.String()
+}
+
+// interruptedExecutorStatus keeps the runner-derived status for interruptions
+// that carry a runner error (idle_timed_out/timed_out/failed) and labels
+// provider-terminal interruptions that exited cleanly as "interrupted" so the
+// attempt status never reads as "completed".
+func interruptedExecutorStatus(result runner.RunResult, runErr error) string {
+	if runErr != nil {
+		return executorStatus(result, runErr)
+	}
+	return "interrupted"
+}
 
 func appendFailureAttempt(loaded *task.Task, phase, kind string, err error, artifactDir string) {
 	if loaded == nil {

--- a/internal/daemon/codex_executor_dispatch_test.go
+++ b/internal/daemon/codex_executor_dispatch_test.go
@@ -45,7 +45,7 @@ import (
 // to record invocation markers and emit the executor result JSON line.
 func writeFakeCodexExecutor(t *testing.T, body string) string {
 	t.Helper()
-	return writeFakeCommand(t, "codex", "cat >/dev/null\n"+body)
+	return writeFakeCommand(t, "codex", "cat >/dev/null\n"+body+"\nprintf '%s\\n' '"+fakeCodexTurnCompleted+"'\n")
 }
 
 // TestDaemonDispatchesSelectedExecutorBinary parameterizes over the supported

--- a/internal/daemon/codex_executor_result_capture_test.go
+++ b/internal/daemon/codex_executor_result_capture_test.go
@@ -29,9 +29,9 @@ func TestCodexExecutorLastMessageJSONReachesExecutorResult(t *testing.T) {
 	promptPath, schemaPath := writeDaemonPromptFiles(t)
 
 	executorResult := `{"status":"completed","summary":"codex last-message summary","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
-	// The fake executor writes the result to --output-last-message and emits a
-	// non-result line on stdout so the test only passes when the daemon parses
-	// the last-message file rather than relying on stdout JSONL.
+	// The fake writes the result to --output-last-message and emits turn.completed
+	// plus a non-result stdout line, so the test only passes when the daemon reads
+	// the last-message file rather than stdout JSONL.
 	claudeBin := writeFakeClaude(t, "exit 1\n")
 	codexBin := writeFakeCommand(t, "codex", `lastmsg=""
 while [ "$#" -gt 0 ]; do
@@ -51,6 +51,7 @@ if [ -n "$lastmsg" ]; then
   printf '%s' '`+executorResult+`' > "$lastmsg"
 fi
 printf '%s\n' '{"event":"unrelated"}'
+printf '%s\n' '`+fakeCodexTurnCompleted+`'
 `)
 
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
@@ -117,6 +118,7 @@ if [ -n "$lastmsg" ]; then
   printf '%s' '`+hardStopResult+`' > "$lastmsg"
 fi
 printf '%s\n' '`+hardStopResult+`'
+printf '%s\n' '`+fakeCodexTurnCompleted+`'
 `)
 
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -136,13 +136,23 @@ type daemonDependencies struct {
 	stageExecutorOutput func(context.Context, Options, string, string, []string) error
 	supervisorRunner    func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)
 	setupExecutorRunner func(context.Context, setuppreflight.Options) (*setuppreflight.Result, error)
+	// writeAttemptArtifact persists one JSON attempt artifact (run_result,
+	// executor_terminal, or executor_result). It is a seam so lifecycle tests can
+	// inject a deterministic write failure for a single named artifact and prove
+	// the runner outcome and terminal classification still survive.
+	writeAttemptArtifact func(path string, value any) error
+	// writeProviderMetadata persists a provider completion metadata blob (Grok
+	// raw output). Injectable for the same reason as writeAttemptArtifact.
+	writeProviderMetadata func(path string, data []byte) error
 }
 
 func defaultDaemonDependencies() daemonDependencies {
 	return daemonDependencies{
-		stageExecutorOutput: defaultStageExecutorOutput,
-		supervisorRunner:    defaultSupervisorRunner,
-		setupExecutorRunner: setuppreflight.RunExecutor,
+		stageExecutorOutput:   defaultStageExecutorOutput,
+		supervisorRunner:      defaultSupervisorRunner,
+		setupExecutorRunner:   setuppreflight.RunExecutor,
+		writeAttemptArtifact:  writeJSON,
+		writeProviderMetadata: runner.WriteGrokCompletionMetadata,
 	}
 }
 
@@ -160,6 +170,12 @@ func (opts Options) daemonDependencies() daemonDependencies {
 	}
 	if deps.setupExecutorRunner == nil {
 		deps.setupExecutorRunner = defaults.setupExecutorRunner
+	}
+	if deps.writeAttemptArtifact == nil {
+		deps.writeAttemptArtifact = defaults.writeAttemptArtifact
+	}
+	if deps.writeProviderMetadata == nil {
+		deps.writeProviderMetadata = defaults.writeProviderMetadata
 	}
 	return deps
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -185,7 +185,10 @@ func TestRunOnceRecordsSupervisorTimeoutInTaskAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeDaemonTask(t, taskPath, repo)
-	setTimeoutMS(t, taskPath, 50)
+	// The executor reaches a normal terminal well within this budget while the
+	// sleeping supervisor exhausts it, so the recorded failure is the supervisor
+	// timeout rather than an executor interruption before review.
+	setTimeoutMS(t, taskPath, 800)
 
 	err := runTestDaemon(context.Background(), Options{
 		Root:               root,
@@ -196,6 +199,7 @@ func TestRunOnceRecordsSupervisorTimeoutInTaskAttempt(t *testing.T) {
 		Supervisor:         "codex",
 		ClaudeBin:          claudeBin,
 		CodexBin:           codexBin,
+		DisableClaudeGuard: true,
 	})
 	if err == nil {
 		t.Fatal("expected supervisor timeout")
@@ -644,7 +648,10 @@ func TestRunOnceParseFailureNeedsSupervisorReview(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)
 	promptPath, schemaPath := writeDaemonPromptFiles(t)
-	claudeBin := writeFakeClaude(t, "echo not-json\n")
+	// A result event is the Claude normal terminal; its inner payload is invalid
+	// JSON. An executor-result parse failure after a normal terminal must still
+	// be reviewed by the supervisor rather than treated as an interruption.
+	claudeBin := writeFakeClaude(t, `echo '{"type":"result","subtype":"success","is_error":false,"result":"not-json"}'`+"\n")
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -673,6 +680,11 @@ func TestRunOnceParseFailureNeedsSupervisorReview(t *testing.T) {
 	if len(failedTask.Risks) == 0 {
 		t.Fatal("expected parse risk")
 	}
+	last := failedTask.Attempts[len(failedTask.Attempts)-1]
+	if last.SupervisorVerdict == task.AttemptVerdictNotReviewed || last.SupervisorVerdict == "" {
+		t.Fatalf("expected a supervisor verdict after a normal terminal; got %q", last.SupervisorVerdict)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 1)
 }
 
 func TestRunOnceCompletedWithRisksNeedsSupervisorReview(t *testing.T) {
@@ -784,6 +796,15 @@ func TestRunOnceStopsAfterConsecutiveNoDiffAttempts(t *testing.T) {
 	}
 }
 
+// Representative normal-terminal markers the fake executors auto-append so
+// strict terminal classification sees a completed attempt. A body that emits
+// its own explicit failed terminal still routes as an interruption because
+// failed terminals take precedence.
+const (
+	fakeClaudeResultEvent  = `{"type":"result","subtype":"success","is_error":false}`
+	fakeCodexTurnCompleted = `{"type":"turn.completed"}`
+)
+
 func writeFakeClaude(t *testing.T, body string) string {
 	t.Helper()
 	return writeFakeCommand(t, "claude", `supervisor=0
@@ -807,7 +828,7 @@ if [ "$supervisor" = "1" ]; then
   fi
   exit 0
 fi
-`+body)
+`+body+"\nprintf '%s\\n' '"+fakeClaudeResultEvent+"'\n")
 }
 
 func prepareDonePRTask(t *testing.T, taskPath, repo, prStatus string) (task.Task, string) {

--- a/internal/daemon/executor_attempt.go
+++ b/internal/daemon/executor_attempt.go
@@ -24,12 +24,26 @@ type attemptOutcome struct {
 	Completed      time.Time
 	RunResult      runner.RunResult
 	RunErr         error
+	Terminal       runner.ExecutorTerminal
+	CLI            string
 	ExecutorResult runner.ExecutorResult
 	ParseErr       error
 	DiffDirty      bool
 	Diff           string
 	DiffErr        error
 	DiffSnapshot   workspace.Snapshot
+	// Per-artifact availability flags. Any may be non-nil on an interruption
+	// without discarding routing, so the inventory names each artifact truthfully:
+	// GitStatusErr and DiffPatchErr split the diff evidence, and RawOutputErr flags
+	// a capture-file creation failure that left no raw output to claim.
+	RawOutputErr error
+	RunResultErr error
+	TerminalErr  error
+	GrokMetaErr  error
+	ResultErr    error
+	StagingErr   error
+	GitStatusErr error
+	DiffPatchErr error
 }
 
 func defaultStageExecutorOutput(ctx context.Context, opts Options, workDir, attemptDir string, excludePaths []string) error {
@@ -88,35 +102,64 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 	if err != nil {
 		return attemptOutcome{}, err
 	}
+	// A capture-file creation failure returns before either raw log exists, so the
+	// on-disk stdout/stderr paths decide whether raw provider output was preserved.
+	rawOutputErr := rawOutputCaptureErr(stdoutPath, stderrPath)
+	deps := opts.daemonDependencies()
+
+	// Terminal classification is the single executor->supervisor routing
+	// decision. It is derived only from the in-memory runner outcome and captured
+	// provider output, so it is fixed immediately after the runner returns and
+	// survives every post-run persistence failure below. An interruption keeps
+	// this decision even when no artifact can be written; a normal terminal keeps
+	// the existing hard-failure semantics because the supervisor must not review
+	// an attempt whose evidence could not be persisted.
+	terminal := runner.ClassifyExecutorTerminal(cli, stdoutPath, run.RunResult.Stdout, run.RunResult, run.RunErr)
+	interrupted := !terminal.NormalTerminal
+
+	// Persist the runner outcome and routing decision. Each write records a
+	// separate availability flag instead of discarding the outcome.
+	runResultErr := deps.writeAttemptArtifact(runartifact.Path(attemptDir, runartifact.RunResultFilename), run.RunResult)
+	terminalErr := deps.writeAttemptArtifact(runartifact.Path(attemptDir, runartifact.ExecutorTerminalFilename), terminal)
+
+	var grokMetaErr error
 	if cli == "grok" {
 		data, readErr := os.ReadFile(stdoutPath)
 		if readErr != nil {
 			data = []byte(run.RunResult.Stdout)
 		}
-		if metaErr := runner.WriteGrokCompletionMetadata(runartifact.Path(attemptDir, runartifact.GrokCompletionMetadataFilename), data); metaErr != nil {
-			return attemptOutcome{}, metaErr
-		}
+		grokMetaErr = deps.writeProviderMetadata(runartifact.Path(attemptDir, runartifact.GrokCompletionMetadataFilename), data)
 	}
 
-	resultPath := runartifact.Path(attemptDir, runartifact.ExecutorResultFilename)
 	lastMessagePath := codexLastMessagePath(cli, attemptDir)
 	executorResult, parseErr := resolveExecutorResult(cli, stdoutPath, run.RunResult.Stdout, lastMessagePath)
+	var resultErr error
 	if parseErr == nil {
-		if err := writeJSON(resultPath, executorResult); err != nil {
-			return attemptOutcome{}, err
-		}
+		resultErr = deps.writeAttemptArtifact(runartifact.Path(attemptDir, runartifact.ExecutorResultFilename), executorResult)
 	}
 
 	// Stage untracked executor output, excluding context-only inputs, before
 	// supervisor review. The parent context preserves evidence after a timeout.
 	excludePaths := nonCommittedInputDestinations(loaded.Files)
-	if err := opts.daemonDependencies().stageExecutorOutput(ctx, opts, workDir, attemptDir, excludePaths); err != nil {
-		return attemptOutcome{}, &reviewStagingError{Err: err}
-	}
+	stagingErr := deps.stageExecutorOutput(ctx, opts, workDir, attemptDir, excludePaths)
 
-	diffArtifacts, err := executorflow.CaptureDiffArtifacts(ctx, workDir, baseSHA, attemptDir, workspaceOptions(opts))
-	if err != nil {
-		return attemptOutcome{}, err
+	// CaptureDiffArtifacts returns every successfully captured component with any
+	// snapshot-capture failure in diffArtifacts.Err (second return nil) and any
+	// artifact-write failure as the second return. A normal terminal fails on a
+	// write failure but tolerates a capture-only failure as a recorded risk.
+	diffArtifacts, diffWriteErr := executorflow.CaptureDiffArtifacts(ctx, workDir, baseSHA, attemptDir, workspaceOptions(opts))
+	diffErr := diffArtifacts.Err
+
+	if !interrupted {
+		if err := firstNonNilErr(runResultErr, terminalErr, grokMetaErr, resultErr); err != nil {
+			return attemptOutcome{}, err
+		}
+		if stagingErr != nil {
+			return attemptOutcome{}, &reviewStagingError{Err: stagingErr}
+		}
+		if diffWriteErr != nil {
+			return attemptOutcome{}, diffWriteErr
+		}
 	}
 
 	return attemptOutcome{
@@ -124,13 +167,51 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 		Completed:      run.Completed,
 		RunResult:      run.RunResult,
 		RunErr:         run.RunErr,
+		Terminal:       terminal,
+		CLI:            cli,
 		ExecutorResult: executorResult,
 		ParseErr:       parseErr,
 		DiffDirty:      diffArtifacts.Dirty,
 		Diff:           diffArtifacts.Diff,
-		DiffErr:        diffArtifacts.Err,
+		DiffErr:        diffErr,
 		DiffSnapshot:   diffArtifacts.Snapshot,
+		RawOutputErr:   rawOutputErr,
+		RunResultErr:   runResultErr,
+		TerminalErr:    terminalErr,
+		GrokMetaErr:    grokMetaErr,
+		ResultErr:      resultErr,
+		StagingErr:     stagingErr,
+		GitStatusErr:   diffArtifacts.GitStatusErr,
+		DiffPatchErr:   diffArtifacts.DiffPatchErr,
 	}, nil
+}
+
+// rawOutputCaptureErr reports the capture logs that were never created, so an
+// interruption inventory never claims raw provider output a capture-file failure
+// prevented Galley from persisting.
+func rawOutputCaptureErr(paths ...string) error {
+	var missing []string
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err != nil {
+			missing = append(missing, filepath.Base(p))
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("capture file not created: %s", strings.Join(missing, ", "))
+}
+
+func firstNonNilErr(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func markRevisionRequestsAddressed(loaded *task.Task, evidence string) {

--- a/internal/daemon/executor_defaults_preflight_test.go
+++ b/internal/daemon/executor_defaults_preflight_test.go
@@ -178,6 +178,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '`+fakeCodexTurnCompleted+`'
     ;;
 esac
 `)
@@ -359,6 +360,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '`+fakeCodexTurnCompleted+`'
     ;;
 esac
 `)
@@ -539,6 +541,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '`+fakeCodexTurnCompleted+`'
     ;;
 esac
 `)

--- a/internal/daemon/glm_executor_test.go
+++ b/internal/daemon/glm_executor_test.go
@@ -1,11 +1,103 @@
 package daemon
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/shinpr/galley/internal/task"
 )
+
+func loadGLMExecutorTask(t *testing.T, taskPath, repo string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.CLI = "glm"
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGLMExecutorNormalTerminalReachesSupervisor(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	validResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '"+validResult+"'\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	loadGLMExecutorTask(t, taskPath, repo)
+
+	if err := runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin, GLMAuthToken: "test-token"}); err != nil {
+		t.Fatal(err)
+	}
+
+	done, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("done task missing: %v", err)
+	}
+	if done.Status != "accepted" {
+		t.Fatalf("status = %q; want accepted", done.Status)
+	}
+	if len(done.Attempts) != 1 || done.Attempts[0].SupervisorVerdict != "accepted" {
+		t.Fatalf("attempts = %#v; want one accepted attempt", done.Attempts)
+	}
+	if done.Attempts[0].Error != nil && done.Attempts[0].Error.Kind == task.AttemptKindExecutorInterrupted {
+		t.Fatalf("a normal GLM terminal must not be an interruption: %#v", done.Attempts[0].Error)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 1)
+}
+
+func TestGLMExecutorAPIErrorInterruptionSkipsSupervisor(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	claudeBin := writeFakeClaude(t, `echo change > daemon-output.txt`+"\n"+`echo '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"glm-sess","error":"rate limited"}'`+"\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	loadGLMExecutorTask(t, taskPath, repo)
+	// loop_budget > 1 proves the interruption never starts attempt 2.
+	setLoopBudget(t, taskPath, 3)
+
+	_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin, GLMAuthToken: "test-token"})
+
+	failed := mustLoadFailedTask(t, root)
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	attempt := failed.Attempts[0]
+	if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+		t.Fatalf("verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+	}
+	if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+	}
+	if !strings.Contains(attempt.Error.Message, "message=rate limited") || !strings.Contains(attempt.Error.Message, "session_id=glm-sess") {
+		t.Fatalf("interruption must retain GLM provider detail: %q", attempt.Error.Message)
+	}
+	if attempt.Error.ArtifactDir == "" {
+		t.Fatal("interruption must record the artifact directory task show surfaces")
+	}
+	foundRequeue := false
+	for _, r := range failed.Risks {
+		if strings.Contains(r.Mitigation, "galley task requeue") {
+			foundRequeue = true
+		}
+	}
+	if !foundRequeue {
+		t.Fatalf("interruption must record requeue recovery guidance: %#v", failed.Risks)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
 
 func TestPrepareGLMExecutorPlanFailsFastWithoutToken(t *testing.T) {
 	t.Parallel()

--- a/internal/daemon/grok_executor_failure_test.go
+++ b/internal/daemon/grok_executor_failure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,16 +12,16 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-func TestGrokExecutorProcessFailuresKeepGenericDaemonClassifications(t *testing.T) {
+func TestGrokExecutorRuntimeFailuresInterruptBeforeSupervisor(t *testing.T) {
 	tests := []struct {
-		name, body, wantKind string
-		missingBinary        bool
-		idle, total          time.Duration
+		name, body, wantReason string
+		missingBinary          bool
+		idle, total            time.Duration
 	}{
-		{name: "start failure", missingBinary: true, wantKind: "executor_failed"},
-		{name: "non-zero exit", body: "exit 7\n", wantKind: "executor_failed"},
-		{name: "idle timeout", body: "sleep 5\n", idle: 100 * time.Millisecond, wantKind: "idle_timeout"},
-		{name: "total timeout", body: "sleep 5\n", total: 100 * time.Millisecond, wantKind: "timed_out"},
+		{name: "start failure", missingBinary: true, wantReason: "start_failed"},
+		{name: "non-zero exit", body: "exit 7\n", wantReason: "exit_nonzero"},
+		{name: "idle timeout", body: "sleep 5\n", idle: 100 * time.Millisecond, wantReason: "idle_timeout"},
+		{name: "total timeout", body: "sleep 5\n", total: 100 * time.Millisecond, wantReason: "timed_out"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -49,16 +50,40 @@ func TestGrokExecutorProcessFailuresKeepGenericDaemonClassifications(t *testing.
 			if err := task.Save(taskPath, loaded); err != nil {
 				t.Fatal(err)
 			}
-			setLoopBudget(t, taskPath, 1)
-			_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: writeFakeClaude(t, "exit 1\n"), GrokBin: grokBin, IdleTimeout: tc.idle})
+			// loop_budget > 1 proves the interruption never starts attempt 2.
+			setLoopBudget(t, taskPath, 3)
+			// A supervisor that fails loudly if ever invoked; an interruption
+			// must not call it at all.
+			supervisorMarker := filepath.Join(t.TempDir(), "supervisor.called")
+			claudeBin := writeFakeClaude(t, "echo called >> "+supervisorMarker+"\nexit 1\n")
+			_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin, GrokBin: grokBin, IdleTimeout: tc.idle})
 			failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
 			if err != nil {
 				t.Fatalf("failed task missing: %v", err)
 			}
-			if len(failed.Attempts) == 0 || failed.Attempts[0].Error == nil || failed.Attempts[0].Error.Kind != tc.wantKind {
-				t.Fatalf("attempt classification = %#v; want %s", failed.Attempts, tc.wantKind)
+			if failed.Status != "failed" {
+				t.Fatalf("status = %q; want failed", failed.Status)
+			}
+			if len(failed.Attempts) != 1 {
+				t.Fatalf("attempts = %d; want exactly one executor attempt: %#v", len(failed.Attempts), failed.Attempts)
+			}
+			attempt := failed.Attempts[0]
+			if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+				t.Fatalf("supervisor_verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+			}
+			if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+				t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+			}
+			if !strings.Contains(attempt.Error.Message, tc.wantReason) {
+				t.Fatalf("interruption message = %q; want diagnostic reason %q", attempt.Error.Message, tc.wantReason)
+			}
+			if _, err := os.Stat(supervisorMarker); err == nil {
+				t.Fatal("supervisor was invoked for an interrupted executor attempt")
 			}
 			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 1)
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 1)
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
 		})
 	}
 }

--- a/internal/daemon/interrupt_before_supervisor_test.go
+++ b/internal/daemon/interrupt_before_supervisor_test.go
@@ -1,0 +1,313 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runartifact"
+	"github.com/shinpr/galley/internal/task"
+)
+
+func TestExecutorProviderTerminalInterruptionsSkipSupervisor(t *testing.T) {
+	tests := []struct {
+		name         string
+		cli          string
+		executorBody func(supervisorMarker string) string
+		wantDetail   string
+	}{
+		{
+			name: "claude api error result",
+			cli:  "claude",
+			executorBody: func(_ string) string {
+				return `echo '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"sess-1","error":"rate limited"}'` + "\n"
+			},
+			wantDetail: "message=rate limited",
+		},
+		{
+			name: "codex turn.failed",
+			cli:  "codex",
+			executorBody: func(_ string) string {
+				return `printf '%s\n' '{"type":"turn.failed","error":{"code":"quota_exceeded","message":"out of quota"}}'` + "\n"
+			},
+			wantDetail: "code=quota_exceeded",
+		},
+		{
+			name: "grok non-end-turn",
+			cli:  "grok",
+			executorBody: func(_ string) string {
+				return `printf '%s\n' '{"text":"{}","stopReason":"Cancelled","sessionId":"grok-1"}'` + "\n"
+			},
+			wantDetail: "stop_reason=Cancelled",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), ".agent-workflow")
+			repo := initDaemonGitRepo(t)
+			promptPath, schemaPath := writeDaemonPromptFiles(t)
+			supervisorMarker := filepath.Join(t.TempDir(), "supervisor.called")
+			// A missing supervisor_verdict.json is the robust proof no supervisor
+			// ran; the marker is a redundant guard.
+			claudeBin := writeFakeClaude(t, tc.executorBody(supervisorMarker))
+			opts := Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin}
+			switch tc.cli {
+			case "codex":
+				opts.CodexBin = writeFakeCodexExecutor(t, tc.executorBody(supervisorMarker))
+			case "grok":
+				opts.GrokBin = writeFakeCommand(t, "grok", "cat >/dev/null 2>&1 || true\n"+tc.executorBody(supervisorMarker))
+			}
+
+			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeDaemonTask(t, taskPath, repo)
+			loaded, err := task.Load(taskPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			loaded.Executor.CLI = tc.cli
+			if err := task.Save(taskPath, loaded); err != nil {
+				t.Fatal(err)
+			}
+			// loop_budget > 1 proves the interruption never starts attempt 2.
+			setLoopBudget(t, taskPath, 3)
+
+			_ = runTestDaemon(context.Background(), opts)
+
+			failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+			if err != nil {
+				t.Fatalf("failed task missing: %v", err)
+			}
+			if failed.Status != "failed" {
+				t.Fatalf("status = %q; want failed", failed.Status)
+			}
+			if len(failed.Attempts) != 1 {
+				t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+			}
+			attempt := failed.Attempts[0]
+			if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+				t.Fatalf("verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+			}
+			if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+				t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+			}
+			if !strings.Contains(attempt.Error.Message, tc.wantDetail) {
+				t.Fatalf("interruption message = %q; want provider detail %q", attempt.Error.Message, tc.wantDetail)
+			}
+			if attempt.Error.ArtifactDir == "" {
+				t.Fatal("interruption must record the artifact directory")
+			}
+			if _, statErr := os.Stat(supervisorMarker); statErr == nil {
+				t.Fatal("supervisor was invoked for an interrupted attempt")
+			}
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 1)
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+		})
+	}
+}
+
+func TestNormalTerminalInvalidResultKeepsSupervisorLoop(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	validResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+	// Attempt 1 emits a normal result event wrapping invalid JSON (reviewable
+	// parse failure). Attempt 2 emits a valid result and is accepted.
+	claudeBin := writeFakeClaude(t, `if [ -f retry.marker ]; then
+echo change > daemon-output.txt
+echo '`+validResult+`'
+else
+touch retry.marker
+echo '{"type":"result","subtype":"success","is_error":false,"result":"not-json"}'
+fi
+`)
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	if err := runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin}); err != nil {
+		t.Fatal(err)
+	}
+
+	done, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("done task missing: %v", err)
+	}
+	if done.Status != "accepted" {
+		t.Fatalf("status = %q; want accepted", done.Status)
+	}
+	if len(done.Attempts) != 2 {
+		t.Fatalf("attempts = %d; want 2: %#v", len(done.Attempts), done.Attempts)
+	}
+	if done.Attempts[0].SupervisorVerdict != "needs_revision" || done.Attempts[1].SupervisorVerdict != "accepted" {
+		t.Fatalf("verdicts = %q, %q; want needs_revision then accepted", done.Attempts[0].SupervisorVerdict, done.Attempts[1].SupervisorVerdict)
+	}
+	if done.Attempts[0].Error != nil && done.Attempts[0].Error.Kind == task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt 1 must be reviewed, not interrupted: %#v", done.Attempts[0])
+	}
+}
+
+func TestInterruptedDirtyWorktreeIsPreservedAndRequeueable(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	validResult := `{"status":"completed","summary":"resumed","files_modified":["README.md","untracked.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+	// First run: modify a tracked file and create an untracked file, then emit an
+	// explicit provider API-error terminal (interruption). Second run (reused
+	// worktree): assert the retained changes are visible, then complete normally
+	// so the supervisor accepts.
+	claudeBin := writeFakeClaude(t, `if grep -q RESUMED README.md 2>/dev/null && [ -f untracked.txt ]; then
+echo daemon-output > daemon-output.txt
+echo '`+validResult+`'
+else
+echo RESUMED >> README.md
+echo created > untracked.txt
+echo '{"type":"result","subtype":"error_during_execution","is_error":true,"error":"transient provider failure before completion"}'
+fi
+`)
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	opts := Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin}
+	_ = runTestDaemon(context.Background(), opts)
+
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	failed, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+	if failed.Status != "failed" || len(failed.Attempts) != 1 || failed.Attempts[0].Error == nil || failed.Attempts[0].Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("expected a single interrupted attempt: %#v", failed.Attempts)
+	}
+
+	diff := string(mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.DiffPatchFilename)))
+	if !strings.Contains(diff, "RESUMED") {
+		t.Fatalf("diff.patch missing tracked modification: %s", diff)
+	}
+	if !strings.Contains(diff, "untracked.txt") || !strings.Contains(diff, "created") {
+		t.Fatalf("diff.patch missing untracked file: %s", diff)
+	}
+
+	worktreePath := failed.Worktree.Path
+	if !filepath.IsAbs(worktreePath) {
+		worktreePath = filepath.Join(repo, worktreePath)
+	}
+	readme, err := os.ReadFile(filepath.Join(worktreePath, "README.md"))
+	if err != nil || !strings.Contains(string(readme), "RESUMED") {
+		t.Fatalf("retained worktree lost tracked change: %q err=%v", readme, err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreePath, "untracked.txt")); err != nil {
+		t.Fatalf("retained worktree lost untracked change: %v", err)
+	}
+
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root, Reason: "interruption cause resolved"}); err != nil {
+		t.Fatalf("requeue: %v", err)
+	}
+	if err := runTestDaemon(context.Background(), opts); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	done, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("done task missing after requeue: %v", err)
+	}
+	if done.Status != "accepted" {
+		t.Fatalf("status after requeue = %q; want accepted", done.Status)
+	}
+	var reused bool
+	for _, m := range mustGlob(t, filepath.Join(root, "runs", "*", runartifact.WorkspaceFilename)) {
+		if strings.Contains(string(mustReadFile(t, m)), `"worktree_reused": true`) {
+			reused = true
+		}
+	}
+	if !reused {
+		t.Fatal("second run did not reuse the retained worktree")
+	}
+}
+
+func TestInterruptedAttemptSurvivesPostExecutorEvidenceFailures(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	// The executor changes the workspace, then emits a provider API-error
+	// terminal (interruption).
+	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"session_id\":\"sess-x\",\"error\":\"provider outage\"}'\n")
+
+	// Inject a review-staging failure and corrupt the diff target so both the
+	// staging and diff writes fail; neither may override the interruption route.
+	stageFail := func(_ context.Context, _ Options, _, attemptDir string, _ []string) error {
+		if err := os.MkdirAll(filepath.Join(attemptDir, runartifact.GitStatusFilename), 0o700); err != nil {
+			return err
+		}
+		return fmt.Errorf("git add -A (review staging) failed: simulated index lock")
+	}
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	// loop_budget > 1 proves the interruption never starts attempt 2.
+	setLoopBudget(t, taskPath, 3)
+
+	_ = runTestDaemon(context.Background(), Options{
+		Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath,
+		Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin,
+		dependencies: &daemonDependencies{stageExecutorOutput: stageFail},
+	})
+
+	failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+	if failed.Status != "failed" {
+		t.Fatalf("status = %q; want failed", failed.Status)
+	}
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want exactly one executor attempt: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	attempt := failed.Attempts[0]
+	if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+		t.Fatalf("verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+	}
+	if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q (a post-executor evidence failure must not reclassify the interruption)", attempt.Error, task.AttemptKindExecutorInterrupted)
+	}
+	if !strings.Contains(attempt.Error.Message, "provider outage") {
+		t.Fatalf("interruption message must retain provider detail: %q", attempt.Error.Message)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 1)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 1)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
+
+func mustGlob(t *testing.T, pattern string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	return matches
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}

--- a/internal/daemon/interrupt_diagnostics_test.go
+++ b/internal/daemon/interrupt_diagnostics_test.go
@@ -1,0 +1,315 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runartifact"
+	"github.com/shinpr/galley/internal/runner"
+	"github.com/shinpr/galley/internal/task"
+)
+
+func TestAmbiguousClaudeResultFailsClosed(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	supervisorMarker := filepath.Join(t.TempDir(), "supervisor.called")
+	// A raw fake (not writeFakeClaude) so no success terminal is auto-appended:
+	// the executor emits only an ambiguous result. The supervisor branch records
+	// any invocation, which an interruption must never trigger.
+	claudeBin := writeFakeCommand(t, "claude", `for arg in "$@"; do
+  if [ "$arg" = "--no-session-persistence" ]; then
+    echo called >> `+supervisorMarker+`
+    cat >/dev/null
+    printf '%s\n' '{"status":"accepted","summary":"x","acceptance_gaps":[],"reviewed_files":[],"acceptance_evidence":[],"findings":[],"quality_coverage":[],"residual_risks":[],"discussion_items":[],"confidence":"high","next_work_order":""}'
+    exit 0
+  fi
+done
+echo change > daemon-output.txt
+printf '%s\n' '{"type":"result","subtype":"in_progress","session_id":"amb-1"}'
+`)
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+
+	failed := mustLoadFailedTask(t, root)
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	attempt := failed.Attempts[0]
+	if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+		t.Fatalf("verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+	}
+	if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+	}
+	if !strings.Contains(attempt.Error.Message, runner.TerminalReasonAmbiguousResult) {
+		t.Fatalf("message must name the ambiguous reason: %q", attempt.Error.Message)
+	}
+	if !strings.Contains(attempt.Error.Message, "status=in_progress") || !strings.Contains(attempt.Error.Message, "session_id=amb-1") {
+		t.Fatalf("message must retain ambiguous result detail: %q", attempt.Error.Message)
+	}
+	if _, err := os.Stat(supervisorMarker); err == nil {
+		t.Fatal("supervisor was invoked for an ambiguous (interrupted) attempt")
+	}
+	assertNormalTerminal(t, root, false)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
+
+func TestGrokEndTurnWithoutSessionIDStaysReviewable(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	claudeBin := writeFakeClaude(t, "")
+	grokBin := writeFakeCommand(t, "grok", "cat >/dev/null 2>&1 || true\nprintf '%s\\n' '{\"text\":\"{}\",\"stopReason\":\"EndTurn\"}'\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.CLI = "grok"
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin, GrokBin: grokBin})
+
+	// A normal terminal plus a persisted verdict means a real supervisor review,
+	// not an interruption. needs_supervisor_review shares the failed directory,
+	// so the status/verdict is the routing signal, not the directory.
+	assertNormalTerminal(t, root, true)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 1)
+	reviewed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+	if err != nil {
+		t.Fatalf("reviewed task missing: %v", err)
+	}
+	if reviewed.Status != task.StatusNeedsSupervisorReview {
+		t.Fatalf("status = %q; want %q (a reviewed attempt, not an interruption)", reviewed.Status, task.StatusNeedsSupervisorReview)
+	}
+	if len(reviewed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(reviewed.Attempts), reviewed.Attempts)
+	}
+	att := reviewed.Attempts[0]
+	if att.SupervisorVerdict != "needs_revision" {
+		t.Fatalf("verdict = %q; want a real supervisor verdict (needs_revision)", att.SupervisorVerdict)
+	}
+	if att.Error != nil && att.Error.Kind == task.AttemptKindExecutorInterrupted {
+		t.Fatalf("EndTurn without sessionId must not be classified as an interruption: %#v", att.Error)
+	}
+}
+
+func TestInterruptionRetainsProviderDetailWhenRunnerFails(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	// The executor prints a structured provider API error and then exits non-zero
+	// (the appended success terminal never runs). The runner failure sets the
+	// routing reason; the provider detail must still be retained.
+	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"session_id\":\"sess-z\",\"error\":\"provider 529\"}'\nexit 7\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+
+	failed := mustLoadFailedTask(t, root)
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	attempt := failed.Attempts[0]
+	if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+	}
+	if !strings.Contains(attempt.Error.Message, runner.TerminalReasonExitNonZero) {
+		t.Fatalf("runner failure reason must control routing: %q", attempt.Error.Message)
+	}
+	if !strings.Contains(attempt.Error.Message, "message=provider 529") {
+		t.Fatalf("provider detail must be retained even on a runner failure: %q", attempt.Error.Message)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
+
+func TestInterruptionPartialDiffWriteFailureRetainsComponents(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	// Stage normally, then pre-create git_status.json as a directory so only that
+	// write fails while diff.patch still succeeds.
+	stageThenBlockGitStatus := func(ctx context.Context, opts Options, workDir, attemptDir string, exclude []string) error {
+		if err := defaultStageExecutorOutput(ctx, opts, workDir, attemptDir, exclude); err != nil {
+			return err
+		}
+		return os.MkdirAll(filepath.Join(attemptDir, runartifact.GitStatusFilename), 0o700)
+	}
+	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"error\":\"provider outage\"}'\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	_ = runTestDaemon(context.Background(), Options{
+		Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath,
+		Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin,
+		dependencies: &daemonDependencies{stageExecutorOutput: stageThenBlockGitStatus},
+	})
+
+	failed := mustLoadFailedTask(t, root)
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	if failed.Attempts[0].Error == nil || failed.Attempts[0].Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q", failed.Attempts[0].Error, task.AttemptKindExecutorInterrupted)
+	}
+
+	diff := string(mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.DiffPatchFilename)))
+	if !strings.Contains(diff, "change") {
+		t.Fatalf("diff.patch must retain the captured change: %q", diff)
+	}
+
+	foundCaptureRisk := false
+	for _, r := range failed.Risks {
+		if strings.HasPrefix(r.ID, "interrupted-diff-capture") && strings.Contains(r.Detail, "write git_status.json") {
+			foundCaptureRisk = true
+		}
+	}
+	if !foundCaptureRisk {
+		t.Fatalf("expected an interrupted-diff-capture risk disclosing the write failure: %#v", failed.Risks)
+	}
+
+	foundTruthful := false
+	for _, cmd := range failed.Verification.Commands {
+		if cmd.Status != "failed" || !strings.Contains(cmd.OutputExcerpt, "executor interrupted") {
+			continue
+		}
+		foundTruthful = true
+		preservedText, notCaptured := splitInterruptionExcerpt(t, cmd.OutputExcerpt)
+		if !strings.Contains(preservedText, runartifact.DiffPatchFilename) {
+			t.Fatalf("preserved inventory must list diff.patch: %q", cmd.OutputExcerpt)
+		}
+		if strings.Contains(preservedText, runartifact.GitStatusFilename) {
+			t.Fatalf("preserved inventory falsely claims git_status.json: %q", cmd.OutputExcerpt)
+		}
+		if !strings.Contains(notCaptured, runartifact.GitStatusFilename) {
+			t.Fatalf("unavailable inventory must list git_status.json: %q", cmd.OutputExcerpt)
+		}
+	}
+	if !foundTruthful {
+		t.Fatalf("expected truthful capture-failure verification text: %#v", failed.Verification.Commands)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
+
+func TestInterruptionArtifactStatusReportsPerArtifactTruth(t *testing.T) {
+	t.Run("partial git-status write failure", func(t *testing.T) {
+		preserved, failed := interruptionArtifactStatus(attemptOutcome{
+			CLI:          "claude",
+			GitStatusErr: errors.New("write git_status.json: is a directory"),
+		})
+		if !containsString(preserved, "diff.patch") {
+			t.Fatalf("diff.patch must be preserved: %v", preserved)
+		}
+		if containsString(preserved, "git_status.json") {
+			t.Fatalf("git_status.json must not be preserved: %v", preserved)
+		}
+		if !containsSubstring(failed, "git_status.json") {
+			t.Fatalf("git_status.json must be reported unavailable: %v", failed)
+		}
+	})
+	t.Run("raw output capture failure", func(t *testing.T) {
+		preserved, failed := interruptionArtifactStatus(attemptOutcome{
+			CLI:          "claude",
+			RawOutputErr: errors.New("capture file not created: claude.stdout.jsonl"),
+		})
+		if containsString(preserved, "raw provider output") {
+			t.Fatalf("raw provider output must not be claimed preserved: %v", preserved)
+		}
+		if !containsSubstring(failed, "raw provider output") {
+			t.Fatalf("raw provider output must be reported unavailable: %v", failed)
+		}
+	})
+}
+
+func containsString(items []string, want string) bool {
+	for _, s := range items {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubstring(items []string, want string) bool {
+	for _, s := range items {
+		if strings.Contains(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitInterruptionExcerpt(t *testing.T, excerpt string) (preserved, notCaptured string) {
+	t.Helper()
+	const marker = "preserved under "
+	idx := strings.Index(excerpt, marker)
+	if idx < 0 {
+		t.Fatalf("excerpt missing preserved inventory: %q", excerpt)
+	}
+	rest := excerpt[idx+len(marker):]
+	if colon := strings.Index(rest, ": "); colon >= 0 {
+		rest = rest[colon+2:]
+	}
+	const cut = "; not captured: "
+	if at := strings.Index(rest, cut); at >= 0 {
+		return rest[:at], rest[at+len(cut):]
+	}
+	return rest, ""
+}
+
+func mustLoadFailedTask(t *testing.T, root string) task.Task {
+	t.Helper()
+	failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+	if failed.Status != "failed" {
+		t.Fatalf("status = %q; want failed", failed.Status)
+	}
+	return failed
+}
+
+func assertNormalTerminal(t *testing.T, root string, want bool) {
+	t.Helper()
+	data := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename))
+	var terminal runner.ExecutorTerminal
+	if err := json.Unmarshal(data, &terminal); err != nil {
+		t.Fatalf("decode executor_terminal.json: %v", err)
+	}
+	if terminal.NormalTerminal != want {
+		t.Fatalf("NormalTerminal = %t; want %t (reason=%q)", terminal.NormalTerminal, want, terminal.Reason)
+	}
+}

--- a/internal/daemon/interrupt_persistence_failure_test.go
+++ b/internal/daemon/interrupt_persistence_failure_test.go
@@ -1,0 +1,179 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runartifact"
+	"github.com/shinpr/galley/internal/task"
+)
+
+// claudeAPIErrorInterruptionBody is a Claude executor body that changes the
+// workspace and emits an explicit provider API-error result event, so the
+// attempt is an interruption regardless of the appended success terminal.
+const claudeAPIErrorInterruptionBody = "echo change > daemon-output.txt\n" +
+	`echo '{"type":"result","subtype":"error_during_execution","is_error":true,"error":"provider outage"}'` + "\n"
+
+func runClaudeInterruptionWithDeps(t *testing.T, body string, deps *daemonDependencies) (task.Task, string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	claudeBin := writeFakeClaude(t, body)
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+	_ = runTestDaemon(context.Background(), Options{
+		Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath,
+		Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin,
+		dependencies: deps,
+	})
+	return mustLoadFailedTask(t, root), root
+}
+
+func assertSingleInterruption(t *testing.T, failed task.Task, root string) {
+	t.Helper()
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d; want 1: %#v", len(failed.Attempts), failed.Attempts)
+	}
+	attempt := failed.Attempts[0]
+	if attempt.SupervisorVerdict != task.AttemptVerdictNotReviewed {
+		t.Fatalf("verdict = %q; want %q", attempt.SupervisorVerdict, task.AttemptVerdictNotReviewed)
+	}
+	if attempt.Error == nil || attempt.Error.Kind != task.AttemptKindExecutorInterrupted {
+		t.Fatalf("attempt error = %#v; want kind %q", attempt.Error, task.AttemptKindExecutorInterrupted)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", "supervisor_verdict.json"), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-2"), 0)
+}
+
+func assertRiskDetailContains(t *testing.T, failed task.Task, want string) {
+	t.Helper()
+	for _, r := range failed.Risks {
+		if strings.Contains(r.Detail, want) {
+			return
+		}
+	}
+	t.Fatalf("expected a risk disclosing %q: %#v", want, failed.Risks)
+}
+
+func TestInterruptionSurvivesRunResultWriteFailure(t *testing.T) {
+	deps := &daemonDependencies{
+		writeAttemptArtifact: func(path string, value any) error {
+			if strings.HasSuffix(path, runartifact.RunResultFilename) {
+				return fmt.Errorf("simulated run_result write failure")
+			}
+			return writeJSON(path, value)
+		},
+	}
+	failed, root := runClaudeInterruptionWithDeps(t, claudeAPIErrorInterruptionBody, deps)
+	assertSingleInterruption(t, failed, root)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 1)
+	assertRiskDetailContains(t, failed, "run_result.json could not be written")
+}
+
+func TestInterruptionSurvivesTerminalWriteFailure(t *testing.T) {
+	deps := &daemonDependencies{
+		writeAttemptArtifact: func(path string, value any) error {
+			if strings.HasSuffix(path, runartifact.ExecutorTerminalFilename) {
+				return fmt.Errorf("simulated executor_terminal write failure")
+			}
+			return writeJSON(path, value)
+		},
+	}
+	failed, root := runClaudeInterruptionWithDeps(t, claudeAPIErrorInterruptionBody, deps)
+	assertSingleInterruption(t, failed, root)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 0)
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 1)
+	assertRiskDetailContains(t, failed, "executor_terminal.json could not be written")
+}
+
+func TestInterruptionSurvivesProviderAndResultMetadataWriteFailure(t *testing.T) {
+	t.Run("grok provider metadata", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), ".agent-workflow")
+		repo := initDaemonGitRepo(t)
+		promptPath, schemaPath := writeDaemonPromptFiles(t)
+		claudeBin := writeFakeClaude(t, "")
+		// Non-EndTurn stopReason is an interruption; the provider metadata write
+		// is injected to fail.
+		grokBin := writeFakeCommand(t, "grok", "cat >/dev/null 2>&1 || true\nprintf '%s\\n' '{\"text\":\"{}\",\"stopReason\":\"Cancelled\",\"sessionId\":\"g1\"}'\n")
+		taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+		if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeDaemonTask(t, taskPath, repo)
+		loaded, err := task.Load(taskPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loaded.Executor.CLI = "grok"
+		if err := task.Save(taskPath, loaded); err != nil {
+			t.Fatal(err)
+		}
+		setLoopBudget(t, taskPath, 3)
+		deps := &daemonDependencies{
+			writeProviderMetadata: func(path string, data []byte) error {
+				if strings.HasSuffix(path, runartifact.GrokCompletionMetadataFilename) {
+					return fmt.Errorf("simulated grok metadata write failure")
+				}
+				return os.WriteFile(path, data, 0o600)
+			},
+		}
+		_ = runTestDaemon(context.Background(), Options{
+			Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath,
+			Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin, GrokBin: grokBin,
+			dependencies: deps,
+		})
+		failed := mustLoadFailedTask(t, root)
+		assertSingleInterruption(t, failed, root)
+		assertRiskDetailContains(t, failed, "grok_completion.json could not be written")
+	})
+
+	t.Run("executor result metadata", func(t *testing.T) {
+		validResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+		// A parseable result plus an explicit API-error terminal: the result write
+		// is attempted and injected to fail while the attempt stays an interruption.
+		body := "echo change > daemon-output.txt\n" +
+			"echo '" + validResult + "'\n" +
+			`echo '{"type":"result","subtype":"error_during_execution","is_error":true,"error":"provider outage"}'` + "\n"
+		deps := &daemonDependencies{
+			writeAttemptArtifact: func(path string, value any) error {
+				if strings.HasSuffix(path, runartifact.ExecutorResultFilename) {
+					return fmt.Errorf("simulated executor_result write failure")
+				}
+				return writeJSON(path, value)
+			},
+		}
+		failed, root := runClaudeInterruptionWithDeps(t, body, deps)
+		assertSingleInterruption(t, failed, root)
+		assertRiskDetailContains(t, failed, "executor_result.json could not be written")
+	})
+}
+
+func TestInterruptionSurvivesStagingOnlyFailure(t *testing.T) {
+	deps := &daemonDependencies{
+		stageExecutorOutput: func(_ context.Context, _ Options, _, _ string, _ []string) error {
+			return fmt.Errorf("git add -A (review staging) failed: simulated index lock")
+		},
+	}
+	// Modify a tracked file so the unstaged diff captures the change even though
+	// staging failed (an untracked file would need staging to appear).
+	body := "echo RESUMED >> README.md\n" +
+		`echo '{"type":"result","subtype":"error_during_execution","is_error":true,"error":"provider outage"}'` + "\n"
+	failed, root := runClaudeInterruptionWithDeps(t, body, deps)
+	assertSingleInterruption(t, failed, root)
+	diff := string(mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.DiffPatchFilename)))
+	if !strings.Contains(diff, "RESUMED") {
+		t.Fatalf("diff.patch must retain the captured change: %q", diff)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.GitStatusFilename), 1)
+	assertRiskDetailContains(t, failed, "review staging failed")
+}

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -168,6 +168,15 @@ func runSupervisorLoop(ctx, shutdownCtx context.Context, opts Options, runningPa
 			EffectiveExecutor: effectiveExecutor,
 		})
 		if err != nil {
+			// An interruption is published to the existing failed-task state
+			// with its preserved worktree and evidence. The attempt was already
+			// recorded (not_reviewed) by runOneSupervisorAttempt, so this is a
+			// clean terminal publication, not a daemon error, and must never
+			// start another executor attempt regardless of remaining budget.
+			if interrupted, ok := asExecutorInterrupted(err); ok {
+				fmt.Fprintf(os.Stderr, "galley: task %s executor interrupted (%s); publishing to failed for requeue\n", loaded.ID, interrupted.Reason)
+				return taskstate.MoveToStatus(opts.Root, runningPath, loaded)
+			}
 			// When an exhausted supervisor idle timeout fails the task,
 			// emit one concise line in the existing Galley log tone so the
 			// daemon log distinguishes it from a task total-timeout expiry.
@@ -275,6 +284,12 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 		}
 		appendFailureAttempt(req.Loaded, "executor", classifyFailureKind("executor_failed", err), err, attemptDir)
 		return attemptReview{}, err
+	}
+	// A provider or runtime interruption never reaches the supervisor: the
+	// attempt is recorded as not_reviewed with preserved evidence and the loop
+	// stops so no verdict is invented and no further executor attempt starts.
+	if !outcome.Terminal.NormalTerminal {
+		return attemptReview{}, appendInterruptedAttempt(req.Loaded, outcome, attemptDir)
 	}
 	setupResultEvidence, setupUpdateEvidence := setuppreflight.LoadRunEvidence(req.RunDir, req.RunID)
 	evidence := supervisor.Evidence{

--- a/internal/executorflow/attempt.go
+++ b/internal/executorflow/attempt.go
@@ -2,6 +2,7 @@ package executorflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -29,6 +30,11 @@ type CommandAttemptResult struct {
 	RunErr    error
 }
 
+// RunCommandAttempt persists the audit command plan (a pre-run failure that
+// aborts the attempt), runs the executor command, and returns the raw runner
+// outcome. Persisting run_result.json is deliberately left to the caller so the
+// terminal classification and every post-run artifact write share one set of
+// separate, non-discarding availability flags.
 func RunCommandAttempt(ctx context.Context, opts CommandAttemptOptions) (CommandAttemptResult, error) {
 	auditPlan := opts.CommandPlan
 	if err := jsonio.Write(runartifact.Path(opts.AttemptDir, runartifact.CommandPlanFilename), auditPlan); err != nil {
@@ -43,9 +49,6 @@ func RunCommandAttempt(ctx context.Context, opts CommandAttemptOptions) (Command
 		StderrPath:  opts.StderrPath,
 	})
 	completed := time.Now().UTC()
-	if err := jsonio.Write(runartifact.Path(opts.AttemptDir, runartifact.RunResultFilename), runResult); err != nil {
-		return CommandAttemptResult{}, err
-	}
 	return CommandAttemptResult{Started: started, Completed: completed, RunResult: runResult, RunErr: runErr}, nil
 }
 
@@ -53,22 +56,39 @@ type DiffArtifacts struct {
 	Snapshot workspace.Snapshot
 	Dirty    bool
 	Diff     string
-	Err      error
+	// Err combines every capture and write failure for the normal-terminal
+	// hard-fail path. GitStatusErr and DiffPatchErr report each component
+	// independently so an interruption inventory can name the exact artifact that
+	// was preserved versus unavailable.
+	Err          error
+	GitStatusErr error
+	DiffPatchErr error
 }
 
 func CaptureDiffArtifacts(ctx context.Context, workDir, baseSHA, attemptDir string, opts workspace.Options) (DiffArtifacts, error) {
 	snapshot, err := workspace.CaptureSnapshotFromBase(ctx, workDir, baseSHA, opts)
 	if err != nil {
-		return DiffArtifacts{Snapshot: snapshot, Err: err}, nil
+		// A snapshot-capture failure leaves neither artifact writable.
+		return DiffArtifacts{Snapshot: snapshot, Err: err, GitStatusErr: err, DiffPatchErr: err}, nil
 	}
 	dirty := snapshot.BranchDiff != "" || snapshot.StagedDiff != "" || snapshot.UnstagedDiff != ""
+	// Both writes are attempted independently so one failure never suppresses the
+	// other retained artifact.
+	artifacts := DiffArtifacts{Snapshot: snapshot, Dirty: dirty, Diff: snapshot.Diff}
+	var writeErrs []error
 	if err := jsonio.Write(runartifact.Path(attemptDir, runartifact.GitStatusFilename), snapshot); err != nil {
-		return DiffArtifacts{}, err
+		artifacts.GitStatusErr = fmt.Errorf("write git_status.json: %w", err)
+		writeErrs = append(writeErrs, artifacts.GitStatusErr)
 	}
 	if err := os.WriteFile(runartifact.Path(attemptDir, runartifact.DiffPatchFilename), []byte(snapshot.Diff), 0o600); err != nil {
-		return DiffArtifacts{}, fmt.Errorf("write diff.patch: %w", err)
+		artifacts.DiffPatchErr = fmt.Errorf("write diff.patch: %w", err)
+		writeErrs = append(writeErrs, artifacts.DiffPatchErr)
 	}
-	return DiffArtifacts{Snapshot: snapshot, Dirty: dirty, Diff: snapshot.Diff}, nil
+	if len(writeErrs) > 0 {
+		artifacts.Err = errors.Join(writeErrs...)
+		return artifacts, artifacts.Err
+	}
+	return artifacts, nil
 }
 
 type RequiredCheckContext struct {

--- a/internal/runartifact/artifact.go
+++ b/internal/runartifact/artifact.go
@@ -35,6 +35,7 @@ const (
 
 	// Executor and supervisor attempt artifacts.
 	ExecutorResultFilename         = "executor_result.json"
+	ExecutorTerminalFilename       = "executor_terminal.json"
 	RunResultFilename              = "run_result.json"
 	CommandPlanFilename            = "command_plan.json"
 	GrokCompletionMetadataFilename = "grok_completion.json"

--- a/internal/runner/terminal.go
+++ b/internal/runner/terminal.go
@@ -1,0 +1,437 @@
+package runner
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+)
+
+// Terminal classification decides whether an executor process reached a normal
+// provider terminal (reviewable by the supervisor) or was interrupted (partial
+// work preserved, failed task published without a supervisor verdict). Routing
+// depends only on runner state plus the provider's machine-readable
+// normal-terminal marker, never on the process exit code or error-text
+// matching. Provider failure detail is retained for diagnosis only. Extracting
+// the executor-result payload is a separate concern handled by the executor
+// result parser; a bare result payload is not a substitute for a terminal
+// marker here.
+const (
+	TerminalReasonStartFailed        = "start_failed"
+	TerminalReasonTimedOut           = "timed_out"
+	TerminalReasonIdleTimeout        = "idle_timeout"
+	TerminalReasonKilled             = "killed"
+	TerminalReasonExitNonZero        = "exit_nonzero"
+	TerminalReasonProviderAPIError   = "provider_api_error"
+	TerminalReasonProviderTurnFailed = "provider_turn_failed"
+	TerminalReasonProviderNonEndTurn = "provider_non_end_turn"
+	TerminalReasonMalformedOutput    = "malformed_provider_output"
+	TerminalReasonMissingTerminal    = "missing_normal_terminal"
+	TerminalReasonAmbiguousResult    = "ambiguous_provider_result"
+	TerminalReasonUnknown            = "unknown"
+)
+
+// ProviderTerminalDetail carries the optional structured fields a provider
+// exposes about how a turn ended. Every field is diagnostic and may be empty
+// when the provider CLI omits it; none of them controls routing.
+type ProviderTerminalDetail struct {
+	Status     string `json:"status,omitempty"`
+	Code       string `json:"code,omitempty"`
+	StopReason string `json:"stop_reason,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// ExecutorTerminal is Galley's routing decision for one executor attempt.
+// NormalTerminal true means "runner succeeded and the provider emitted its
+// reliable normal-terminal marker". Reason is empty for a normal terminal and
+// otherwise names the diagnostic interruption cause.
+type ExecutorTerminal struct {
+	CLI            string                 `json:"cli"`
+	NormalTerminal bool                   `json:"normal_terminal"`
+	Reason         string                 `json:"reason,omitempty"`
+	Detail         ProviderTerminalDetail `json:"detail"`
+}
+
+// ClassifyExecutorTerminal produces the single routing decision for an executor
+// attempt. A non-nil runErr (start failure, timeout, idle timeout, kill, or
+// non-zero exit) is always an interruption because a normal terminal requires
+// the runner to have succeeded. The runner failure controls the routing reason,
+// but the provider output is still scanned so any structured diagnostic detail
+// (status, code, stop reason, session ID, message) is retained for diagnosis.
+// When the runner succeeded, the provider stdout is inspected for the
+// provider-specific normal-terminal marker.
+func ClassifyExecutorTerminal(cli, stdoutPath, stdoutTail string, result RunResult, runErr error) ExecutorTerminal {
+	if runErr != nil {
+		return ExecutorTerminal{
+			CLI:            cli,
+			NormalTerminal: false,
+			Reason:         runnerFailureReason(result, runErr),
+			Detail:         scanProviderDetail(cli, stdoutPath, stdoutTail),
+		}
+	}
+	switch cli {
+	case "grok":
+		return grokTerminal(cli, stdoutPath, stdoutTail)
+	case "codex":
+		return codexTerminal(cli, stdoutPath, stdoutTail)
+	default: // claude, glm, and the default executor share the Claude transport.
+		return claudeTerminal(cli, stdoutPath, stdoutTail)
+	}
+}
+
+// scanProviderDetail extracts whatever structured provider detail is present in
+// the captured output for diagnosis only. It never changes routing and is used
+// on the runner-failure path where the interruption reason is already fixed by
+// runnerFailureReason.
+func scanProviderDetail(cli, stdoutPath, stdoutTail string) ProviderTerminalDetail {
+	switch cli {
+	case "grok":
+		return grokDetail(stdoutPath, stdoutTail)
+	case "codex":
+		return scanCodex(stdoutPath, stdoutTail).detail()
+	default:
+		return scanClaude(stdoutPath, stdoutTail).detail
+	}
+}
+
+// runnerFailureReason classifies a runner failure through the typed sentinels
+// rather than error-message substrings so a wording change cannot silently
+// reclassify a timeout or kill.
+func runnerFailureReason(result RunResult, err error) string {
+	switch {
+	case errors.Is(err, ErrIdleTimeout):
+		return TerminalReasonIdleTimeout
+	case errors.Is(err, ErrTimeout), errors.Is(err, context.DeadlineExceeded):
+		return TerminalReasonTimedOut
+	case errors.Is(err, ErrKilled):
+		return TerminalReasonKilled
+	}
+	var cmdErr *CommandError
+	if errors.As(err, &cmdErr) {
+		switch cmdErr.Kind {
+		case CommandErrorStart:
+			return TerminalReasonStartFailed
+		case CommandErrorIdleTimeout:
+			return TerminalReasonIdleTimeout
+		case CommandErrorTimeout:
+			return TerminalReasonTimedOut
+		case CommandErrorKilled:
+			return TerminalReasonKilled
+		case CommandErrorExitNonZero:
+			return TerminalReasonExitNonZero
+		}
+	}
+	if result.IdleTimedOut {
+		return TerminalReasonIdleTimeout
+	}
+	if result.TimedOut {
+		return TerminalReasonTimedOut
+	}
+	return TerminalReasonUnknown
+}
+
+// grokTerminal routes on the Grok stopReason marker alone. The stopReason is
+// the routing marker; sessionId is optional diagnostic detail that never gates
+// the decision, so an "EndTurn" envelope is a normal terminal even when
+// sessionId is absent. A missing result payload under EndTurn is an ordinary
+// completed-result failure the supervisor still reviews. Output that is not a
+// parseable envelope, or that carries no stopReason marker, has no reliable
+// normal terminal and fails closed to an interruption.
+func grokTerminal(cli, stdoutPath, stdoutTail string) ExecutorTerminal {
+	env, ok := parseGrokRouting(stdoutPath, stdoutTail)
+	if !ok || env.StopReason == "" {
+		return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonMalformedOutput, Detail: env.detail()}
+	}
+	if env.StopReason == "EndTurn" {
+		return ExecutorTerminal{CLI: cli, NormalTerminal: true, Detail: env.detail()}
+	}
+	return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonProviderNonEndTurn, Detail: env.detail()}
+}
+
+// grokRouting is the minimal, routing-focused view of a Grok envelope: only the
+// stopReason marker gates routing, and sessionId is retained as diagnostic
+// detail. It deliberately does not require sessionId (unlike ParseGrokEnvelope,
+// which validates the stricter executor-result contract) so terminal
+// classification never depends on optional session detail.
+type grokRouting struct {
+	StopReason string
+	SessionID  string
+}
+
+func (g grokRouting) detail() ProviderTerminalDetail {
+	return ProviderTerminalDetail{StopReason: g.StopReason, SessionID: g.SessionID}
+}
+
+func parseGrokRouting(stdoutPath, stdoutTail string) (grokRouting, bool) {
+	var env struct {
+		StopReason string `json:"stopReason"`
+		SessionID  string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(readProviderOutput(stdoutPath, stdoutTail), &env); err != nil {
+		return grokRouting{}, false
+	}
+	return grokRouting{StopReason: strings.TrimSpace(env.StopReason), SessionID: env.SessionID}, true
+}
+
+// grokDetail returns any diagnostic detail available in the captured output
+// without deciding routing (used on the runner-failure path).
+func grokDetail(stdoutPath, stdoutTail string) ProviderTerminalDetail {
+	env, ok := parseGrokRouting(stdoutPath, stdoutTail)
+	if !ok {
+		return ProviderTerminalDetail{}
+	}
+	return env.detail()
+}
+
+// claudeResultClass classifies a Claude/GLM `result` event. A normal terminal
+// requires an explicit known-success signal; a result event without one is
+// ambiguous rather than a success, so classification fails closed.
+type claudeResultClass int
+
+const (
+	claudeResultNone claudeResultClass = iota
+	claudeResultSuccess
+	claudeResultError
+	claudeResultAmbiguous
+)
+
+// claudeScan is the result of inspecting the complete Claude/GLM stdout
+// history. class is the highest-precedence classification observed (error >
+// success > ambiguous > none) and detail carries the matching diagnostic detail.
+type claudeScan struct {
+	class  claudeResultClass
+	detail ProviderTerminalDetail
+}
+
+// scanClaude walks the full stdout history and reduces every `result` event to
+// one classification. An explicit API-error result takes precedence over a
+// success so a mixed history fails closed; an explicit success takes precedence
+// over an ambiguous result event; an ambiguous result (a `result` event without
+// an explicit success or error signal) is retained so the attempt fails closed
+// rather than being accepted as a normal terminal.
+func scanClaude(stdoutPath, stdoutTail string) claudeScan {
+	var (
+		apiError        *ProviderTerminalDetail
+		successDetail   ProviderTerminalDetail
+		ambiguousDetail ProviderTerminalDetail
+		sawSuccess      bool
+		sawAmbiguous    bool
+	)
+	forEachProviderLine(stdoutPath, stdoutTail, func(line string) bool {
+		detail, class := claudeResultEvent(line)
+		switch class {
+		case claudeResultError:
+			if apiError == nil {
+				d := detail
+				apiError = &d
+			}
+		case claudeResultSuccess:
+			sawSuccess = true
+			successDetail = detail
+		case claudeResultAmbiguous:
+			sawAmbiguous = true
+			ambiguousDetail = detail
+		}
+		return true
+	})
+	switch {
+	case apiError != nil:
+		return claudeScan{class: claudeResultError, detail: *apiError}
+	case sawSuccess:
+		return claudeScan{class: claudeResultSuccess, detail: successDetail}
+	case sawAmbiguous:
+		return claudeScan{class: claudeResultAmbiguous, detail: ambiguousDetail}
+	default:
+		return claudeScan{class: claudeResultNone}
+	}
+}
+
+// claudeTerminal requires an explicit known-success Claude/GLM result event to
+// establish a normal terminal; a bare executor-result payload is never a
+// substitute, and a `result` event without an explicit success or error signal
+// is treated as an ambiguous interruption rather than a normal terminal.
+func claudeTerminal(cli, stdoutPath, stdoutTail string) ExecutorTerminal {
+	scan := scanClaude(stdoutPath, stdoutTail)
+	switch scan.class {
+	case claudeResultError:
+		return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonProviderAPIError, Detail: scan.detail}
+	case claudeResultSuccess:
+		return ExecutorTerminal{CLI: cli, NormalTerminal: true, Detail: scan.detail}
+	case claudeResultAmbiguous:
+		return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonAmbiguousResult, Detail: scan.detail}
+	default:
+		return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonMissingTerminal}
+	}
+}
+
+// codexScan is the result of inspecting the complete Codex stdout history: the
+// nested detail of the first `turn.failed` (if any) and whether a
+// `turn.completed` was seen.
+type codexScan struct {
+	failed    *ProviderTerminalDetail
+	completed bool
+}
+
+func (c codexScan) detail() ProviderTerminalDetail {
+	if c.failed != nil {
+		return *c.failed
+	}
+	return ProviderTerminalDetail{}
+}
+
+// scanCodex walks the full stdout history so an explicit `turn.failed` anywhere
+// takes precedence over a completed turn.
+func scanCodex(stdoutPath, stdoutTail string) codexScan {
+	var scan codexScan
+	forEachProviderLine(stdoutPath, stdoutTail, func(line string) bool {
+		typ, raw := codexEventType(line)
+		switch typ {
+		case "turn.completed":
+			scan.completed = true
+		case "turn.failed":
+			if scan.failed == nil {
+				d := codexFailureDetail(raw)
+				scan.failed = &d
+			}
+		}
+		return true
+	})
+	return scan
+}
+
+// codexTerminal requires a `turn.completed` event for a normal terminal. An
+// explicit `turn.failed` anywhere fails closed; absent any turn terminal the
+// attempt is a missing-terminal interruption; a bare executor-result payload is
+// never a substitute.
+func codexTerminal(cli, stdoutPath, stdoutTail string) ExecutorTerminal {
+	scan := scanCodex(stdoutPath, stdoutTail)
+	if scan.failed != nil {
+		return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonProviderTurnFailed, Detail: *scan.failed}
+	}
+	if scan.completed {
+		return ExecutorTerminal{CLI: cli, NormalTerminal: true}
+	}
+	return ExecutorTerminal{CLI: cli, NormalTerminal: false, Reason: TerminalReasonMissingTerminal}
+}
+
+// claudeResultEvent classifies a Claude/GLM output line. A normal terminal
+// requires an explicit known-success signal (is_error explicitly false or a
+// "success" subtype). A `result` event with an explicit error signal (is_error
+// true or an "error" subtype) is an API error; a `result` event with neither
+// signal is ambiguous and fails closed rather than being read as success.
+func claudeResultEvent(line string) (ProviderTerminalDetail, claudeResultClass) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ProviderTerminalDetail{}, claudeResultNone
+	}
+	var event struct {
+		Type      string `json:"type"`
+		Subtype   string `json:"subtype"`
+		IsError   *bool  `json:"is_error"`
+		SessionID string `json:"session_id"`
+		Result    string `json:"result"`
+		Error     string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return ProviderTerminalDetail{}, claudeResultNone
+	}
+	if event.Type != "result" {
+		return ProviderTerminalDetail{}, claudeResultNone
+	}
+	detail := ProviderTerminalDetail{Status: event.Subtype, SessionID: event.SessionID}
+	switch {
+	case (event.IsError != nil && *event.IsError) || isErrorSubtype(event.Subtype):
+		detail.Message = firstNonEmptyString(event.Error, event.Result)
+		return detail, claudeResultError
+	case (event.IsError != nil && !*event.IsError) || event.Subtype == "success":
+		return detail, claudeResultSuccess
+	default:
+		return detail, claudeResultAmbiguous
+	}
+}
+
+func isErrorSubtype(subtype string) bool {
+	return strings.HasPrefix(subtype, "error")
+}
+
+// codexEventType returns a JSONL event's top-level type and the raw event so a
+// turn.failed event's nested error detail can be extracted for diagnosis.
+func codexEventType(line string) (string, json.RawMessage) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", nil
+	}
+	var event struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return "", nil
+	}
+	return event.Type, json.RawMessage(line)
+}
+
+// codexFailureDetail extracts the optional nested error status/code/message a
+// Codex turn.failed event may carry. Missing nested detail yields an empty
+// struct without changing routing.
+func codexFailureDetail(raw json.RawMessage) ProviderTerminalDetail {
+	var event struct {
+		Error *struct {
+			Status  string `json:"status"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &event); err != nil || event.Error == nil {
+		return ProviderTerminalDetail{}
+	}
+	return ProviderTerminalDetail{Status: event.Error.Status, Code: event.Error.Code, Message: event.Error.Message}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// readProviderOutput returns the captured stdout file contents, falling back to
+// the in-memory tail when the file is unavailable.
+func readProviderOutput(stdoutPath, stdoutTail string) []byte {
+	if stdoutPath != "" {
+		if data, err := os.ReadFile(stdoutPath); err == nil {
+			return data
+		}
+	}
+	return []byte(stdoutTail)
+}
+
+// forEachProviderLine streams the captured stdout line by line, preferring the
+// on-disk file and falling back to the in-memory tail. The callback returns
+// false to stop early.
+func forEachProviderLine(stdoutPath, stdoutTail string, fn func(line string) bool) {
+	if stdoutPath != "" {
+		if file, err := os.Open(stdoutPath); err == nil {
+			defer file.Close()
+			scanner := bufio.NewScanner(file)
+			scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+			for scanner.Scan() {
+				if !fn(scanner.Text()) {
+					return
+				}
+			}
+			if scanner.Err() == nil {
+				return
+			}
+		}
+	}
+	for _, line := range strings.Split(stdoutTail, "\n") {
+		if !fn(line) {
+			return
+		}
+	}
+}

--- a/internal/runner/terminal_test.go
+++ b/internal/runner/terminal_test.go
@@ -1,0 +1,320 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyExecutorTerminalRouting(t *testing.T) {
+	validResult := `{"status":"completed","summary":"done","files_modified":[],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+	tests := []struct {
+		name       string
+		cli        string
+		stdout     string
+		runErr     error
+		result     RunResult
+		wantNormal bool
+		wantReason string
+		wantDetail func(t *testing.T, d ProviderTerminalDetail)
+	}{
+		{
+			name:       "claude success result event",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"success","is_error":false,"session_id":"abc","result":"` + escape(validResult) + `"}`,
+			wantNormal: true,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Status != "success" || d.SessionID != "abc" {
+					t.Fatalf("detail = %#v", d)
+				}
+			},
+		},
+		{
+			name:       "claude api error result event",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"abc","error":"rate limited"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderAPIError,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Message != "rate limited" {
+					t.Fatalf("expected retained provider message, got %#v", d)
+				}
+			},
+		},
+		{
+			name:       "claude bare result payload alone is an interruption",
+			cli:        "claude",
+			stdout:     validResult,
+			wantNormal: false,
+			wantReason: TerminalReasonMissingTerminal,
+		},
+		{
+			name:       "claude output without a terminal is an interruption",
+			cli:        "claude",
+			stdout:     "not-json\nstill nothing\n",
+			wantNormal: false,
+			wantReason: TerminalReasonMissingTerminal,
+		},
+		{
+			// A result event without an explicit success signal (no is_error and a
+			// non-"success" subtype) fails closed instead of being read as success.
+			name:       "claude ambiguous result without an explicit success signal fails closed",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"in_progress","session_id":"amb"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonAmbiguousResult,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Status != "in_progress" || d.SessionID != "amb" {
+					t.Fatalf("ambiguous result must retain diagnostic detail, got %#v", d)
+				}
+			},
+		},
+		{
+			// A bare result event with no fields at all is also ambiguous, never a
+			// normal terminal.
+			name:       "claude result event with no signal fields fails closed",
+			cli:        "claude",
+			stdout:     `{"type":"result"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonAmbiguousResult,
+		},
+		{
+			name:       "claude api error after a success result is an interruption",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"success","is_error":false}` + "\n" + `{"type":"result","subtype":"error_during_execution","is_error":true,"error":"overloaded"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderAPIError,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Message != "overloaded" {
+					t.Fatalf("mixed history must retain the api-error detail, got %#v", d)
+				}
+			},
+		},
+		{
+			name:       "glm reuses the claude contract",
+			cli:        "glm",
+			stdout:     `{"type":"result","subtype":"success"}`,
+			wantNormal: true,
+		},
+		{
+			name:       "glm api error result event",
+			cli:        "glm",
+			stdout:     `{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"glm-1","error":"upstream 529"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderAPIError,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Message != "upstream 529" || d.SessionID != "glm-1" {
+					t.Fatalf("glm api error must retain provider detail, got %#v", d)
+				}
+			},
+		},
+		{
+			name:       "codex turn.completed",
+			cli:        "codex",
+			stdout:     `{"type":"thread.started"}` + "\n" + `{"type":"turn.completed"}`,
+			wantNormal: true,
+		},
+		{
+			name:       "codex turn.failed with nested detail",
+			cli:        "codex",
+			stdout:     `{"type":"turn.failed","error":{"code":"context_length","message":"too long"}}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderTurnFailed,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Code != "context_length" || d.Message != "too long" {
+					t.Fatalf("detail = %#v", d)
+				}
+			},
+		},
+		{
+			name:       "codex turn.failed without nested detail",
+			cli:        "codex",
+			stdout:     `{"type":"turn.failed"}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderTurnFailed,
+		},
+		{
+			name:       "codex turn.failed after turn.completed is an interruption",
+			cli:        "codex",
+			stdout:     `{"type":"turn.completed"}` + "\n" + `{"type":"turn.failed","error":{"code":"stream_error"}}`,
+			wantNormal: false,
+			wantReason: TerminalReasonProviderTurnFailed,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Code != "stream_error" {
+					t.Fatalf("mixed history must retain the turn.failed detail, got %#v", d)
+				}
+			},
+		},
+		{
+			name:       "codex bare result payload alone is an interruption",
+			cli:        "codex",
+			stdout:     validResult,
+			wantNormal: false,
+			wantReason: TerminalReasonMissingTerminal,
+		},
+		{
+			name:       "grok EndTurn with exit code 0 is a normal terminal",
+			cli:        "grok",
+			stdout:     `{"text":"{}","stopReason":"EndTurn","sessionId":"s1"}`,
+			result:     RunResult{ExitCode: 0},
+			wantNormal: true,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.StopReason != "EndTurn" || d.SessionID != "s1" {
+					t.Fatalf("detail = %#v", d)
+				}
+			},
+		},
+		{
+			// The stopReason marker alone decides routing; a missing sessionId
+			// (optional diagnostic) must not prevent the EndTurn normal terminal.
+			name:       "grok EndTurn without sessionId is a normal terminal",
+			cli:        "grok",
+			stdout:     `{"text":"{}","stopReason":"EndTurn"}`,
+			result:     RunResult{ExitCode: 0},
+			wantNormal: true,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.StopReason != "EndTurn" || d.SessionID != "" {
+					t.Fatalf("detail = %#v", d)
+				}
+			},
+		},
+		{
+			name:       "grok non-EndTurn with exit code 0 is an interruption",
+			cli:        "grok",
+			stdout:     `{"text":"{}","stopReason":"Cancelled","sessionId":"s2"}`,
+			result:     RunResult{ExitCode: 0},
+			wantNormal: false,
+			wantReason: TerminalReasonProviderNonEndTurn,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.StopReason != "Cancelled" {
+					t.Fatalf("detail = %#v", d)
+				}
+			},
+		},
+		{
+			name:       "runner start failure is an interruption regardless of output",
+			cli:        "claude",
+			stdout:     validResult,
+			runErr:     &CommandError{Kind: CommandErrorStart, Err: fmt.Errorf("start claude: no such file")},
+			wantNormal: false,
+			wantReason: TerminalReasonStartFailed,
+		},
+		{
+			name:       "runner total timeout is an interruption",
+			cli:        "codex",
+			runErr:     &CommandError{Kind: CommandErrorTimeout, Err: fmt.Errorf("timed out")},
+			result:     RunResult{TimedOut: true},
+			wantNormal: false,
+			wantReason: TerminalReasonTimedOut,
+		},
+		{
+			name:       "runner idle timeout is an interruption",
+			cli:        "grok",
+			runErr:     &CommandError{Kind: CommandErrorIdleTimeout, Err: fmt.Errorf("idle")},
+			result:     RunResult{IdleTimedOut: true},
+			wantNormal: false,
+			wantReason: TerminalReasonIdleTimeout,
+		},
+		{
+			name:       "runner kill is an interruption",
+			cli:        "claude",
+			runErr:     &CommandError{Kind: CommandErrorKilled, Err: fmt.Errorf("signal: killed")},
+			wantNormal: false,
+			wantReason: TerminalReasonKilled,
+		},
+		{
+			// Exit-code boundary: a success marker cannot override a non-zero
+			// exit, and (paired with the grok exit-0 cases above) proves the exit
+			// code never decides routing on its own.
+			name:       "non-zero exit with a success result is an interruption",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"success","is_error":false}`,
+			runErr:     &CommandError{Kind: CommandErrorExitNonZero, Err: fmt.Errorf("exit status 7")},
+			wantNormal: false,
+			wantReason: TerminalReasonExitNonZero,
+		},
+		{
+			name:       "context deadline is an interruption",
+			cli:        "claude",
+			runErr:     context.DeadlineExceeded,
+			wantNormal: false,
+			wantReason: TerminalReasonTimedOut,
+		},
+		{
+			// A structured provider failure plus a non-zero exit: the runner
+			// failure controls the routing reason, but the provider's diagnostic
+			// detail is still scanned and retained.
+			name:       "structured provider failure plus non-zero exit retains provider detail",
+			cli:        "claude",
+			stdout:     `{"type":"result","subtype":"error_during_execution","is_error":true,"error":"upstream 529"}`,
+			runErr:     &CommandError{Kind: CommandErrorExitNonZero, Err: fmt.Errorf("exit status 1")},
+			wantNormal: false,
+			wantReason: TerminalReasonExitNonZero,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Message != "upstream 529" {
+					t.Fatalf("runner failure must still retain provider detail, got %#v", d)
+				}
+			},
+		},
+		{
+			// Same contract for a total timeout over a codex turn.failed.
+			name:       "structured provider failure plus timeout retains provider detail",
+			cli:        "codex",
+			stdout:     `{"type":"turn.failed","error":{"code":"deadline","message":"exceeded"}}`,
+			runErr:     &CommandError{Kind: CommandErrorTimeout, Err: fmt.Errorf("timed out")},
+			result:     RunResult{TimedOut: true},
+			wantNormal: false,
+			wantReason: TerminalReasonTimedOut,
+			wantDetail: func(t *testing.T, d ProviderTerminalDetail) {
+				if d.Code != "deadline" || d.Message != "exceeded" {
+					t.Fatalf("runner failure must still retain provider detail, got %#v", d)
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			var stdoutPath string
+			if tc.stdout != "" {
+				stdoutPath = filepath.Join(dir, "stdout")
+				if err := os.WriteFile(stdoutPath, []byte(tc.stdout), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := ClassifyExecutorTerminal(tc.cli, stdoutPath, tc.stdout, tc.result, tc.runErr)
+			if got.NormalTerminal != tc.wantNormal {
+				t.Fatalf("NormalTerminal = %t; want %t (reason=%q)", got.NormalTerminal, tc.wantNormal, got.Reason)
+			}
+			if !tc.wantNormal && got.Reason != tc.wantReason {
+				t.Fatalf("Reason = %q; want %q", got.Reason, tc.wantReason)
+			}
+			if tc.wantNormal && got.Reason != "" {
+				t.Fatalf("normal terminal must not carry an interruption reason, got %q", got.Reason)
+			}
+			if tc.wantDetail != nil {
+				tc.wantDetail(t, got.Detail)
+			}
+		})
+	}
+}
+
+func TestClassifyExecutorTerminalFallsBackToTail(t *testing.T) {
+	got := ClassifyExecutorTerminal("grok", "", `{"text":"{}","stopReason":"EndTurn","sessionId":"s"}`, RunResult{}, nil)
+	if !got.NormalTerminal {
+		t.Fatalf("expected normal terminal from tail fallback, got %#v", got)
+	}
+}
+
+func escape(s string) string {
+	out := make([]rune, 0, len(s)+8)
+	for _, r := range s {
+		if r == '"' || r == '\\' {
+			out = append(out, '\\')
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -207,6 +207,17 @@ type Attempt struct {
 	Error             *AttemptError `yaml:"error,omitempty" json:"error,omitempty"`
 }
 
+const (
+	// AttemptKindExecutorInterrupted marks an attempt whose executor was
+	// interrupted (provider or runtime failure) before it reached a normal
+	// provider terminal. It is distinct from an ordinary completed-result
+	// failure because no supervisor reviewed the attempt.
+	AttemptKindExecutorInterrupted = "executor_interrupted"
+	// AttemptVerdictNotReviewed marks an attempt no supervisor evaluated, so a
+	// non-verdict is never mistaken for an accepted or needs_revision decision.
+	AttemptVerdictNotReviewed = "not_reviewed"
+)
+
 // AttemptError records the operator-facing failure that ended an attempt.
 type AttemptError struct {
 	Phase       string `yaml:"phase" json:"phase"`

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -22,6 +22,8 @@ fi
 cat > /dev/null
 echo "smoke" > smoke-output.txt
 echo '{"status":"completed","summary":"smoke done","files_modified":["smoke-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["smoke-output.txt"],"notes":"created smoke output"}],"verification":[{"command":"test -f smoke-output.txt","status":"passed","reason":"file exists","output_excerpt":"ok"}],"decisions":[],"risks":[]}'
+# Classification keys on this terminal event, not the executor-result JSON above.
+echo '{"type":"result","subtype":"success","is_error":false}'
 SH
 chmod +x "$BIN_DIR/claude"
 


### PR DESCRIPTION
## Goal

Stop executor provider or runtime interruptions before normal Supervisor review, preserve partial work and run evidence, and let operators resume the retained worktree through the existing requeue workflow.

## Acceptance Criteria

- `AC1` When an executor process ends, Galley shall decide whether the attempt reached a normal provider terminal using runner state and machine-readable provider output. Claude and GLM successful result events, Codex `turn.completed`, and Grok `EndTurn` are normal terminals; explicit failed or non-normal terminals, start failures, timeouts, kills, and output without a reliable normal terminal are interruptions. The decision shall not depend on process exit code or human-language error matching alone.
  - Verification: Table-driven runner and daemon tests cover Claude/GLM normal result versus API-error result, Codex `turn.completed` versus `turn.failed`, Grok `EndTurn` versus non-EndTurn with exit code 0, and runner start/timeout/kill failures; claim: every executor supplies the same normal-terminal versus interruption decision; primary failure mode: a provider/runtime interruption is treated as completed or a normal terminal is treated as interrupted; boundary: provider output and runner result -> common attempt routing; state: executor ends -> terminal evidence is evaluated -> one routing decision is produced; residual: none.
  - Status: satisfied
- `AC2` When an executor reaches a normal provider terminal without a runner failure, Galley shall preserve the existing Supervisor path. An executor-result parse or schema-validation failure after that normal terminal shall remain reviewable, and a Supervisor `needs_revision` verdict shall continue to start the next executor attempt under the existing loop budget.
  - Verification: Focused daemon tests exercise valid and invalid executor results after representative normal terminals, assert that Supervisor receives the attempt evidence, and assert that `needs_revision` starts the next attempt; claim: ordinary executor-result failures retain the existing AFK correction loop; primary failure mode: the interruption path stops a normally completed attempt before review; boundary: normal terminal -> Supervisor loop; state: normal terminal -> review -> accepted or needs_revision; residual: none.
  - Status: satisfied
- `AC3` When an executor attempt is interrupted, Galley shall not invoke Supervisor and shall not start another executor attempt in the same run, regardless of whether the worktree contains a diff or how much loop budget remains. The task shall move to `tasks/failed` without recording an `accepted` or `needs_revision` verdict that no Supervisor produced.
  - Verification: Daemon lifecycle tests run interrupted executors with empty and dirty worktrees and `loop_budget` greater than one, then assert zero Supervisor calls, exactly one executor attempt, final placement under `tasks/failed`, and a non-verdict marker such as `not_reviewed`; claim: provider/runtime interruptions cannot consume the normal revision loop; primary failure mode: interruption reaches Supervisor or starts attempt 2; boundary: interrupted executor outcome -> task lifecycle publication; state: running task -> interruption -> failed task awaiting recovery; residual: none.
  - Status: satisfied
- `AC4` When an executor is interrupted after modifying its workspace, Galley shall preserve tracked and untracked changes and persist the available command plan, run result, raw provider output, git status, and diff evidence before publishing the failed task. Requeueing that task shall reuse the existing dirty worktree so the next executor can continue from the retained changes.
  - Verification: An integration test uses a fake executor that changes a tracked file and creates an untracked file before interruption, then asserts the attempt artifacts contain both changes, the failed worktree retains them, and a requeued run reports a reused worktree with the same changes visible; claim: interruption is resumable without lost implementation work; primary failure mode: failure publication or requeue resets or removes partial changes; boundary: executor process -> run artifacts -> failed task -> requeued workspace; state: clean worktree -> partial edits -> interruption -> requeue -> edits remain; residual: executor-created commits remain governed by the existing branch behavior.
  - Status: satisfied
- `AC5` When an executor is interrupted, the latest attempt shall record an executor-owned structured error distinct from an ordinary completed-result failure, and `galley task show` shall surface the interruption, evidence location, and recovery action. When the provider exposes structured status, code, stop reason, session ID, or message detail, Galley shall retain that detail for diagnosis; unavailable or unparseable detail shall fall back to a generic interruption reason without changing routing.
  - Verification: Focused tests cover Claude/GLM structured API failure, Codex `turn.failed` with and without parseable nested detail, Grok non-EndTurn, and an unknown interruption, then assert the task attempt and `task show` identify the executor interruption, preserve available provider detail and artifact directory, and recommend resolving the cause then requeueing; claim: operators can diagnose and resume an interruption without error-text classification controlling behavior; primary failure mode: interruption collapses into a normal Supervisor failure or missing detail prevents correct routing; boundary: provider terminal evidence -> task YAML -> task show; state: interruption recorded -> operator inspects task -> evidence and next action are visible; residual: unknown provider causes retain a generic reason.
  - Status: satisfied
- `AC6` User-facing supervision and operations documentation shall explain that executor interruptions stop before Supervisor, preserve the worktree and run evidence, and resume through the existing `galley task requeue` workflow after the interruption cause is resolved. The behavior change shall be recorded under CHANGELOG Unreleased.
  - Verification: Review `docs/supervision.md`, `docs/task-yaml.md`, `docs/operations.md`, and `CHANGELOG.md`; run schema check and task/profile example validation; claim: operators understand that interrupted work is retained and resumable; primary failure mode: documentation still describes every executor failure as a Supervisor retry or implies that partial work is discarded; boundary: documented daemon and CLI workflow; state: task interrupted -> operator follows documented recovery -> retained task is requeued; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go build ./... && go build -o /tmp/galley ./cmd/galley`: passed
- `gofmt -l internal/ scripts/`: passed
- `go vet ./internal/...`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml && profile validate --kind quality/environment`: passed
- `python3 -m json.tool on 9 schema/plugin JSON files`: passed
- `gofmt -l internal/`: passed
- `go test ./internal/daemon/ -run 'TestInterruptionArtifactStatusReportsPerArtifactTruth|TestInterruptionPartialDiffWriteFailureRetainsComponents' -v`: passed
- `go run ./cmd/galley task validate <afk-task>; profile validate --kind quality/environment`: passed
- `python3 -m json.tool on all CI-listed JSON files`: passed
- `gofmt -l internal/ cmd/`: passed
- `go run ./cmd/galley task validate <afk-task>; profile validate --kind quality/environment; schema check`: passed
- `python3 -m json.tool on schemas/*.json, plugin.json, marketplace.json (CI JSON set)`: passed
- `./scripts/smoke-local.sh`: passed
- `gofmt -l <edited go files> ; gofmt -l $(git ls-files '*.go')`: passed
- `go run ./cmd/galley task validate <afk> ; profile validate quality/environment ; schema check`: passed
- `python3 -m json.tool <schemas/plugins/marketplace json> ; test_create_task_skeleton.py`: passed
- `gofmt -l .`: passed
- `go vet ./...`: passed
- `go build ./...`: passed
- `GOOS=windows GOARCH=amd64 go build ./...`: passed
- `go test ./...`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml && go run ./cmd/galley task validate examples/afk-task-codex.yaml && go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `for f in $(git ls-files '*.json'); do python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$f"; done`: passed
- `sh scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` What decides whether an executor attempt enters normal Supervisor review? -> Use only whether the runner succeeded and the provider emitted a reliable normal terminal; do not route by detailed error category.
  - Rationale: The product decision is whether Supervisor can review a completed attempt, while provider-specific failure detail is diagnostic and may be absent or unstable.
  - Reversibility: high
- `D2` How should an interrupted task be published and resumed? -> Publish it through the existing failed-task state with preserved attempt evidence and worktree, then resume it through the existing `galley task requeue` workflow after the cause is resolved.
  - Rationale: Existing failed-task inspection, worktree reuse, and requeue behavior already provide the required operator recovery path.
  - Reversibility: high
- `D3` How should provider-specific failure detail affect behavior? -> Retain structured provider detail when available, but use it only for diagnosis and never as the condition for Supervisor routing.
  - Rationale: This preserves actionable evidence without introducing brittle or provider-specific control flow.
  - Reversibility: high
- `executor-decision-4` How should the daemon fakes emit provider terminal markers without editing ~40 individual test bodies? -> Auto-append a representative normal-terminal event in the shared helpers (writeFakeClaude appends a Claude success result event; writeFakeCodexExecutor appends turn.completed), plus add turn.completed to the handful of raw codex executor bodies that build codex via writeFakeCommand.
  - Rationale: Claude executors are built only through writeFakeClaude, so one helper change covers them uniformly; failed-terminal bodies (API error, turn.failed) still route as interruptions via the new failed/non-normal precedence, and the auto-appended marker exercises the scan-complete-history path end-to-end.
  - Reversibility: high
- `executor-decision-5` The dirty-worktree interruption test previously relied on a missing-marker interruption, which the auto-appended terminal would mask. -> Change that run's else branch to emit an explicit provider API-error result event so precedence keeps it an interruption; missing-marker coverage stays in the runner unit table and the new evidence-failure lifecycle test.
  - Rationale: Preserves the AC3/AC4 lifecycle intent (interruption + dirty worktree + requeue) while remaining compatible with the representative-terminal fakes.
  - Reversibility: high
- `executor-decision-6` Should ClassifyExecutorTerminal keep the lastMessagePath parameter? -> Remove it; terminal classification no longer reads the Codex last-message capture (that surface belongs to executor-result parsing in resolveExecutorResult/ExtractExecutorResult).
  - Rationale: Enforces the requirement to keep executor-result parsing separate and prevents a bare-result payload from substituting for a terminal marker.
  - Reversibility: high
- `executor-decision-7` How should Claude/GLM ambiguous result events (a result event with no explicit success or error signal) be routed? -> Treat them as an ambiguous interruption (new TerminalReasonAmbiguousResult) rather than a normal terminal, while retaining the event's diagnostic detail.
  - Rationale: The work order requires accepting Claude/GLM only with an explicit known-success signal; failing closed on ambiguity prevents a provider/runtime interruption from being mistaken for a completed attempt, and a distinct reason keeps task-show diagnosis truthful.
  - Reversibility: high
- `executor-decision-8` How should Grok terminal routing avoid depending on optional sessionId while ParseGrokEnvelope still requires it for result extraction? -> Add a routing-only parse (parseGrokRouting) in the runner terminal path that requires only the stopReason marker and treats sessionId as optional diagnostic detail, leaving ParseGrokEnvelope's stricter result-extraction contract unchanged.
  - Rationale: Separates routing markers from optional diagnostics without weakening the executor-result parsing contract other code relies on; a missing sessionId or result payload under EndTurn stays Supervisor-reviewable.
  - Reversibility: high
- `executor-decision-9` Where to add the partial git-status/diff write-failure coverage the work order requests (runner vs daemon)? -> Cover it with an end-to-end daemon test (TestInterruptionPartialDiffWriteFailureRetainsComponents) that injects a git_status.json-as-directory write failure and asserts diff.patch retention, the disclosed capture risk, and truthful verification text.
  - Rationale: The work order asks for runner and daemon tests and the retention behavior spans executorflow + daemon evidence recording; a daemon test exercises the full interruption artifact path, and executorflow has no existing test file, so adding a whole-flow test is the smallest coherent coverage.
  - Reversibility: high
- `executor-decision-10` How to inject deterministic run_result/metadata/terminal write failures for lifecycle tests without corrupting the attempt directory? -> Added writeAttemptArtifact and writeProviderMetadata seams to the existing daemonDependencies struct (mirroring stageExecutorOutput) and moved the run_result.json write out of executorflow.RunCommandAttempt into the daemon so all post-run persistence flows through injectable, parallel-safe seams.
  - Rationale: Matches the repository's established dependency-injection pattern used by TestInterruptedAttemptSurvivesPostExecutorEvidenceFailures, keeps injection per-Options (parallel-safe) rather than mutating package globals, and colocates every post-run artifact write with its separate availability flag.
  - Reversibility: high
- `executor-decision-11` Should a normal-terminal attempt also tolerate post-run persistence write failures? -> No — normal terminals keep the existing hard-failure semantics (run_result/terminal/metadata/result write failure -> executor_failed; staging -> review_staging_failed; diff write -> failure), while capture-only diff failures remain a recorded risk as before.
  - Rationale: The survival contract targets not losing the interruption routing decision; a normal terminal must not be handed to the supervisor with unpersisted evidence, and preserving current behavior avoids regressing tested normal-path failure classification.
  - Reversibility: high
- `executor-decision-12` How to make the staging-only injected-failure test observe preserved diff evidence? -> Modify a tracked file (README.md) in the executor body so the unstaged diff captures the change even though review staging failed (an untracked file would require staging to appear in the diff).
  - Rationale: CaptureSnapshotFromBase records unstaged tracked modifications without git add, isolating the staging failure from diff capture.
  - Reversibility: high
- `executor-decision-13` How should raw stdout/stderr capture availability be detected so the interruption inventory never falsely claims raw output? -> Derive availability from the on-disk existence of the executor stdout/stderr capture paths (os.Stat) in rawOutputCaptureErr, since a capture-file creation failure returns before either file exists while a start/exit/timeout failure still leaves the created (possibly empty) capture files.
  - Rationale: On-disk existence is the truthful signal for whether raw output was persisted and is robust to the untyped capture-file creation error returned by runner.RunCommand; it keeps the reporting logic unit-testable via attemptOutcome fields.
  - Reversibility: high
- `executor-decision-14` Should the combined DiffArtifacts.Err be removed now that per-artifact errors exist? -> Keep Err as the joined error for the normal-terminal hard-fail path and the existing interrupted-diff-capture risk, and add GitStatusErr/DiffPatchErr only for the per-artifact inventory.
  - Rationale: Preserves the previously accepted normal-path behavior and the combined diff-capture risk while satisfying the per-artifact truthful-inventory requirement with the smallest change.
  - Reversibility: high
- `executor-decision-15` Where should the GLM daemon lifecycle tests live? -> Extend the existing internal/daemon/glm_executor_test.go with the two lifecycle tests plus a small loadGLMExecutorTask helper.
  - Rationale: That file already houses GLM daemon-level tests (token fail-fast, verification command), keeping GLM coverage cohesive and matching the repo pattern of per-provider test files.
  - Reversibility: high
- `executor-decision-16` What is the GLM 'test token' the daemon lifecycle tests should use? -> Set Options.GLMAuthToken="test-token" so prepareGLMExecutorPlan resolves the token and redirects the Claude plan to the GLM endpoint.
  - Rationale: GLMAuthToken is the daemon's real injection point (resolved from daemon.yaml glm_api_key); the fake Claude binary ignores the redirect env vars, so a nonempty token exercises the GLM dispatch path deterministically.
  - Reversibility: high
- `executor-decision-17` How aggressively should the comment cleanup trim source-file rationale comments over 40 words? -> Trim over-limit and pure-restatement test comments plus two marginally-over daemon comments; retain longer source docs that state the routing public contract and fail-closed safety invariants.
  - Rationale: The repo quality profile's comment-quality rule explicitly exempts comments that document a public contract or safety invariant from the 40-word/2-sentence limit; the retained terminal.go/executor_attempt.go/loop.go docs are exactly that and do not merely restate names, ACs, control flow, or assertions.
  - Reversibility: high
- `executor-decision-18` How far beyond the four explicitly named locations should the comment audit extend? -> Removed every added/changed comment whose full content is recoverable from the adjacent code, assertions (including their t.Fatalf messages), an AC, or a test name — including all remaining test-function docstrings and assertion-narrating one-liners — while keeping fixture-mechanics rationale, helper/const docs, and source-symbol godocs.
  - Rationale: The task directs 'Audit every added/changed comment and retain only concise non-obvious protocol, safety, fixture, or fallback rationale', and the named glm docstrings (which contained substantive detail) were themselves listed for removal, establishing that test docstrings restating name+assertions are in scope.
  - Reversibility: high
- `executor-decision-19` Whether to trim mixed docstrings (restatement + a rationale clause) or remove them wholesale. -> Removed such docstrings wholesale where the rationale clause is already documented in the corresponding source godoc (e.g. routing/diagnosis-only rationale lives in terminal.go) or in a retained inline case comment.
  - Rationale: Keeps tests clean without losing the rationale, which remains available at the source of truth; duplicating it in the test is the noise the task targets.
  - Reversibility: high
- `executor-decision-20` Remove or rewrite the flagged scripts/smoke-local.sh comment at the appended normal-terminal echo? -> Rewrote it to one concise line ('# Classification keys on this terminal event, not the executor-result JSON above.') instead of deleting it.
  - Rationale: The fixture emits two adjacent JSON lines (a full executor-result payload and a separate bare terminal event); the reason a second event is load-bearing (the classifier keys on the terminal event, not the result JSON) is genuinely non-obvious and absent from the code, so a maintainer could silently break the smoke test by deleting it. The rewrite drops the narration the finding cited while preserving only that rationale, consistent with the work order's allowance to rewrite comments that preserve non-obvious rationale.
  - Reversibility: high
- `executor-decision-21` Should the removal-would-lose-information test also strip the unflagged added comments (fail-closed precedence, seam-injection rationale, exit-code boundaries, auto-append behavior, per-artifact error-flag contracts, provider-detail routing invariants)? -> Kept them unchanged after auditing each.
  - Rationale: Each states rationale, a constraint, an edge case, or a public/API contract that is not derivable from names, tests, ACs, or visible control flow (e.g. why writeFakeClaude auto-appends a success terminal and failed terminals still win, why loop_budget>1 is chosen, why a missing supervisor_verdict.json is the robust proof, the DiffArtifacts.Err vs per-component contract). The supervisor's own comment audit flagged only the eight addressed here.
  - Reversibility: high

## Discussion Items

- `discussion-1` Accepted scope expansion: The final diff includes three necessary, minimal paths outside task.scope.allowed_paths: internal/executorflow/attempt.go for independent diff-artifact capture, internal/runartifact/artifact.go for the shared executor_terminal.json name, and scripts/smoke-local.sh for a real normal-terminal smoke fixture. All three are accurately reported in executor scope_expansions and linked to AC1, AC2, or AC4.
- `discussion-2` Scope expansion: Accepted diff includes changes outside task.scope.allowed_paths: internal/executorflow/attempt.go, internal/runartifact/artifact.go, scripts/smoke-local.sh. Review whether this scope expansion belongs in this PR.
  - Human decision required: true

## Risks

- `R1` compatibility: Provider CLI versions may omit or change optional terminal detail while retaining their normal completion markers.
  - Mitigation: Base routing on the smallest stable structured normal-terminal contract, fail closed to interruption when normal completion cannot be established, and cover missing optional detail in tests.
- `R2` regression: A normal provider terminal followed by an invalid executor result could be misclassified as an interruption and lose the existing AFK Supervisor correction loop.
  - Mitigation: Test normal-terminal attempts with invalid result payloads and require them to enter the existing Supervisor path.
- `R3` state-safety: Publishing an interrupted task before capturing executor output could hide or lose partial tracked and untracked work.
  - Mitigation: Keep evidence capture and worktree preservation before terminal task publication, with an interruption-and-requeue lifecycle test.
