### PR TITLE
Stop executor provider or runtime interruptions before normal Supervisor review, preserve partial work and run evidence, and let operators resume the retained worktree through the existing requeue workflow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project follows semantic versioning.
 
 ### Changed
 
-- Executor provider or runtime interruptions now stop before Supervisor review. Galley decides whether an attempt reached a reliable normal provider terminal (Claude/GLM success result, Codex `turn.completed`, Grok `EndTurn`) from runner state and machine-readable provider output; interruptions skip the Supervisor and any further attempt, preserve the dirty worktree and run evidence, record an executor-owned `not_reviewed` attempt with retained provider detail, and publish the task to `tasks/failed`. `galley task show` surfaces the interruption, its evidence directory, and the `galley task requeue` recovery action, which resumes the retained worktree. A parse or schema-validation failure after a normal terminal remains reviewable under the existing correction loop.
+- Executor interruptions now bypass Supervisor, preserve the worktree and run evidence, and resume through `galley task requeue`; result-validation failures after a normal provider terminal remain reviewable.
 - Packaged Claude, Codex, and Grok Galley plugins are now versioned as `0.1.26`: troubleshooting guidance routes executor interruptions through wait-or-update recovery without requiring an exact provider failure classification, and the bundled helper updates task-level executor CLI, model, and effort overrides before validation and requeue.
 
 ## v0.10.2 - 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project follows semantic versioning.
 
 ### Changed
 
+- Executor provider or runtime interruptions now stop before Supervisor review. Galley decides whether an attempt reached a reliable normal provider terminal (Claude/GLM success result, Codex `turn.completed`, Grok `EndTurn`) from runner state and machine-readable provider output; interruptions skip the Supervisor and any further attempt, preserve the dirty worktree and run evidence, record an executor-owned `not_reviewed` attempt with retained provider detail, and publish the task to `tasks/failed`. `galley task show` surfaces the interruption, its evidence directory, and the `galley task requeue` recovery action, which resumes the retained worktree. A parse or schema-validation failure after a normal terminal remains reviewable under the existing correction loop.
 - Packaged Claude, Codex, and Grok Galley plugins are now versioned as `0.1.26`: troubleshooting guidance routes executor interruptions through wait-or-update recovery without requiring an exact provider failure classification, and the bundled helper updates task-level executor CLI, model, and effort overrides before validation and requeue.
 
 ## v0.10.2 - 2026-07-15

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,9 +63,9 @@ galley task archive ~/.galley/tasks/done/TASK.yaml
 
 `galley task list` shows task state, status, PR URL, latest verdict, and latest summary across the workflow root.
 
-`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Accepted terminal tasks show prior attempt errors as audit history, not active failures.
+`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Accepted terminal tasks show prior attempt errors as audit history, not active failures. When the latest attempt is an executor interruption, `task show` marks it (`latest_executor_interruption: true`), points at the attempt evidence directory, and prints a `latest_recovery` line with the `galley task requeue` command to run after the interruption cause is resolved.
 
-`galley task requeue` accepts a task ID or task file, returns a reviewed task from `tasks/failed`, `tasks/done`, or `tasks/running` to `tasks/queued`, records an optional reason, and increments `supervisor.review_iterations`. When the task worktree is reused, successful setup and acceptance-skeleton phases are reused rather than repeated.
+`galley task requeue` accepts a task ID or task file, returns a reviewed task from `tasks/failed`, `tasks/done`, or `tasks/running` to `tasks/queued`, records an optional reason, and increments `supervisor.review_iterations`. When the task worktree is reused, successful setup and acceptance-skeleton phases are reused rather than repeated. An executor interruption preserves the dirty worktree, so requeueing resumes the next executor attempt from the retained tracked and untracked changes.
 
 ## Profiles
 

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -50,8 +50,19 @@ For implementation tasks, the supervisor should reject a no-diff result unless t
 | Parse failure or schema validation failure | retry, then `tasks/failed/` with status `needs_supervisor_review` |
 | Two consecutive attempts with no git diff | stop early as a no-progress safeguard |
 | `hard_stop` | `tasks/failed/` with status `failed`, without retry |
+| Executor interruption (provider or runtime, before any normal terminal) | `tasks/failed/` with status `failed`, without Supervisor review or another attempt |
 
 `needs_supervisor_review` is a task state, not a daemon process failure. `galley daemon run --once` can exit 0 after recording that state.
+
+## Executor Interruptions
+
+Before normal Supervisor review, Galley decides whether an executor attempt reached a reliable normal provider terminal. Claude and GLM success result events, Codex `turn.completed`, and Grok `EndTurn` are normal terminals; explicit failed terminals, start failures, timeouts, kills, and output with no reliable normal terminal are interruptions. The decision uses runner state and machine-readable provider output, never the process exit code or error text alone.
+
+An interrupted attempt does not invoke the Supervisor and does not start another executor attempt in the same run, regardless of loop budget or worktree diff. Galley captures the command plan, run result, raw provider output, git status, diff, and a terminal-decision record, preserves the tracked and untracked worktree changes, and publishes the task to `tasks/failed/` with status `failed`. The attempt records an executor-owned error with the non-verdict marker `not_reviewed` and retains any provider status, code, stop reason, session ID, or message detail for diagnosis; unavailable detail falls back to a generic interruption reason without changing routing.
+
+An executor-result parse or schema-validation failure that follows a normal terminal is not an interruption: it stays reviewable, and a `needs_revision` verdict continues to start the next executor attempt under the existing loop budget.
+
+Resolve the interruption cause (for example a provider outage or a local dependency), then resume the retained worktree with `galley task requeue`.
 
 `completed_with_risks` means the executor believes the implementation is coherent, but verification limits, assumptions, or residual risks still need supervisor attention.
 

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -66,7 +66,7 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `executor`: optional per-field overrides for CLI, model, and effort.
 - `preflight.acceptance_skeleton.enabled`: optional boolean that selects the fixed skeleton preflight flow.
 - `decisions`, `risks`: author and executor notes.
-- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state populated during lifecycle transitions.
+- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state populated during lifecycle transitions. An attempt that ended in an executor interruption records `supervisor_verdict: not_reviewed` and an executor-phase `error` with the retained provider detail; see [supervision.md](supervision.md#executor-interruptions).
 
 ## Execution Policy And Executor
 

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -220,6 +220,13 @@ func newTaskShowCommand() *cobra.Command {
 						if last.Error.ArtifactDir != "" {
 							fmt.Fprintf(cmd.OutOrStdout(), "%s_error_artifact_dir: %s\n", prefix, last.Error.ArtifactDir)
 						}
+						// An executor interruption stops before Supervisor and
+						// keeps the worktree, so surface the resume path instead
+						// of implying a review verdict is pending.
+						if isExecutorInterruption(last) {
+							fmt.Fprintf(cmd.OutOrStdout(), "%s_executor_interruption: true\n", prefix)
+							fmt.Fprintf(cmd.OutOrStdout(), "%s_recovery: resolve the interruption cause, then run: galley task requeue %s\n", prefix, loaded.ID)
+						}
 					}
 				}
 				if len(loaded.Risks) > 0 {
@@ -391,6 +398,17 @@ func taskFiles(dir string) ([]string, error) {
 // though the supervisor already approved the work.
 func isAcceptedTerminalStatus(status string) bool {
 	return task.IsAcceptedTerminal(status)
+}
+
+// isExecutorInterruption reports whether an attempt ended because the executor
+// was interrupted before Supervisor review. Interruptions are the only executor
+// attempts that carry an executor-phase error with the non-verdict marker
+// `not_reviewed`; ordinary completed attempts always record a Supervisor
+// verdict, and infrastructure failures record their own phase and kind marker.
+func isExecutorInterruption(attempt task.Attempt) bool {
+	return attempt.Error != nil &&
+		attempt.Error.Phase == "executor" &&
+		attempt.SupervisorVerdict == "not_reviewed"
 }
 
 func taskSummary(path string, loaded task.Task) taskListItem {

--- a/internal/cli/task_show_interruption_test.go
+++ b/internal/cli/task_show_interruption_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	taskpkg "github.com/shinpr/galley/internal/task"
+)
+
+// The message strings mirror the daemon's interruptionMessage format, which
+// internal/daemon owns and tests; this test only checks that task show renders
+// what the daemon persists.
+func TestTaskShowSurfacesExecutorInterruption(t *testing.T) {
+	cases := []struct {
+		name        string
+		message     string
+		wantDetail  []string
+		notInOutput []string
+	}{
+		{
+			name:       "claude api failure",
+			message:    "Executor interrupted before Supervisor review (reason=claude_result_error); status=error_during_execution; session_id=claude-sess",
+			wantDetail: []string{"claude_result_error", "error_during_execution", "claude-sess"},
+		},
+		{
+			name:       "glm api failure",
+			message:    "Executor interrupted before Supervisor review (reason=claude_result_error); status=error_during_execution; session_id=glm-sess",
+			wantDetail: []string{"claude_result_error", "glm-sess"},
+		},
+		{
+			name:       "codex detail present",
+			message:    "Executor interrupted before Supervisor review (reason=codex_turn_failed); code=rate_limit; detail=model overloaded",
+			wantDetail: []string{"codex_turn_failed", "rate_limit", "model overloaded"},
+		},
+		{
+			name:        "codex detail absent",
+			message:     "Executor interrupted before Supervisor review (reason=codex_turn_failed)",
+			wantDetail:  []string{"codex_turn_failed"},
+			notInOutput: []string{"code=", "detail="},
+		},
+		{
+			name:        "codex detail unparseable",
+			message:     "Executor interrupted before Supervisor review (reason=codex_turn_failed)",
+			wantDetail:  []string{"codex_turn_failed"},
+			notInOutput: []string{"code=", "detail="},
+		},
+		{
+			name:       "grok non-endturn",
+			message:    "Executor interrupted before Supervisor review (reason=grok_non_end_turn); stop_reason=MaxTokens; session_id=grok-sess",
+			wantDetail: []string{"grok_non_end_turn", "MaxTokens"},
+		},
+		{
+			name:       "unknown interruption",
+			message:    "Executor interrupted before Supervisor review (reason=no_normal_terminal)",
+			wantDetail: []string{"no_normal_terminal"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskPath := writeCLITaskYAML(t)
+			loaded, err := taskpkg.Load(taskPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := t.TempDir()
+			artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")
+			loaded.Status = "failed"
+			loaded.Attempts = []taskpkg.Attempt{{
+				Number:            1,
+				ClaudeStatus:      "completed",
+				SupervisorVerdict: "not_reviewed",
+				Summary:           tc.message,
+				Error: &taskpkg.AttemptError{
+					Phase:       "executor",
+					Kind:        "executor_interrupted",
+					Message:     tc.message,
+					ArtifactDir: artifactDir,
+				},
+			}}
+			dst := filepath.Join(root, "tasks", "failed", "task.yaml")
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := taskpkg.Save(dst, loaded); err != nil {
+				t.Fatal(err)
+			}
+
+			stdout, _, err := executeCommand("task", "show", "--root", root, "task-cli-test", "-o", "text")
+			if err != nil {
+				t.Fatalf("task show: %v", err)
+			}
+			want := []string{
+				"latest_error_phase: executor",
+				"latest_error_kind: executor_interrupted",
+				"latest_executor_interruption: true",
+				"latest_recovery: resolve the interruption cause, then run: galley task requeue task-cli-test",
+				artifactDir,
+			}
+			want = append(want, tc.wantDetail...)
+			for _, w := range want {
+				if !strings.Contains(stdout, w) {
+					t.Fatalf("task show output missing %q\n%s", w, stdout)
+				}
+			}
+			for _, n := range tc.notInOutput {
+				if strings.Contains(stdout, n) {
+					t.Fatalf("task show output must not contain %q\n%s", n, stdout)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/task_show_interruption_test.go
+++ b/internal/cli/task_show_interruption_test.go
@@ -9,8 +9,6 @@ import (
 	taskpkg "github.com/shinpr/galley/internal/task"
 )
 
-// interruptMessage mirrors the daemon-owned interruptionMessage format rather
-// than defining it here.
 func TestTaskShowExecutorInterruptionRendering(t *testing.T) {
 	root := t.TempDir()
 	artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")

--- a/internal/cli/task_show_interruption_test.go
+++ b/internal/cli/task_show_interruption_test.go
@@ -9,52 +9,51 @@ import (
 	taskpkg "github.com/shinpr/galley/internal/task"
 )
 
-// The message strings mirror the daemon's interruptionMessage format, which
-// internal/daemon owns and tests; this test only checks that task show renders
-// what the daemon persists.
-func TestTaskShowSurfacesExecutorInterruption(t *testing.T) {
+// interruptMessage mirrors the daemon-owned interruptionMessage format rather
+// than defining it here.
+func TestTaskShowExecutorInterruptionRendering(t *testing.T) {
+	root := t.TempDir()
+	artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")
+	interruptMessage := "Executor interrupted before Supervisor review (reason=claude_result_error); status=error_during_execution; session_id=claude-sess"
+
 	cases := []struct {
-		name        string
-		message     string
-		wantDetail  []string
-		notInOutput []string
+		name             string
+		attempt          taskpkg.Attempt
+		wantInterruption bool
+		wantDetail       []string
 	}{
 		{
-			name:       "claude api failure",
-			message:    "Executor interrupted before Supervisor review (reason=claude_result_error); status=error_during_execution; session_id=claude-sess",
-			wantDetail: []string{"claude_result_error", "error_during_execution", "claude-sess"},
+			name: "executor interruption",
+			attempt: taskpkg.Attempt{
+				Number:            1,
+				ClaudeStatus:      "completed",
+				SupervisorVerdict: "not_reviewed",
+				Summary:           interruptMessage,
+				Error: &taskpkg.AttemptError{
+					Phase:       "executor",
+					Kind:        "executor_interrupted",
+					Message:     interruptMessage,
+					ArtifactDir: artifactDir,
+				},
+			},
+			wantInterruption: true,
+			wantDetail:       []string{"claude_result_error", "error_during_execution", "claude-sess"},
 		},
 		{
-			name:       "glm api failure",
-			message:    "Executor interrupted before Supervisor review (reason=claude_result_error); status=error_during_execution; session_id=glm-sess",
-			wantDetail: []string{"claude_result_error", "glm-sess"},
-		},
-		{
-			name:       "codex detail present",
-			message:    "Executor interrupted before Supervisor review (reason=codex_turn_failed); code=rate_limit; detail=model overloaded",
-			wantDetail: []string{"codex_turn_failed", "rate_limit", "model overloaded"},
-		},
-		{
-			name:        "codex detail absent",
-			message:     "Executor interrupted before Supervisor review (reason=codex_turn_failed)",
-			wantDetail:  []string{"codex_turn_failed"},
-			notInOutput: []string{"code=", "detail="},
-		},
-		{
-			name:        "codex detail unparseable",
-			message:     "Executor interrupted before Supervisor review (reason=codex_turn_failed)",
-			wantDetail:  []string{"codex_turn_failed"},
-			notInOutput: []string{"code=", "detail="},
-		},
-		{
-			name:       "grok non-endturn",
-			message:    "Executor interrupted before Supervisor review (reason=grok_non_end_turn); stop_reason=MaxTokens; session_id=grok-sess",
-			wantDetail: []string{"grok_non_end_turn", "MaxTokens"},
-		},
-		{
-			name:       "unknown interruption",
-			message:    "Executor interrupted before Supervisor review (reason=no_normal_terminal)",
-			wantDetail: []string{"no_normal_terminal"},
+			name: "ordinary supervisor failure",
+			attempt: taskpkg.Attempt{
+				Number:            1,
+				ClaudeStatus:      "completed",
+				SupervisorVerdict: "supervisor_failed",
+				Summary:           "supervisor evaluation failed",
+				Error: &taskpkg.AttemptError{
+					Phase:       "supervisor",
+					Kind:        "supervisor_failed",
+					Message:     "supervisor crashed",
+					ArtifactDir: artifactDir,
+				},
+			},
+			wantInterruption: false,
 		},
 	}
 	for _, tc := range cases {
@@ -64,21 +63,8 @@ func TestTaskShowSurfacesExecutorInterruption(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			root := t.TempDir()
-			artifactDir := filepath.Join(root, "runs", "task-cli-test-1", "attempt-1")
 			loaded.Status = "failed"
-			loaded.Attempts = []taskpkg.Attempt{{
-				Number:            1,
-				ClaudeStatus:      "completed",
-				SupervisorVerdict: "not_reviewed",
-				Summary:           tc.message,
-				Error: &taskpkg.AttemptError{
-					Phase:       "executor",
-					Kind:        "executor_interrupted",
-					Message:     tc.message,
-					ArtifactDir: artifactDir,
-				},
-			}}
+			loaded.Attempts = []taskpkg.Attempt{tc.attempt}
 			dst := filepath.Join(root, "tasks", "failed", "task.yaml")
 			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 				t.Fatal(err)
@@ -91,22 +77,27 @@ func TestTaskShowSurfacesExecutorInterruption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("task show: %v", err)
 			}
-			want := []string{
-				"latest_error_phase: executor",
-				"latest_error_kind: executor_interrupted",
+			interruptionMarkers := []string{
 				"latest_executor_interruption: true",
 				"latest_recovery: resolve the interruption cause, then run: galley task requeue task-cli-test",
-				artifactDir,
 			}
-			want = append(want, tc.wantDetail...)
-			for _, w := range want {
-				if !strings.Contains(stdout, w) {
-					t.Fatalf("task show output missing %q\n%s", w, stdout)
+			if tc.wantInterruption {
+				want := append([]string{
+					"latest_error_phase: executor",
+					"latest_error_kind: executor_interrupted",
+					artifactDir,
+				}, interruptionMarkers...)
+				want = append(want, tc.wantDetail...)
+				for _, w := range want {
+					if !strings.Contains(stdout, w) {
+						t.Fatalf("task show output missing %q\n%s", w, stdout)
+					}
 				}
-			}
-			for _, n := range tc.notInOutput {
-				if strings.Contains(stdout, n) {
-					t.Fatalf("task show output must not contain %q\n%s", n, stdout)
+			} else {
+				for _, marker := range interruptionMarkers {
+					if strings.Contains(stdout, marker) {
+						t.Fatalf("ordinary failure must not render %q\n%s", marker, stdout)
+					}
 				}
 			}
 		})

--- a/internal/daemon/acceptance_skeleton_creator_codex_daemon_test.go
+++ b/internal/daemon/acceptance_skeleton_creator_codex_daemon_test.go
@@ -75,6 +75,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '{"type":"turn.completed","usage":{}}'
     ;;
 esac
 `)

--- a/internal/daemon/codex_executor_dispatch_test.go
+++ b/internal/daemon/codex_executor_dispatch_test.go
@@ -45,7 +45,12 @@ import (
 // to record invocation markers and emit the executor result JSON line.
 func writeFakeCodexExecutor(t *testing.T, body string) string {
 	t.Helper()
-	return writeFakeCommand(t, "codex", "cat >/dev/null\n"+body)
+	// Emit a realistic Codex `turn.completed` terminal after the body so the
+	// normal-terminal decision matches production routing; interruption bodies
+	// exit before this line or emit their own terminal event.
+	return writeFakeCommand(t, "codex", "cat >/dev/null\n"+body+`
+printf '%s\n' '{"type":"turn.completed","usage":{}}'
+`)
 }
 
 // TestDaemonDispatchesSelectedExecutorBinary parameterizes over the supported

--- a/internal/daemon/codex_executor_result_capture_test.go
+++ b/internal/daemon/codex_executor_result_capture_test.go
@@ -51,6 +51,7 @@ if [ -n "$lastmsg" ]; then
   printf '%s' '`+executorResult+`' > "$lastmsg"
 fi
 printf '%s\n' '{"event":"unrelated"}'
+printf '%s\n' '{"type":"turn.completed","usage":{}}'
 `)
 
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
@@ -117,6 +118,7 @@ if [ -n "$lastmsg" ]; then
   printf '%s' '`+hardStopResult+`' > "$lastmsg"
 fi
 printf '%s\n' '`+hardStopResult+`'
+printf '%s\n' '{"type":"turn.completed","usage":{}}'
 `)
 
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/shinpr/galley/internal/daemonconfig"
+	"github.com/shinpr/galley/internal/executorflow"
 	"github.com/shinpr/galley/internal/galleyhome"
 	"github.com/shinpr/galley/internal/inputfiles"
 	"github.com/shinpr/galley/internal/jsonio"
@@ -133,16 +134,18 @@ type Options struct {
 }
 
 type daemonDependencies struct {
-	stageExecutorOutput func(context.Context, Options, string, string, []string) error
-	supervisorRunner    func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)
-	setupExecutorRunner func(context.Context, setuppreflight.Options) (*setuppreflight.Result, error)
+	stageExecutorOutput  func(context.Context, Options, string, string, []string) error
+	captureDiffArtifacts func(context.Context, string, string, string, workspace.Options) (executorflow.DiffArtifacts, error)
+	supervisorRunner     func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)
+	setupExecutorRunner  func(context.Context, setuppreflight.Options) (*setuppreflight.Result, error)
 }
 
 func defaultDaemonDependencies() daemonDependencies {
 	return daemonDependencies{
-		stageExecutorOutput: defaultStageExecutorOutput,
-		supervisorRunner:    defaultSupervisorRunner,
-		setupExecutorRunner: setuppreflight.RunExecutor,
+		stageExecutorOutput:  defaultStageExecutorOutput,
+		captureDiffArtifacts: executorflow.CaptureDiffArtifacts,
+		supervisorRunner:     defaultSupervisorRunner,
+		setupExecutorRunner:  setuppreflight.RunExecutor,
 	}
 }
 
@@ -154,6 +157,9 @@ func (opts Options) daemonDependencies() daemonDependencies {
 	deps := *opts.dependencies
 	if deps.stageExecutorOutput == nil {
 		deps.stageExecutorOutput = defaults.stageExecutorOutput
+	}
+	if deps.captureDiffArtifacts == nil {
+		deps.captureDiffArtifacts = defaults.captureDiffArtifacts
 	}
 	if deps.supervisorRunner == nil {
 		deps.supervisorRunner = defaults.supervisorRunner

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -650,7 +650,7 @@ func TestRunOnceParseFailureNeedsSupervisorReview(t *testing.T) {
 	// A real Claude run that finishes normally but emits non-JSON still ends its
 	// stream with a success result event; only the embedded executor result is
 	// unparseable. That normal terminal must reach Supervisor review rather than
-	// be misclassified as an interruption (AC2, R2).
+	// be misclassified as an interruption.
 	claudeBin := writeFakeClaude(t, `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"not-json","session_id":"sess-parse"}'`+"\n")
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -185,7 +185,10 @@ func TestRunOnceRecordsSupervisorTimeoutInTaskAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeDaemonTask(t, taskPath, repo)
-	setTimeoutMS(t, taskPath, 50)
+	// The timeout must let the fast executor reach its normal terminal while the
+	// sleeping supervisor still exceeds it, so the recorded failure is the
+	// supervisor timeout rather than an executor interruption.
+	setTimeoutMS(t, taskPath, 500)
 
 	err := runTestDaemon(context.Background(), Options{
 		Root:               root,
@@ -644,7 +647,11 @@ func TestRunOnceParseFailureNeedsSupervisorReview(t *testing.T) {
 	root := filepath.Join(t.TempDir(), ".agent-workflow")
 	repo := initDaemonGitRepo(t)
 	promptPath, schemaPath := writeDaemonPromptFiles(t)
-	claudeBin := writeFakeClaude(t, "echo not-json\n")
+	// A real Claude run that finishes normally but emits non-JSON still ends its
+	// stream with a success result event; only the embedded executor result is
+	// unparseable. That normal terminal must reach Supervisor review rather than
+	// be misclassified as an interruption (AC2, R2).
+	claudeBin := writeFakeClaude(t, `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"not-json","session_id":"sess-parse"}'`+"\n")
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
 		t.Fatal(err)
@@ -807,7 +814,9 @@ if [ "$supervisor" = "1" ]; then
   fi
   exit 0
 fi
-`+body)
+`+body+`
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"fake-claude-session"}'
+`)
 }
 
 func prepareDonePRTask(t *testing.T, taskPath, repo, prStatus string) (task.Task, string) {

--- a/internal/daemon/executor_attempt.go
+++ b/internal/daemon/executor_attempt.go
@@ -32,7 +32,17 @@ type attemptOutcome struct {
 	Diff           string
 	DiffErr        error
 	DiffSnapshot   workspace.Snapshot
+	// EvidenceErr records a post-interruption staging or diff-capture failure. It
+	// is secondary evidence: the interruption stays primary so the task still
+	// routes to tasks/failed and requeue recovery stays available.
+	EvidenceErr error
 }
+
+// evidenceCaptureTimeout bounds post-executor git status and diff capture. The
+// capture uses a context detached from the executor so a shutdown that cancels
+// the executor cannot cancel evidence capture; the bound stops a wedged git
+// process from blocking shutdown.
+const evidenceCaptureTimeout = 2 * time.Minute
 
 func defaultStageExecutorOutput(ctx context.Context, opts Options, workDir, attemptDir string, excludePaths []string) error {
 	bins := vcsBinaries(opts)
@@ -118,19 +128,7 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 		return attemptOutcome{}, err
 	}
 
-	// Stage untracked executor output, excluding context-only inputs, before
-	// supervisor review. The parent context preserves evidence after a timeout.
-	excludePaths := nonCommittedInputDestinations(loaded.Files)
-	if err := opts.daemonDependencies().stageExecutorOutput(ctx, opts, workDir, attemptDir, excludePaths); err != nil {
-		return attemptOutcome{}, &reviewStagingError{Err: err}
-	}
-
-	diffArtifacts, err := executorflow.CaptureDiffArtifacts(ctx, workDir, baseSHA, attemptDir, workspaceOptions(opts))
-	if err != nil {
-		return attemptOutcome{}, err
-	}
-
-	return attemptOutcome{
+	outcome := attemptOutcome{
 		Started:        run.Started,
 		Completed:      run.Completed,
 		RunResult:      run.RunResult,
@@ -138,11 +136,37 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 		Terminal:       terminal,
 		ExecutorResult: executorResult,
 		ParseErr:       parseErr,
-		DiffDirty:      diffArtifacts.Dirty,
-		Diff:           diffArtifacts.Diff,
-		DiffErr:        diffArtifacts.Err,
-		DiffSnapshot:   diffArtifacts.Snapshot,
-	}, nil
+	}
+
+	evidenceCtx, evidenceCancel := context.WithTimeout(context.WithoutCancel(ctx), evidenceCaptureTimeout)
+	defer evidenceCancel()
+
+	excludePaths := nonCommittedInputDestinations(loaded.Files)
+	stageErr := opts.daemonDependencies().stageExecutorOutput(evidenceCtx, opts, workDir, attemptDir, excludePaths)
+	if stageErr != nil && !terminal.Interrupted() {
+		// For a normally completed attempt a staging failure is terminal: the
+		// supervisor would otherwise review a stale or empty diff.
+		return attemptOutcome{}, &reviewStagingError{Err: stageErr}
+	}
+	if stageErr != nil {
+		// The interruption stays the primary outcome; still attempt diff capture
+		// so git status/diff evidence is retained where possible.
+		outcome.EvidenceErr = stageErr
+	}
+
+	diffArtifacts, err := opts.daemonDependencies().captureDiffArtifacts(evidenceCtx, workDir, baseSHA, attemptDir, workspaceOptions(opts))
+	if err != nil {
+		if !terminal.Interrupted() {
+			return attemptOutcome{}, err
+		}
+		outcome.EvidenceErr = errors.Join(outcome.EvidenceErr, err)
+		return outcome, nil
+	}
+	outcome.DiffDirty = diffArtifacts.Dirty
+	outcome.Diff = diffArtifacts.Diff
+	outcome.DiffErr = diffArtifacts.Err
+	outcome.DiffSnapshot = diffArtifacts.Snapshot
+	return outcome, nil
 }
 
 func markRevisionRequestsAddressed(loaded *task.Task, evidence string) {
@@ -243,7 +267,7 @@ func executorAttemptError(outcome attemptOutcome, attemptDir string) *task.Attem
 
 // executorInterruptionError signals that an executor attempt did not reach a
 // normal provider terminal. The daemon loop publishes the task to tasks/failed
-// without invoking Supervisor or starting another executor attempt (AC3).
+// without invoking Supervisor or starting another executor attempt.
 type executorInterruptionError struct {
 	terminal runner.ExecutorTerminal
 }
@@ -264,10 +288,10 @@ func asExecutorInterruptionError(err error) (*executorInterruptionError, bool) {
 }
 
 // interruptionKind maps an interrupted attempt to its persisted attempt-error
-// kind. Runner failures keep the existing timeout/idle/executor classifications
-// so downstream recovery still sees the actionable signal; a provider-reported
-// non-normal terminal (runner succeeded) records the distinct
-// executor_interrupted kind (AC5).
+// kind. Runner failures keep the timeout/idle/executor classifications so
+// recovery still sees the actionable signal; a provider-reported non-normal
+// terminal with a successful runner records the distinct executor_interrupted
+// kind.
 func interruptionKind(outcome attemptOutcome) string {
 	if outcome.RunErr != nil {
 		return classifyFailureKind("executor_failed", outcome.RunErr)
@@ -278,7 +302,7 @@ func interruptionKind(outcome attemptOutcome) string {
 // appendExecutorInterruptionAttempt records the interrupted attempt with an
 // executor-owned structured error, a non-verdict marker (no Supervisor produced
 // one), and a requeue recovery risk. Provider detail is retained for diagnosis
-// only; it never changes routing (D3).
+// only; it never changes routing.
 func appendExecutorInterruptionAttempt(loaded *task.Task, outcome attemptOutcome, attemptDir string) {
 	message := interruptionMessage(outcome.Terminal)
 	loaded.Attempts = append(loaded.Attempts, task.Attempt{
@@ -302,11 +326,19 @@ func appendExecutorInterruptionAttempt(loaded *task.Task, outcome attemptOutcome
 	})
 	appendRisk(loaded, "executor-interruption", "external_dependency", message,
 		"Resolve the interruption cause, then run `galley task requeue` to resume from the preserved worktree.", true)
+	// CaptureDiffArtifacts reports a snapshot/diff failure in-band as DiffErr (nil
+	// function error), so it is joined with any staging failure. Both surface as
+	// secondary evidence; the interruption stays primary and the worktree keeps
+	// partial changes for requeue.
+	if evidenceErr := errors.Join(outcome.EvidenceErr, outcome.DiffErr); evidenceErr != nil {
+		appendRisk(loaded, "executor-interruption-evidence", "partial_verification", evidenceErr.Error(),
+			"Evidence capture failed after the interruption; the preserved worktree still holds the partial changes for requeue.", true)
+	}
 }
 
-// interruptionMessage renders an operator-facing interruption reason that keeps
-// available provider detail while falling back to a generic reason when the
-// provider exposes none (AC5).
+// interruptionMessage renders an operator-facing interruption reason, keeping
+// available provider detail and falling back to a generic reason when none
+// exists.
 func interruptionMessage(terminal runner.ExecutorTerminal) string {
 	parts := []string{fmt.Sprintf("Executor interrupted before Supervisor review (reason=%s)", terminal.Reason)}
 	if terminal.RunError != "" {

--- a/internal/daemon/executor_attempt.go
+++ b/internal/daemon/executor_attempt.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ type attemptOutcome struct {
 	Completed      time.Time
 	RunResult      runner.RunResult
 	RunErr         error
+	Terminal       runner.ExecutorTerminal
 	ExecutorResult runner.ExecutorResult
 	ParseErr       error
 	DiffDirty      bool
@@ -107,6 +109,15 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 		}
 	}
 
+	// The normal-terminal versus interruption decision is derived from runner
+	// state and provider output and persisted as attempt evidence before the
+	// task is routed. runExecutorAttempt still captures diff, git status, and raw
+	// logs below so an interrupted attempt keeps its full evidence set.
+	terminal := classifyExecutorTerminal(cli, stdoutPath, run.RunResult.Stdout, run.RunErr)
+	if err := writeJSON(runartifact.Path(attemptDir, runartifact.ExecutorTerminalFilename), terminal); err != nil {
+		return attemptOutcome{}, err
+	}
+
 	// Stage untracked executor output, excluding context-only inputs, before
 	// supervisor review. The parent context preserves evidence after a timeout.
 	excludePaths := nonCommittedInputDestinations(loaded.Files)
@@ -124,6 +135,7 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, pro
 		Completed:      run.Completed,
 		RunResult:      run.RunResult,
 		RunErr:         run.RunErr,
+		Terminal:       terminal,
 		ExecutorResult: executorResult,
 		ParseErr:       parseErr,
 		DiffDirty:      diffArtifacts.Dirty,
@@ -227,6 +239,95 @@ func executorAttemptError(outcome attemptOutcome, attemptDir string) *task.Attem
 		return nil
 	}
 	return attemptError("executor", classifyFailureKind("executor_failed", outcome.RunErr), outcome.RunErr, attemptDir)
+}
+
+// executorInterruptionError signals that an executor attempt did not reach a
+// normal provider terminal. The daemon loop publishes the task to tasks/failed
+// without invoking Supervisor or starting another executor attempt (AC3).
+type executorInterruptionError struct {
+	terminal runner.ExecutorTerminal
+}
+
+func (e *executorInterruptionError) Error() string {
+	if e == nil {
+		return "executor interrupted"
+	}
+	return "executor interrupted: " + e.terminal.Reason
+}
+
+func asExecutorInterruptionError(err error) (*executorInterruptionError, bool) {
+	var interruption *executorInterruptionError
+	if errors.As(err, &interruption) {
+		return interruption, true
+	}
+	return nil, false
+}
+
+// interruptionKind maps an interrupted attempt to its persisted attempt-error
+// kind. Runner failures keep the existing timeout/idle/executor classifications
+// so downstream recovery still sees the actionable signal; a provider-reported
+// non-normal terminal (runner succeeded) records the distinct
+// executor_interrupted kind (AC5).
+func interruptionKind(outcome attemptOutcome) string {
+	if outcome.RunErr != nil {
+		return classifyFailureKind("executor_failed", outcome.RunErr)
+	}
+	return "executor_interrupted"
+}
+
+// appendExecutorInterruptionAttempt records the interrupted attempt with an
+// executor-owned structured error, a non-verdict marker (no Supervisor produced
+// one), and a requeue recovery risk. Provider detail is retained for diagnosis
+// only; it never changes routing (D3).
+func appendExecutorInterruptionAttempt(loaded *task.Task, outcome attemptOutcome, attemptDir string) {
+	message := interruptionMessage(outcome.Terminal)
+	loaded.Attempts = append(loaded.Attempts, task.Attempt{
+		Number:            len(loaded.Attempts) + 1,
+		StartedAt:         outcome.Started.Format(time.RFC3339Nano),
+		CompletedAt:       outcome.Completed.Format(time.RFC3339Nano),
+		ClaudeStatus:      executorStatus(outcome.RunResult, outcome.RunErr),
+		SupervisorVerdict: "not_reviewed",
+		Summary:           message,
+		Error: &task.AttemptError{
+			Phase:       "executor",
+			Kind:        interruptionKind(outcome),
+			Message:     message,
+			ArtifactDir: attemptDir,
+		},
+	})
+	loaded.Verification.Commands = append(loaded.Verification.Commands, task.VerificationCommand{
+		Cmd:           executorVerificationCmd(loaded.Executor.CLI),
+		Status:        "failed",
+		OutputExcerpt: fmt.Sprintf("executor interrupted (%s); terminal decision and raw logs captured under %s", outcome.Terminal.Reason, attemptDir),
+	})
+	appendRisk(loaded, "executor-interruption", "external_dependency", message,
+		"Resolve the interruption cause, then run `galley task requeue` to resume from the preserved worktree.", true)
+}
+
+// interruptionMessage renders an operator-facing interruption reason that keeps
+// available provider detail while falling back to a generic reason when the
+// provider exposes none (AC5).
+func interruptionMessage(terminal runner.ExecutorTerminal) string {
+	parts := []string{fmt.Sprintf("Executor interrupted before Supervisor review (reason=%s)", terminal.Reason)}
+	if terminal.RunError != "" {
+		parts = append(parts, fmt.Sprintf("run_error=%s", terminal.RunError))
+	}
+	if terminal.Status != "" {
+		parts = append(parts, fmt.Sprintf("status=%s", terminal.Status))
+	}
+	if terminal.Code != "" {
+		parts = append(parts, fmt.Sprintf("code=%s", terminal.Code))
+	}
+	if terminal.StopReason != "" {
+		parts = append(parts, fmt.Sprintf("stop_reason=%s", terminal.StopReason))
+	}
+	if terminal.SessionID != "" {
+		parts = append(parts, fmt.Sprintf("session_id=%s", terminal.SessionID))
+	}
+	if terminal.Message != "" {
+		parts = append(parts, fmt.Sprintf("detail=%s", terminal.Message))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func appendSupervisorFailureAttempt(loaded *task.Task, outcome attemptOutcome, err error, attemptDir string) {

--- a/internal/daemon/executor_defaults_preflight_test.go
+++ b/internal/daemon/executor_defaults_preflight_test.go
@@ -178,6 +178,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '{"type":"turn.completed","usage":{}}'
     ;;
 esac
 `)
@@ -359,6 +360,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '{"type":"turn.completed","usage":{}}'
     ;;
 esac
 `)
@@ -539,6 +541,7 @@ case "$input" in
   *)
     echo change > daemon-output.txt
     printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '{"type":"turn.completed","usage":{}}'
     ;;
 esac
 `)

--- a/internal/daemon/executor_interruption_test.go
+++ b/internal/daemon/executor_interruption_test.go
@@ -91,10 +91,10 @@ func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
 		{
 			name:         "claude api failure",
 			cli:          "claude",
-			stdout:       `printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"claude-sess"}'` + "\n",
+			stdout:       `printf '%s\n' '{"type":"result","subtype":"success","is_error":true,"api_error_status":529,"terminal_reason":"api_error","stop_reason":"stop_sequence","session_id":"claude-sess","result":"api overloaded"}'` + "\n",
 			wantReason:   "claude_result_error",
 			wantProvider: "claude",
-			wantMessage:  []string{"claude_result_error", "error_during_execution", "claude-sess"},
+			wantMessage:  []string{"claude_result_error", "api_error", "529", "stop_sequence", "claude-sess", "api overloaded"},
 		},
 		{
 			name:         "codex turn.failed with detail",

--- a/internal/daemon/executor_interruption_test.go
+++ b/internal/daemon/executor_interruption_test.go
@@ -1,0 +1,399 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runartifact"
+	"github.com/shinpr/galley/internal/runner"
+	"github.com/shinpr/galley/internal/supervisor"
+	"github.com/shinpr/galley/internal/task"
+)
+
+func countingSupervisor(calls *int32, verdict func(attempt int) supervisor.Verdict) func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error) {
+	return func(_ context.Context, _ Options, _ supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+		n := atomic.AddInt32(calls, 1)
+		return verdict(int(n)), nil
+	}
+}
+
+func withSupervisorSeam(opts Options, seam func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)) Options {
+	deps := opts.daemonDependencies()
+	deps.supervisorRunner = seam
+	opts.dependencies = &deps
+	return opts
+}
+
+// writeRawExecutor writes a fake executor binary that emits exactly body on
+// stdout without the shared happy-path helpers' appended normal-terminal event,
+// so interruption cases control the provider terminal the daemon classifies.
+func writeRawExecutor(t *testing.T, name, body string) string {
+	t.Helper()
+	return writeFakeCommand(t, name, "cat >/dev/null 2>/dev/null || true\n"+body)
+}
+
+func TestInterruptedExecutorBypassesSupervisor(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty worktree", body: "exit 1\n"},
+		{name: "dirty worktree", body: "echo partial > daemon-output.txt\necho scratch > untracked.txt\nexit 1\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), ".agent-workflow")
+			repo := initDaemonGitRepo(t)
+			promptPath, schemaPath := writeDaemonPromptFiles(t)
+			claudeBin := writeFakeClaude(t, tc.body)
+			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeDaemonTask(t, taskPath, repo)
+			setLoopBudget(t, taskPath, 3)
+
+			var supCalls int32
+			opts := testDaemonOptions(Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+			opts = withSupervisorSeam(opts, countingSupervisor(&supCalls, func(int) supervisor.Verdict {
+				t.Errorf("supervisor must not run for an interrupted executor")
+				return supervisor.Verdict{Status: "accepted"}
+			}))
+			_ = Run(context.Background(), opts)
+
+			assertInterruptedFailedTask(t, root, &supCalls)
+		})
+	}
+}
+
+// Each fixture emits its provider terminal and exits 0, so an interruption
+// verdict must come from the terminal, not the process exit code.
+func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
+	const validResult = `{"status":"completed","summary":"done","files_modified":[],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+	cases := []struct {
+		name         string
+		cli          string
+		stdout       string
+		wantReason   string
+		wantProvider string
+		wantMessage  []string
+		notMessage   []string
+	}{
+		{
+			name:         "claude api failure",
+			cli:          "claude",
+			stdout:       `printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"claude-sess"}'` + "\n",
+			wantReason:   "claude_result_error",
+			wantProvider: "claude",
+			wantMessage:  []string{"claude_result_error", "error_during_execution", "claude-sess"},
+		},
+		{
+			name:         "glm api failure",
+			cli:          "glm",
+			stdout:       `printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"glm-sess"}'` + "\n",
+			wantReason:   "claude_result_error",
+			wantProvider: "glm",
+			wantMessage:  []string{"claude_result_error", "error_during_execution", "glm-sess"},
+		},
+		{
+			name:         "codex turn.failed with detail",
+			cli:          "codex",
+			stdout:       `printf '%s\n' '{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}'` + "\n",
+			wantReason:   "codex_turn_failed",
+			wantProvider: "codex",
+			wantMessage:  []string{"codex_turn_failed", "rate_limit", "model overloaded"},
+		},
+		{
+			name:         "codex turn.failed without detail",
+			cli:          "codex",
+			stdout:       `printf '%s\n' '{"type":"turn.failed"}'` + "\n",
+			wantReason:   "codex_turn_failed",
+			wantProvider: "codex",
+			wantMessage:  []string{"codex_turn_failed"},
+			notMessage:   []string{"code=", "detail="},
+		},
+		{
+			name:         "codex turn.failed with unparseable detail",
+			cli:          "codex",
+			stdout:       `printf '%s\n' '{"type":"turn.failed","error":"boom"}'` + "\n",
+			wantReason:   "codex_turn_failed",
+			wantProvider: "codex",
+			wantMessage:  []string{"codex_turn_failed"},
+			notMessage:   []string{"code=", "detail="},
+		},
+		{
+			name:         "grok non-endturn",
+			cli:          "grok",
+			stdout:       `printf '%s\n' '{"text":"partial","stopReason":"MaxTokens","sessionId":"grok-sess"}'` + "\n",
+			wantReason:   "grok_non_end_turn",
+			wantProvider: "grok",
+			wantMessage:  []string{"grok_non_end_turn", "MaxTokens"},
+		},
+		{
+			name:         "grok malformed terminal",
+			cli:          "grok",
+			stdout:       "printf '%s\\n' 'not-json'\n",
+			wantReason:   "malformed_provider_terminal",
+			wantProvider: "grok",
+			wantMessage:  []string{"malformed_provider_terminal"},
+		},
+		{
+			name:         "unknown interruption without terminal",
+			cli:          "claude",
+			stdout:       `echo change > daemon-output.txt` + "\n" + `printf '%s\n' '` + validResult + `'` + "\n",
+			wantReason:   "no_normal_terminal",
+			wantProvider: "claude",
+			wantMessage:  []string{"no_normal_terminal"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), ".agent-workflow")
+			repo := initDaemonGitRepo(t)
+			promptPath, schemaPath := writeDaemonPromptFiles(t)
+			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeDaemonTask(t, taskPath, repo)
+			setExecutorCLI(t, taskPath, tc.cli)
+			setLoopBudget(t, taskPath, 2)
+
+			opts := Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude"}
+			switch tc.cli {
+			case "codex":
+				opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
+				opts.CodexBin = writeRawExecutor(t, "codex", tc.stdout)
+			case "grok":
+				opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
+				opts.GrokBin = writeRawExecutor(t, "grok", tc.stdout)
+			case "glm":
+				opts.ClaudeBin = writeRawExecutor(t, "claude", tc.stdout)
+				opts.GLMAuthToken = "test-glm-token"
+			default:
+				opts.ClaudeBin = writeRawExecutor(t, "claude", tc.stdout)
+			}
+
+			var supCalls int32
+			opts = testDaemonOptions(opts)
+			opts = withSupervisorSeam(opts, countingSupervisor(&supCalls, func(int) supervisor.Verdict {
+				t.Errorf("supervisor must not run for a %s interruption", tc.name)
+				return supervisor.Verdict{Status: "accepted"}
+			}))
+			_ = Run(context.Background(), opts)
+
+			failed := assertInterruptedFailedTask(t, root, &supCalls)
+			last := failed.Attempts[len(failed.Attempts)-1]
+			if last.Error.Kind != "executor_interrupted" {
+				t.Fatalf("error kind = %q, want executor_interrupted", last.Error.Kind)
+			}
+			for _, want := range tc.wantMessage {
+				if !strings.Contains(last.Error.Message, want) {
+					t.Fatalf("attempt error message missing %q: %q", want, last.Error.Message)
+				}
+			}
+			for _, unwanted := range tc.notMessage {
+				if strings.Contains(last.Error.Message, unwanted) {
+					t.Fatalf("attempt error message must not contain %q: %q", unwanted, last.Error.Message)
+				}
+			}
+			// task show consumes these fields to render the interruption and
+			// requeue recovery (see cli.isExecutorInterruption).
+			if last.Error.Phase != "executor" || last.SupervisorVerdict != "not_reviewed" || last.Error.ArtifactDir == "" {
+				t.Fatalf("task-show fields incomplete: %#v", last.Error)
+			}
+			terminalData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename))
+			var terminal runner.ExecutorTerminal
+			if err := json.Unmarshal(terminalData, &terminal); err != nil {
+				t.Fatalf("decode executor_terminal.json: %v", err)
+			}
+			if terminal.Normal {
+				t.Fatalf("executor_terminal.json Normal = true, want interrupted: %s", terminalData)
+			}
+			if terminal.Reason != tc.wantReason {
+				t.Fatalf("executor_terminal.json reason = %q, want %q", terminal.Reason, tc.wantReason)
+			}
+			if terminal.Provider != tc.wantProvider {
+				t.Fatalf("executor_terminal.json provider = %q, want %q", terminal.Provider, tc.wantProvider)
+			}
+			for _, want := range tc.wantMessage {
+				if !strings.Contains(string(terminalData), want) {
+					t.Fatalf("executor_terminal.json missing detail %q: %s", want, terminalData)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalTerminalInvalidResultStillReviewedAndRetried(t *testing.T) {
+	claudeBin := writeFakeClaude(t, `echo change > daemon-output.txt
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"not-valid-json","session_id":"sess-ac2"}'`+"\n")
+	assertInvalidResultReviewedAndRetried(t, "claude", claudeBin, "")
+}
+
+func TestGrokEndTurnInvalidResultStillReviewedAndRetried(t *testing.T) {
+	grokBin := writeRawExecutor(t, "grok", `echo change > grok-output.txt
+printf '%s\n' '{"text":"garbage not a result","stopReason":"EndTurn","sessionId":"grok-ac2"}'`+"\n")
+	claudeBin := writeFakeClaude(t, "exit 1\n")
+	assertInvalidResultReviewedAndRetried(t, "grok", claudeBin, grokBin)
+}
+
+func TestInterruptionPreservesWorkspaceAndRequeueReuses(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	// README.md is committed by initDaemonGitRepo; new-file.txt is untracked.
+	claudeBin := writeFakeClaude(t, "echo changed >> README.md\necho created > new-file.txt\nexit 1\n")
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+
+	opts := testDaemonOptions(Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+	_ = Run(context.Background(), opts)
+
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	failed, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+
+	statusData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.GitStatusFilename))
+	if !strings.Contains(string(statusData), "README.md") || !strings.Contains(string(statusData), "new-file.txt") {
+		t.Fatalf("git status evidence missing changes: %s", statusData)
+	}
+
+	worktree := taskWorktreePath(repo, failed.Worktree.Path)
+	if data, err := os.ReadFile(filepath.Join(worktree, "new-file.txt")); err != nil || !strings.Contains(string(data), "created") {
+		t.Fatalf("untracked change not retained in worktree: %v %q", err, data)
+	}
+	if data, err := os.ReadFile(filepath.Join(worktree, "README.md")); err != nil || !strings.Contains(string(data), "changed") {
+		t.Fatalf("tracked change not retained in worktree: %v %q", err, data)
+	}
+
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root, Reason: "resolved interruption"}); err != nil {
+		t.Fatalf("requeue: %v", err)
+	}
+	_ = Run(context.Background(), opts)
+
+	reuseFound := false
+	workspaces, _ := filepath.Glob(filepath.Join(root, "runs", "*", runartifact.WorkspaceFilename))
+	for _, path := range workspaces {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var prepared struct {
+			WorktreeReused  bool   `json:"worktree_reused"`
+			Dirty           bool   `json:"dirty"`
+			StatusPorcelain string `json:"status_porcelain"`
+		}
+		if err := json.Unmarshal(data, &prepared); err != nil {
+			continue
+		}
+		if prepared.WorktreeReused {
+			reuseFound = true
+			if !prepared.Dirty {
+				t.Fatalf("reused worktree evidence must be dirty: %s", data)
+			}
+			if !strings.Contains(prepared.StatusPorcelain, "new-file.txt") {
+				t.Fatalf("reused worktree must still show retained change: %s", data)
+			}
+		}
+	}
+	if !reuseFound {
+		t.Fatal("no reused-worktree evidence found after requeue")
+	}
+}
+
+func assertInterruptedFailedTask(t *testing.T, root string, supCalls *int32) task.Task {
+	t.Helper()
+	if got := atomic.LoadInt32(supCalls); got != 0 {
+		t.Fatalf("supervisor calls = %d, want 0", got)
+	}
+	failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+	if failed.Status != "failed" {
+		t.Fatalf("status = %q, want failed", failed.Status)
+	}
+	if len(failed.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want exactly 1 (%#v)", len(failed.Attempts), failed.Attempts)
+	}
+	only := failed.Attempts[0]
+	if only.SupervisorVerdict != "not_reviewed" {
+		t.Fatalf("supervisor_verdict = %q, want not_reviewed", only.SupervisorVerdict)
+	}
+	if only.Error == nil || only.Error.Phase != "executor" {
+		t.Fatalf("attempt error = %#v, want executor phase", only.Error)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename), 1)
+	if matches, _ := filepath.Glob(filepath.Join(root, "runs", "*", "attempt-2")); len(matches) != 0 {
+		t.Fatalf("attempt-2 must not exist: %v", matches)
+	}
+	return failed
+}
+
+func assertInvalidResultReviewedAndRetried(t *testing.T, cli, claudeBin, executorBin string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setExecutorCLI(t, taskPath, cli)
+	setLoopBudget(t, taskPath, 3)
+
+	opts := Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin}
+	if cli == "grok" {
+		opts.GrokBin = executorBin
+	}
+
+	var supCalls int32
+	opts = testDaemonOptions(opts)
+	opts = withSupervisorSeam(opts, countingSupervisor(&supCalls, func(attempt int) supervisor.Verdict {
+		if attempt == 1 {
+			return supervisor.Verdict{Status: "needs_revision", Summary: "fix invalid result", NextWorkOrder: "Return valid structured JSON."}
+		}
+		return supervisor.Verdict{Status: "accepted", Summary: "accepted after revision"}
+	}))
+	if err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&supCalls); got != 2 {
+		t.Fatalf("supervisor calls = %d, want 2 (invalid result reviewed and needs_revision retried)", got)
+	}
+	done, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("done task missing: %v", err)
+	}
+	if done.Status != "accepted" {
+		t.Fatalf("status = %q, want accepted", done.Status)
+	}
+	if len(done.Attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(done.Attempts))
+	}
+}
+
+func setExecutorCLI(t *testing.T, taskPath, cli string) {
+	t.Helper()
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.CLI = cli
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/daemon/executor_interruption_test.go
+++ b/internal/daemon/executor_interruption_test.go
@@ -3,16 +3,19 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/shinpr/galley/internal/executorflow"
 	"github.com/shinpr/galley/internal/runartifact"
 	"github.com/shinpr/galley/internal/runner"
 	"github.com/shinpr/galley/internal/supervisor"
 	"github.com/shinpr/galley/internal/task"
+	"github.com/shinpr/galley/internal/workspace"
 )
 
 func countingSupervisor(calls *int32, verdict func(attempt int) supervisor.Verdict) func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error) {
@@ -71,10 +74,11 @@ func TestInterruptedExecutorBypassesSupervisor(t *testing.T) {
 	}
 }
 
-// Each fixture emits its provider terminal and exits 0, so an interruption
-// verdict must come from the terminal, not the process exit code.
+// Representative provider wiring across the Claude, Codex, and Grok transports;
+// the exhaustive classification matrix lives in internal/runner/terminal_test.go.
+// Each fixture exits 0, so an interruption must come from the provider terminal,
+// not the exit code.
 func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
-	const validResult = `{"status":"completed","summary":"done","files_modified":[],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
 	cases := []struct {
 		name         string
 		cli          string
@@ -93,14 +97,6 @@ func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
 			wantMessage:  []string{"claude_result_error", "error_during_execution", "claude-sess"},
 		},
 		{
-			name:         "glm api failure",
-			cli:          "glm",
-			stdout:       `printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"glm-sess"}'` + "\n",
-			wantReason:   "claude_result_error",
-			wantProvider: "glm",
-			wantMessage:  []string{"claude_result_error", "error_during_execution", "glm-sess"},
-		},
-		{
 			name:         "codex turn.failed with detail",
 			cli:          "codex",
 			stdout:       `printf '%s\n' '{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}'` + "\n",
@@ -109,46 +105,12 @@ func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
 			wantMessage:  []string{"codex_turn_failed", "rate_limit", "model overloaded"},
 		},
 		{
-			name:         "codex turn.failed without detail",
-			cli:          "codex",
-			stdout:       `printf '%s\n' '{"type":"turn.failed"}'` + "\n",
-			wantReason:   "codex_turn_failed",
-			wantProvider: "codex",
-			wantMessage:  []string{"codex_turn_failed"},
-			notMessage:   []string{"code=", "detail="},
-		},
-		{
-			name:         "codex turn.failed with unparseable detail",
-			cli:          "codex",
-			stdout:       `printf '%s\n' '{"type":"turn.failed","error":"boom"}'` + "\n",
-			wantReason:   "codex_turn_failed",
-			wantProvider: "codex",
-			wantMessage:  []string{"codex_turn_failed"},
-			notMessage:   []string{"code=", "detail="},
-		},
-		{
 			name:         "grok non-endturn",
 			cli:          "grok",
 			stdout:       `printf '%s\n' '{"text":"partial","stopReason":"MaxTokens","sessionId":"grok-sess"}'` + "\n",
 			wantReason:   "grok_non_end_turn",
 			wantProvider: "grok",
 			wantMessage:  []string{"grok_non_end_turn", "MaxTokens"},
-		},
-		{
-			name:         "grok malformed terminal",
-			cli:          "grok",
-			stdout:       "printf '%s\\n' 'not-json'\n",
-			wantReason:   "malformed_provider_terminal",
-			wantProvider: "grok",
-			wantMessage:  []string{"malformed_provider_terminal"},
-		},
-		{
-			name:         "unknown interruption without terminal",
-			cli:          "claude",
-			stdout:       `echo change > daemon-output.txt` + "\n" + `printf '%s\n' '` + validResult + `'` + "\n",
-			wantReason:   "no_normal_terminal",
-			wantProvider: "claude",
-			wantMessage:  []string{"no_normal_terminal"},
 		},
 	}
 	for _, tc := range cases {
@@ -227,6 +189,133 @@ func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInterruptedExecutorStagingFailureStaysInterrupted(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	claudeBin := writeRawExecutor(t, "claude", "echo partial > daemon-output.txt\n"+
+		`printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"stage-sess"}'`+"\n")
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	stageFail := func(_ context.Context, _ Options, _, _ string, _ []string) error {
+		return context.Canceled
+	}
+	var supCalls int32
+	opts := testDaemonOptions(Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+	deps := opts.daemonDependencies()
+	deps.stageExecutorOutput = stageFail
+	deps.supervisorRunner = countingSupervisor(&supCalls, func(int) supervisor.Verdict {
+		t.Errorf("supervisor must not run for an interrupted executor")
+		return supervisor.Verdict{Status: "accepted"}
+	})
+	opts.dependencies = &deps
+	_ = Run(context.Background(), opts)
+
+	failed := assertInterruptedFailedTask(t, root, &supCalls)
+	last := failed.Attempts[len(failed.Attempts)-1]
+	if last.Error.Kind != "executor_interrupted" {
+		t.Fatalf("error kind = %q, want executor_interrupted (staging failure must not override interruption)", last.Error.Kind)
+	}
+	if last.Error.Phase != "executor" {
+		t.Fatalf("error phase = %q, want executor", last.Error.Phase)
+	}
+	foundEvidenceRisk := false
+	for _, r := range failed.Risks {
+		if strings.HasPrefix(r.ID, "executor-interruption-evidence") {
+			foundEvidenceRisk = true
+		}
+	}
+	if !foundEvidenceRisk {
+		t.Fatalf("expected secondary staging-failure risk, got risks: %#v", failed.Risks)
+	}
+}
+
+// CaptureDiffArtifacts reports a snapshot/diff failure in-band as
+// DiffArtifacts.Err with a nil function error (distinct from a staging or
+// artifact-write error). The interrupted path must promote that into the
+// secondary-evidence risk while the interruption stays primary and requeueable.
+func TestInterruptedExecutorDiffCaptureFailureStaysInterrupted(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	claudeBin := writeRawExecutor(t, "claude", "echo changed >> README.md\necho created > new-file.txt\n"+
+		`printf '%s\n' '{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"diff-sess"}'`+"\n")
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setLoopBudget(t, taskPath, 3)
+
+	diffFail := func(_ context.Context, _, _, _ string, _ workspace.Options) (executorflow.DiffArtifacts, error) {
+		return executorflow.DiffArtifacts{Err: errors.New("git status: snapshot failed")}, nil
+	}
+	var supCalls int32
+	opts := testDaemonOptions(Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+	deps := opts.daemonDependencies()
+	deps.captureDiffArtifacts = diffFail
+	deps.supervisorRunner = countingSupervisor(&supCalls, func(int) supervisor.Verdict {
+		t.Errorf("supervisor must not run for an interrupted executor")
+		return supervisor.Verdict{Status: "accepted"}
+	})
+	opts.dependencies = &deps
+	_ = Run(context.Background(), opts)
+
+	failed := assertInterruptedFailedTask(t, root, &supCalls)
+	last := failed.Attempts[len(failed.Attempts)-1]
+	if last.Error.Kind != "executor_interrupted" {
+		t.Fatalf("error kind = %q, want executor_interrupted (diff-capture failure must not override interruption)", last.Error.Kind)
+	}
+	foundEvidenceRisk := false
+	for _, r := range failed.Risks {
+		if strings.HasPrefix(r.ID, "executor-interruption-evidence") && strings.Contains(r.Detail, "snapshot failed") {
+			foundEvidenceRisk = true
+		}
+	}
+	if !foundEvidenceRisk {
+		t.Fatalf("expected secondary diff-capture-failure risk, got risks: %#v", failed.Risks)
+	}
+
+	worktree := taskWorktreePath(repo, failed.Worktree.Path)
+	if data, err := os.ReadFile(filepath.Join(worktree, "new-file.txt")); err != nil || !strings.Contains(string(data), "created") {
+		t.Fatalf("untracked change not retained in worktree: %v %q", err, data)
+	}
+
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root, Reason: "resolved interruption"}); err != nil {
+		t.Fatalf("requeue: %v", err)
+	}
+	rerun := testDaemonOptions(Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: claudeBin})
+	_ = Run(context.Background(), rerun)
+
+	reuseFound := false
+	workspaces, _ := filepath.Glob(filepath.Join(root, "runs", "*", runartifact.WorkspaceFilename))
+	for _, path := range workspaces {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var prepared struct {
+			WorktreeReused  bool   `json:"worktree_reused"`
+			StatusPorcelain string `json:"status_porcelain"`
+		}
+		if err := json.Unmarshal(data, &prepared); err != nil {
+			continue
+		}
+		if prepared.WorktreeReused && strings.Contains(prepared.StatusPorcelain, "new-file.txt") {
+			reuseFound = true
+		}
+	}
+	if !reuseFound {
+		t.Fatal("no reused-worktree evidence with retained change found after requeue")
 	}
 }
 

--- a/internal/daemon/executor_result_resolver.go
+++ b/internal/daemon/executor_result_resolver.go
@@ -57,11 +57,10 @@ func resolveExecutorResult(cli, stdoutPath, stdoutTail, lastMessagePath string) 
 	return runner.ExecutorResult{}, errors.Join(resultErrs...)
 }
 
-// classifyExecutorTerminal derives the single routing decision for one executor
-// exit from runner state and the machine-readable provider output. It reads the
-// captured stdout (falling back to the in-memory tail) and, for Codex, the
-// captured final message. The decision never depends on the process exit code
-// or human-language error text alone (acceptance criterion AC1, decision D1).
+// classifyExecutorTerminal derives one routing decision per executor exit from
+// runner state plus machine-readable provider output, reading captured stdout
+// with an in-memory tail fallback. Process exit code or human-language error
+// text alone never decides routing.
 func classifyExecutorTerminal(cli, stdoutPath, stdoutTail string, runErr error) runner.ExecutorTerminal {
 	switch cli {
 	case "grok":

--- a/internal/daemon/executor_result_resolver.go
+++ b/internal/daemon/executor_result_resolver.go
@@ -56,3 +56,36 @@ func resolveExecutorResult(cli, stdoutPath, stdoutTail, lastMessagePath string) 
 	)
 	return runner.ExecutorResult{}, errors.Join(resultErrs...)
 }
+
+// classifyExecutorTerminal derives the single routing decision for one executor
+// exit from runner state and the machine-readable provider output. It reads the
+// captured stdout (falling back to the in-memory tail) and, for Codex, the
+// captured final message. The decision never depends on the process exit code
+// or human-language error text alone (acceptance criterion AC1, decision D1).
+func classifyExecutorTerminal(cli, stdoutPath, stdoutTail string, runErr error) runner.ExecutorTerminal {
+	switch cli {
+	case "grok":
+		data, err := os.ReadFile(stdoutPath)
+		if err != nil {
+			data = []byte(stdoutTail)
+		}
+		return runner.GrokTerminal(data, runErr)
+	case "codex":
+		return runner.CodexTerminal(readExecutorStdout(stdoutPath, stdoutTail), runErr)
+	default:
+		// cli is "claude", "glm", or empty (defaulting to claude); GLM shares
+		// Claude's transport but keeps its own provider identity in evidence.
+		provider := cli
+		if provider == "" {
+			provider = "claude"
+		}
+		return runner.ClaudeTerminal(provider, readExecutorStdout(stdoutPath, stdoutTail), runErr)
+	}
+}
+
+func readExecutorStdout(stdoutPath, stdoutTail string) []byte {
+	if data, err := os.ReadFile(stdoutPath); err == nil {
+		return data
+	}
+	return []byte(stdoutTail)
+}

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -282,7 +282,7 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 	// A provider or runtime interruption never reaches Supervisor and never
 	// starts another executor attempt in this run. The attempt evidence and the
 	// dirty worktree are already captured, so publishing to tasks/failed
-	// preserves the partial work for `galley task requeue` (AC3, AC4).
+	// preserves the partial work for `galley task requeue`.
 	if outcome.Terminal.Interrupted() {
 		appendExecutorInterruptionAttempt(req.Loaded, outcome, attemptDir)
 		return attemptReview{}, &executorInterruptionError{terminal: outcome.Terminal}

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -174,6 +174,9 @@ func runSupervisorLoop(ctx, shutdownCtx context.Context, opts Options, runningPa
 			if idle, ok := asSupervisorIdleTimeout(err); ok {
 				fmt.Fprintln(os.Stderr, idle.logLine(loaded.ID))
 			}
+			if interruption, ok := asExecutorInterruptionError(err); ok {
+				fmt.Fprintf(os.Stderr, "galley: task %s executor interrupted (%s) before Supervisor review; preserving worktree for requeue\n", loaded.ID, interruption.terminal.Reason)
+			}
 			return taskstate.FailMoveToStatus(opts.Root, runningPath, loaded, err)
 		}
 		mergeAttemptEvidence(loaded, review.Outcome, runID, prepared.CWD, review.AttemptDir)
@@ -275,6 +278,14 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 		}
 		appendFailureAttempt(req.Loaded, "executor", classifyFailureKind("executor_failed", err), err, attemptDir)
 		return attemptReview{}, err
+	}
+	// A provider or runtime interruption never reaches Supervisor and never
+	// starts another executor attempt in this run. The attempt evidence and the
+	// dirty worktree are already captured, so publishing to tasks/failed
+	// preserves the partial work for `galley task requeue` (AC3, AC4).
+	if outcome.Terminal.Interrupted() {
+		appendExecutorInterruptionAttempt(req.Loaded, outcome, attemptDir)
+		return attemptReview{}, &executorInterruptionError{terminal: outcome.Terminal}
 	}
 	setupResultEvidence, setupUpdateEvidence := setuppreflight.LoadRunEvidence(req.RunDir, req.RunID)
 	evidence := supervisor.Evidence{

--- a/internal/runartifact/artifact.go
+++ b/internal/runartifact/artifact.go
@@ -38,6 +38,9 @@ const (
 	RunResultFilename              = "run_result.json"
 	CommandPlanFilename            = "command_plan.json"
 	GrokCompletionMetadataFilename = "grok_completion.json"
+	// ExecutorTerminalFilename records the normal-terminal versus interruption
+	// routing decision Galley derived from runner state and provider output.
+	ExecutorTerminalFilename       = "executor_terminal.json"
 	SupervisorVerdictFilename      = "supervisor_verdict.json"
 	ModelSupervisorVerdictFilename = "model_supervisor_verdict.json"
 	SupervisorErrorFilename        = "supervisor_error.json"

--- a/internal/runner/terminal.go
+++ b/internal/runner/terminal.go
@@ -1,0 +1,239 @@
+package runner
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+)
+
+// ExecutorTerminal is Galley's routing decision for one executor process exit.
+//
+// Normal reports whether the runner itself succeeded and the provider emitted a
+// reliable normal terminal. When Normal is false the attempt was interrupted
+// and must bypass Supervisor review. Reason is a stable machine code used for
+// routing and diagnosis; the remaining provider detail fields are retained for
+// diagnosis only and never determine routing (prior decision D3).
+type ExecutorTerminal struct {
+	Normal     bool   `json:"normal"`
+	Reason     string `json:"reason"`
+	Provider   string `json:"provider,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Code       string `json:"code,omitempty"`
+	StopReason string `json:"stop_reason,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
+	Message    string `json:"message,omitempty"`
+	RunError   string `json:"run_error,omitempty"`
+}
+
+// Interrupted reports whether the attempt was interrupted rather than reaching a
+// normal provider terminal.
+func (t ExecutorTerminal) Interrupted() bool { return !t.Normal }
+
+// Terminal reason codes. Normal terminals establish that Supervisor may review
+// the attempt; interruption reasons establish that it must not.
+const (
+	// Normal terminals.
+	TerminalReasonClaudeResultSuccess = "claude_result_success"
+	TerminalReasonCodexTurnCompleted  = "codex_turn_completed"
+	TerminalReasonGrokEndTurn         = "grok_end_turn"
+
+	// Provider interruptions (runner succeeded, provider reported a non-normal
+	// terminal or produced no reliable one).
+	TerminalReasonClaudeResultError = "claude_result_error"
+	TerminalReasonCodexTurnFailed   = "codex_turn_failed"
+	TerminalReasonGrokNonEndTurn    = "grok_non_end_turn"
+	TerminalReasonMalformedTerminal = "malformed_provider_terminal"
+	TerminalReasonNoNormalTerminal  = "no_normal_terminal"
+
+	// Runner interruptions (the executor process never produced a reliable
+	// terminal).
+	TerminalReasonRunnerStartFailed = "runner_start_failed"
+	TerminalReasonRunnerTimeout     = "runner_timeout"
+	TerminalReasonRunnerIdleTimeout = "runner_idle_timeout"
+	TerminalReasonRunnerKilled      = "runner_killed"
+	TerminalReasonRunnerExitNonZero = "runner_exit_nonzero"
+)
+
+// runnerInterruption classifies a runner-state failure. Start failures,
+// timeouts, and kills guarantee that no reliable provider terminal exists, so
+// they resolve to an interruption before any provider output is inspected.
+func runnerInterruption(provider string, runErr error) ExecutorTerminal {
+	t := ExecutorTerminal{Provider: provider, RunError: runErr.Error()}
+	switch {
+	case errors.Is(runErr, ErrIdleTimeout):
+		t.Reason = TerminalReasonRunnerIdleTimeout
+	case errors.Is(runErr, ErrTimeout):
+		t.Reason = TerminalReasonRunnerTimeout
+	case errors.Is(runErr, ErrKilled):
+		t.Reason = TerminalReasonRunnerKilled
+	default:
+		var cmdErr *CommandError
+		if errors.As(runErr, &cmdErr) && cmdErr.Kind == CommandErrorStart {
+			t.Reason = TerminalReasonRunnerStartFailed
+		} else {
+			t.Reason = TerminalReasonRunnerExitNonZero
+		}
+	}
+	return t
+}
+
+// ClaudeTerminal classifies a Claude (or GLM, which shares Claude's transport)
+// executor exit from its stream-json stdout and runner error. provider carries
+// the actual executor identity ("claude" or "glm") so interruption evidence
+// names the executor that ran rather than the shared transport.
+func ClaudeTerminal(provider string, stdout []byte, runErr error) ExecutorTerminal {
+	if runErr != nil {
+		return runnerInterruption(provider, runErr)
+	}
+	return scanClaudeStream(provider, stdout)
+}
+
+type claudeResultEvent struct {
+	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype"`
+	IsError   bool            `json:"is_error"`
+	Result    json.RawMessage `json:"result"`
+	SessionID string          `json:"session_id"`
+}
+
+func scanClaudeStream(provider string, stdout []byte) ExecutorTerminal {
+	var result *claudeResultEvent
+	forEachLine(stdout, func(line string) {
+		var ev claudeResultEvent
+		if err := json.Unmarshal([]byte(line), &ev); err == nil && ev.Type == "result" {
+			captured := ev
+			result = &captured
+		}
+	})
+	if result == nil {
+		return ExecutorTerminal{Provider: provider, Reason: TerminalReasonNoNormalTerminal}
+	}
+	t := ExecutorTerminal{Provider: provider, Status: result.Subtype, SessionID: result.SessionID}
+	// Normal completion requires the explicit success result event; a missing or
+	// unknown subtype is an interruption so unreliable terminals never route to
+	// Supervisor (AC1).
+	if !result.IsError && result.Subtype == "success" {
+		t.Normal = true
+		t.Reason = TerminalReasonClaudeResultSuccess
+		return t
+	}
+	t.Reason = TerminalReasonClaudeResultError
+	t.Message = claudeResultMessage(result.Result)
+	return t
+}
+
+func claudeResultMessage(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text
+	}
+	return string(raw)
+}
+
+// CodexTerminal classifies a Codex executor exit from its JSONL stdout and the
+// runner error. Normal completion is established only by a `turn.completed`
+// event; any other stream (including a final message without that event) is an
+// interruption (AC1).
+func CodexTerminal(stdout []byte, runErr error) ExecutorTerminal {
+	if runErr != nil {
+		return runnerInterruption("codex", runErr)
+	}
+	var terminalLine string
+	var terminalType string
+	forEachLine(stdout, func(line string) {
+		var head codexTypeEvent
+		if err := json.Unmarshal([]byte(line), &head); err != nil {
+			return
+		}
+		if head.Type == "turn.completed" || head.Type == "turn.failed" {
+			terminalLine = line
+			terminalType = head.Type
+		}
+	})
+	if terminalType == "" {
+		return ExecutorTerminal{Provider: "codex", Reason: TerminalReasonNoNormalTerminal}
+	}
+	if terminalType == "turn.failed" {
+		t := ExecutorTerminal{Provider: "codex", Reason: TerminalReasonCodexTurnFailed}
+		// Decode nested detail best-effort. A missing or unparseable error field
+		// keeps the turn.failed routing and falls back to a generic reason (AC5).
+		var detailed codexTerminalEvent
+		if err := json.Unmarshal([]byte(terminalLine), &detailed); err == nil && detailed.Error != nil {
+			t.Code = detailed.Error.Code
+			t.Message = detailed.Error.Message
+		}
+		return t
+	}
+	return ExecutorTerminal{Normal: true, Provider: "codex", Reason: TerminalReasonCodexTurnCompleted}
+}
+
+type codexTypeEvent struct {
+	Type string `json:"type"`
+}
+
+type codexTerminalEvent struct {
+	Error *struct {
+		Message string `json:"message"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+// GrokTerminal classifies a Grok executor exit from its JSON envelope and the
+// runner error. The normal terminal is a parseable envelope whose stopReason is
+// `EndTurn`; the session ID and result payload are optional diagnostic detail
+// and never gate routing (AC1, D3). Every other stopReason or an unparseable
+// envelope is an interruption.
+func GrokTerminal(data []byte, runErr error) ExecutorTerminal {
+	if runErr != nil {
+		return runnerInterruption("grok", runErr)
+	}
+	var envelope grokTerminalEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return ExecutorTerminal{Provider: "grok", Reason: TerminalReasonMalformedTerminal, Message: err.Error()}
+	}
+	if strings.TrimSpace(envelope.StopReason) == "" {
+		return ExecutorTerminal{Provider: "grok", Reason: TerminalReasonMalformedTerminal, Message: "grok envelope has no stopReason"}
+	}
+	t := ExecutorTerminal{Provider: "grok", StopReason: envelope.StopReason, SessionID: envelope.SessionID}
+	if envelope.StopReason != "EndTurn" {
+		t.Reason = TerminalReasonGrokNonEndTurn
+		return t
+	}
+	t.Normal = true
+	t.Reason = TerminalReasonGrokEndTurn
+	return t
+}
+
+// grokTerminalEnvelope decodes only the fields the terminal decision reads. It
+// is deliberately more lenient than ParseGrokEnvelope, which also enforces the
+// executor-result contract (sessionId and a result payload) unrelated to
+// routing.
+type grokTerminalEnvelope struct {
+	StopReason string `json:"stopReason"`
+	SessionID  string `json:"sessionId"`
+}
+
+// forEachLine calls fn for every non-empty trimmed line. It uses a growing
+// reader rather than bufio.Scanner so provider result lines that embed large
+// JSON payloads are not silently truncated at the scanner token limit.
+func forEachLine(data []byte, fn func(line string)) {
+	reader := bufio.NewReader(bytes.NewReader(data))
+	for {
+		line, err := reader.ReadString('\n')
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			fn(trimmed)
+		}
+		if err != nil {
+			if err != io.EOF {
+				return
+			}
+			return
+		}
+	}
+}

--- a/internal/runner/terminal.go
+++ b/internal/runner/terminal.go
@@ -15,7 +15,7 @@ import (
 // reliable normal terminal. When Normal is false the attempt was interrupted
 // and must bypass Supervisor review. Reason is a stable machine code used for
 // routing and diagnosis; the remaining provider detail fields are retained for
-// diagnosis only and never determine routing (prior decision D3).
+// diagnosis only and never determine routing.
 type ExecutorTerminal struct {
 	Normal     bool   `json:"normal"`
 	Reason     string `json:"reason"`
@@ -80,13 +80,35 @@ func runnerInterruption(provider string, runErr error) ExecutorTerminal {
 	return t
 }
 
+// mergeRunnerInterruption keeps runner-failure interruption routing while
+// retaining any provider terminal detail parsed from the same exit for
+// diagnosis. A provider success or an absent/malformed terminal never flips
+// routing or masks the runner error reason.
+func mergeRunnerInterruption(runnerTerm, providerTerm ExecutorTerminal) ExecutorTerminal {
+	switch providerTerm.Reason {
+	case "", TerminalReasonNoNormalTerminal, TerminalReasonMalformedTerminal:
+		return runnerTerm
+	}
+	runnerTerm.Status = providerTerm.Status
+	runnerTerm.Code = providerTerm.Code
+	runnerTerm.StopReason = providerTerm.StopReason
+	runnerTerm.SessionID = providerTerm.SessionID
+	if providerTerm.Message != "" {
+		runnerTerm.Message = providerTerm.Message
+	}
+	if !providerTerm.Normal {
+		runnerTerm.Reason = providerTerm.Reason
+	}
+	return runnerTerm
+}
+
 // ClaudeTerminal classifies a Claude (or GLM, which shares Claude's transport)
 // executor exit from its stream-json stdout and runner error. provider carries
 // the actual executor identity ("claude" or "glm") so interruption evidence
 // names the executor that ran rather than the shared transport.
 func ClaudeTerminal(provider string, stdout []byte, runErr error) ExecutorTerminal {
 	if runErr != nil {
-		return runnerInterruption(provider, runErr)
+		return mergeRunnerInterruption(runnerInterruption(provider, runErr), scanClaudeStream(provider, stdout))
 	}
 	return scanClaudeStream(provider, stdout)
 }
@@ -100,29 +122,36 @@ type claudeResultEvent struct {
 }
 
 func scanClaudeStream(provider string, stdout []byte) ExecutorTerminal {
-	var result *claudeResultEvent
+	var success *claudeResultEvent
+	var failure *claudeResultEvent
 	forEachLine(stdout, func(line string) {
 		var ev claudeResultEvent
 		if err := json.Unmarshal([]byte(line), &ev); err == nil && ev.Type == "result" {
 			captured := ev
-			result = &captured
+			if !captured.IsError && captured.Subtype == "success" {
+				success = &captured
+			} else {
+				failure = &captured
+			}
 		}
 	})
-	if result == nil {
-		return ExecutorTerminal{Provider: provider, Reason: TerminalReasonNoNormalTerminal}
+	// An explicit failure result wins over any later success event, so a normal
+	// terminal never masks an earlier provider failure; a missing or unknown
+	// subtype also stays an interruption so unreliable terminals never reach
+	// Supervisor.
+	if failure != nil {
+		return ExecutorTerminal{
+			Provider:  provider,
+			Reason:    TerminalReasonClaudeResultError,
+			Status:    failure.Subtype,
+			SessionID: failure.SessionID,
+			Message:   claudeResultMessage(failure.Result),
+		}
 	}
-	t := ExecutorTerminal{Provider: provider, Status: result.Subtype, SessionID: result.SessionID}
-	// Normal completion requires the explicit success result event; a missing or
-	// unknown subtype is an interruption so unreliable terminals never route to
-	// Supervisor (AC1).
-	if !result.IsError && result.Subtype == "success" {
-		t.Normal = true
-		t.Reason = TerminalReasonClaudeResultSuccess
-		return t
+	if success != nil {
+		return ExecutorTerminal{Provider: provider, Normal: true, Reason: TerminalReasonClaudeResultSuccess, Status: success.Subtype, SessionID: success.SessionID}
 	}
-	t.Reason = TerminalReasonClaudeResultError
-	t.Message = claudeResultMessage(result.Result)
-	return t
+	return ExecutorTerminal{Provider: provider, Reason: TerminalReasonNoNormalTerminal}
 }
 
 func claudeResultMessage(raw json.RawMessage) string {
@@ -137,40 +166,49 @@ func claudeResultMessage(raw json.RawMessage) string {
 }
 
 // CodexTerminal classifies a Codex executor exit from its JSONL stdout and the
-// runner error. Normal completion is established only by a `turn.completed`
-// event; any other stream (including a final message without that event) is an
-// interruption (AC1).
+// runner error. Only a `turn.completed` event establishes normal completion;
+// any other stream, including a final message without that event, is an
+// interruption.
 func CodexTerminal(stdout []byte, runErr error) ExecutorTerminal {
 	if runErr != nil {
-		return runnerInterruption("codex", runErr)
+		return mergeRunnerInterruption(runnerInterruption("codex", runErr), scanCodexStream(stdout))
 	}
-	var terminalLine string
-	var terminalType string
+	return scanCodexStream(stdout)
+}
+
+func scanCodexStream(stdout []byte) ExecutorTerminal {
+	var failedLine string
+	var sawFailed, sawCompleted bool
 	forEachLine(stdout, func(line string) {
 		var head codexTypeEvent
 		if err := json.Unmarshal([]byte(line), &head); err != nil {
 			return
 		}
-		if head.Type == "turn.completed" || head.Type == "turn.failed" {
-			terminalLine = line
-			terminalType = head.Type
+		switch head.Type {
+		case "turn.failed":
+			sawFailed = true
+			failedLine = line
+		case "turn.completed":
+			sawCompleted = true
 		}
 	})
-	if terminalType == "" {
-		return ExecutorTerminal{Provider: "codex", Reason: TerminalReasonNoNormalTerminal}
-	}
-	if terminalType == "turn.failed" {
+	// A `turn.failed` keeps failure routing even when a later `turn.completed`
+	// appears, so a normal terminal never masks an earlier provider failure.
+	if sawFailed {
 		t := ExecutorTerminal{Provider: "codex", Reason: TerminalReasonCodexTurnFailed}
-		// Decode nested detail best-effort. A missing or unparseable error field
-		// keeps the turn.failed routing and falls back to a generic reason (AC5).
+		// Decode nested detail best-effort: a missing or unparseable error field
+		// keeps turn.failed routing with a generic reason.
 		var detailed codexTerminalEvent
-		if err := json.Unmarshal([]byte(terminalLine), &detailed); err == nil && detailed.Error != nil {
+		if err := json.Unmarshal([]byte(failedLine), &detailed); err == nil && detailed.Error != nil {
 			t.Code = detailed.Error.Code
 			t.Message = detailed.Error.Message
 		}
 		return t
 	}
-	return ExecutorTerminal{Normal: true, Provider: "codex", Reason: TerminalReasonCodexTurnCompleted}
+	if sawCompleted {
+		return ExecutorTerminal{Normal: true, Provider: "codex", Reason: TerminalReasonCodexTurnCompleted}
+	}
+	return ExecutorTerminal{Provider: "codex", Reason: TerminalReasonNoNormalTerminal}
 }
 
 type codexTypeEvent struct {
@@ -187,12 +225,16 @@ type codexTerminalEvent struct {
 // GrokTerminal classifies a Grok executor exit from its JSON envelope and the
 // runner error. The normal terminal is a parseable envelope whose stopReason is
 // `EndTurn`; the session ID and result payload are optional diagnostic detail
-// and never gate routing (AC1, D3). Every other stopReason or an unparseable
-// envelope is an interruption.
+// and never gate routing. Every other stopReason or an unparseable envelope is
+// an interruption.
 func GrokTerminal(data []byte, runErr error) ExecutorTerminal {
 	if runErr != nil {
-		return runnerInterruption("grok", runErr)
+		return mergeRunnerInterruption(runnerInterruption("grok", runErr), scanGrokEnvelope(data))
 	}
+	return scanGrokEnvelope(data)
+}
+
+func scanGrokEnvelope(data []byte) ExecutorTerminal {
 	var envelope grokTerminalEnvelope
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		return ExecutorTerminal{Provider: "grok", Reason: TerminalReasonMalformedTerminal, Message: err.Error()}

--- a/internal/runner/terminal.go
+++ b/internal/runner/terminal.go
@@ -57,9 +57,6 @@ const (
 	TerminalReasonRunnerExitNonZero = "runner_exit_nonzero"
 )
 
-// runnerInterruption classifies a runner-state failure. Start failures,
-// timeouts, and kills guarantee that no reliable provider terminal exists, so
-// they resolve to an interruption before any provider output is inspected.
 func runnerInterruption(provider string, runErr error) ExecutorTerminal {
 	t := ExecutorTerminal{Provider: provider, RunError: runErr.Error()}
 	switch {
@@ -114,11 +111,14 @@ func ClaudeTerminal(provider string, stdout []byte, runErr error) ExecutorTermin
 }
 
 type claudeResultEvent struct {
-	Type      string          `json:"type"`
-	Subtype   string          `json:"subtype"`
-	IsError   bool            `json:"is_error"`
-	Result    json.RawMessage `json:"result"`
-	SessionID string          `json:"session_id"`
+	Type           string          `json:"type"`
+	Subtype        string          `json:"subtype"`
+	IsError        bool            `json:"is_error"`
+	APIErrorStatus json.RawMessage `json:"api_error_status"`
+	TerminalReason string          `json:"terminal_reason"`
+	StopReason     string          `json:"stop_reason"`
+	Result         json.RawMessage `json:"result"`
+	SessionID      string          `json:"session_id"`
 }
 
 func scanClaudeStream(provider string, stdout []byte) ExecutorTerminal {
@@ -140,18 +140,36 @@ func scanClaudeStream(provider string, stdout []byte) ExecutorTerminal {
 	// subtype also stays an interruption so unreliable terminals never reach
 	// Supervisor.
 	if failure != nil {
+		status := failure.TerminalReason
+		if status == "" {
+			status = failure.Subtype
+		}
 		return ExecutorTerminal{
-			Provider:  provider,
-			Reason:    TerminalReasonClaudeResultError,
-			Status:    failure.Subtype,
-			SessionID: failure.SessionID,
-			Message:   claudeResultMessage(failure.Result),
+			Provider:   provider,
+			Reason:     TerminalReasonClaudeResultError,
+			Status:     status,
+			Code:       claudeAPIErrorStatus(failure.APIErrorStatus),
+			StopReason: failure.StopReason,
+			SessionID:  failure.SessionID,
+			Message:    claudeResultMessage(failure.Result),
 		}
 	}
 	if success != nil {
 		return ExecutorTerminal{Provider: provider, Normal: true, Reason: TerminalReasonClaudeResultSuccess, Status: success.Subtype, SessionID: success.SessionID}
 	}
 	return ExecutorTerminal{Provider: provider, Reason: TerminalReasonNoNormalTerminal}
+}
+
+func claudeAPIErrorStatus(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(trimmed, &text); err == nil {
+		return text
+	}
+	return string(trimmed)
 }
 
 func claudeResultMessage(raw json.RawMessage) string {

--- a/internal/runner/terminal_test.go
+++ b/internal/runner/terminal_test.go
@@ -1,0 +1,201 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+)
+
+// validExecutorResultLine is a minimal executor result that passes Validate. It
+// is used to prove that a well-formed result payload no longer counts as a
+// normal terminal without an explicit provider terminal event.
+const validExecutorResultLine = `{"status":"completed","summary":"done","files_modified":[],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+
+func TestExecutorTerminalDecision(t *testing.T) {
+	startErr := &CommandError{Kind: CommandErrorStart, Err: errors.New("start claude: no such file")}
+	timeoutErr := &CommandError{Kind: CommandErrorTimeout, Err: errors.New("timed out")}
+	idleErr := &CommandError{Kind: CommandErrorIdleTimeout, Err: errors.New("idle")}
+	killErr := &CommandError{Kind: CommandErrorKilled, Err: errors.New("killed")}
+	exitErr := &CommandError{Kind: CommandErrorExitNonZero, Err: errors.New("exit status 7")}
+
+	tests := []struct {
+		name       string
+		got        ExecutorTerminal
+		wantNormal bool
+		wantReason string
+	}{
+		{
+			name:       "claude success result event",
+			got:        ClaudeTerminal("claude", []byte(`{"type":"system"}`+"\n"+`{"type":"result","subtype":"success","is_error":false,"result":"ok","session_id":"s1"}`), nil),
+			wantNormal: true,
+			wantReason: TerminalReasonClaudeResultSuccess,
+		},
+		{
+			name:       "claude API-error result event",
+			got:        ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s2"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonClaudeResultError,
+		},
+		{
+			// A result event whose subtype is neither "success" nor an error is
+			// not a reliable normal terminal, so it must not reach Supervisor.
+			name:       "claude unknown non-success subtype",
+			got:        ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"other","is_error":false}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonClaudeResultError,
+		},
+		{
+			name:       "claude missing subtype",
+			got:        ClaudeTerminal("claude", []byte(`{"type":"result","is_error":false}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonClaudeResultError,
+		},
+		{
+			name:       "claude structured result without terminal",
+			got:        ClaudeTerminal("claude", []byte(validExecutorResultLine), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonNoNormalTerminal,
+		},
+		{
+			name:       "claude no reliable terminal",
+			got:        ClaudeTerminal("claude", []byte("not-json output\n"), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonNoNormalTerminal,
+		},
+		{
+			name:       "claude start failure",
+			got:        ClaudeTerminal("claude", []byte(validExecutorResultLine), startErr),
+			wantNormal: false,
+			wantReason: TerminalReasonRunnerStartFailed,
+		},
+		{
+			name:       "claude total timeout",
+			got:        ClaudeTerminal("claude", nil, timeoutErr),
+			wantNormal: false,
+			wantReason: TerminalReasonRunnerTimeout,
+		},
+		{
+			name:       "claude idle timeout",
+			got:        ClaudeTerminal("claude", nil, idleErr),
+			wantNormal: false,
+			wantReason: TerminalReasonRunnerIdleTimeout,
+		},
+		{
+			name:       "claude killed",
+			got:        ClaudeTerminal("claude", nil, killErr),
+			wantNormal: false,
+			wantReason: TerminalReasonRunnerKilled,
+		},
+		{
+			name:       "claude non-zero exit without terminal",
+			got:        ClaudeTerminal("claude", []byte("partial\n"), exitErr),
+			wantNormal: false,
+			wantReason: TerminalReasonRunnerExitNonZero,
+		},
+		{
+			name:       "codex turn.completed",
+			got:        CodexTerminal([]byte(`{"type":"turn.completed","usage":{}}`), nil),
+			wantNormal: true,
+			wantReason: TerminalReasonCodexTurnCompleted,
+		},
+		{
+			name:       "codex turn.failed with detail",
+			got:        CodexTerminal([]byte(`{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonCodexTurnFailed,
+		},
+		{
+			name:       "codex turn.failed without detail",
+			got:        CodexTerminal([]byte(`{"type":"turn.failed"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonCodexTurnFailed,
+		},
+		{
+			// An unparseable error field keeps turn.failed routing with a generic
+			// reason rather than collapsing to "no terminal".
+			name:       "codex turn.failed with unparseable detail",
+			got:        CodexTerminal([]byte(`{"type":"turn.failed","error":"boom"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonCodexTurnFailed,
+		},
+		{
+			name:       "codex last message without turn.completed",
+			got:        CodexTerminal([]byte(`{"type":"item.completed"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonNoNormalTerminal,
+		},
+		{
+			name:       "grok EndTurn",
+			got:        GrokTerminal([]byte(`{"text":"hi","stopReason":"EndTurn","sessionId":"g1"}`), nil),
+			wantNormal: true,
+			wantReason: TerminalReasonGrokEndTurn,
+		},
+		{
+			// EndTurn is a normal terminal even without the optional sessionId or
+			// result payload; those are diagnostic detail and never gate routing.
+			name:       "grok EndTurn without session or payload",
+			got:        GrokTerminal([]byte(`{"stopReason":"EndTurn"}`), nil),
+			wantNormal: true,
+			wantReason: TerminalReasonGrokEndTurn,
+		},
+		{
+			name:       "grok non-EndTurn with exit code zero",
+			got:        GrokTerminal([]byte(`{"text":"partial","stopReason":"MaxTokens","sessionId":"g2"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonGrokNonEndTurn,
+		},
+		{
+			name:       "grok malformed envelope",
+			got:        GrokTerminal([]byte("not json"), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonMalformedTerminal,
+		},
+		{
+			name:       "grok missing stop reason",
+			got:        GrokTerminal([]byte(`{"text":"hi","sessionId":"g3"}`), nil),
+			wantNormal: false,
+			wantReason: TerminalReasonMalformedTerminal,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got.Normal != tc.wantNormal {
+				t.Fatalf("Normal = %t, want %t (%+v)", tc.got.Normal, tc.wantNormal, tc.got)
+			}
+			if tc.got.Reason != tc.wantReason {
+				t.Fatalf("Reason = %q, want %q (%+v)", tc.got.Reason, tc.wantReason, tc.got)
+			}
+			if tc.got.Interrupted() == tc.got.Normal {
+				t.Fatalf("Interrupted() must be the inverse of Normal (%+v)", tc.got)
+			}
+		})
+	}
+}
+
+// TestClaudeTerminalPreservesProviderIdentity asserts that GLM, which shares
+// Claude's transport, keeps its own provider identity in terminal evidence.
+func TestClaudeTerminalPreservesProviderIdentity(t *testing.T) {
+	glm := ClaudeTerminal("glm", []byte(`{"type":"result","subtype":"success","is_error":false}`), nil)
+	if glm.Provider != "glm" {
+		t.Fatalf("Provider = %q, want glm (%+v)", glm.Provider, glm)
+	}
+	glmInterrupt := ClaudeTerminal("glm", nil, &CommandError{Kind: CommandErrorTimeout, Err: errors.New("t")})
+	if glmInterrupt.Provider != "glm" {
+		t.Fatalf("interrupted Provider = %q, want glm (%+v)", glmInterrupt.Provider, glmInterrupt)
+	}
+}
+
+func TestExecutorTerminalRetainsProviderDetail(t *testing.T) {
+	codex := CodexTerminal([]byte(`{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}`), nil)
+	if codex.Code != "rate_limit" || codex.Message != "model overloaded" {
+		t.Fatalf("codex detail not retained: %+v", codex)
+	}
+	grok := GrokTerminal([]byte(`{"text":"partial","stopReason":"MaxTokens","sessionId":"g9"}`), nil)
+	if grok.StopReason != "MaxTokens" || grok.SessionID != "g9" {
+		t.Fatalf("grok detail not retained: %+v", grok)
+	}
+	claude := ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s9"}`), nil)
+	if claude.SessionID != "s9" || claude.Status != "error_during_execution" {
+		t.Fatalf("claude detail not retained: %+v", claude)
+	}
+}

--- a/internal/runner/terminal_test.go
+++ b/internal/runner/terminal_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 )
 
-// validExecutorResultLine is a minimal executor result that passes Validate. It
-// is used to prove that a well-formed result payload no longer counts as a
-// normal terminal without an explicit provider terminal event.
+// validExecutorResultLine is a minimal executor result that passes Validate; a
+// well-formed result alone is not a normal terminal without a provider terminal event.
 const validExecutorResultLine = `{"status":"completed","summary":"done","files_modified":[],"acceptance_criteria":[],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
 
 func TestExecutorTerminalDecision(t *testing.T) {
@@ -182,6 +181,53 @@ func TestClaudeTerminalPreservesProviderIdentity(t *testing.T) {
 	glmInterrupt := ClaudeTerminal("glm", nil, &CommandError{Kind: CommandErrorTimeout, Err: errors.New("t")})
 	if glmInterrupt.Provider != "glm" {
 		t.Fatalf("interrupted Provider = %q, want glm (%+v)", glmInterrupt.Provider, glmInterrupt)
+	}
+}
+
+func TestExecutorTerminalRetainsProviderDetailOnNonZeroExit(t *testing.T) {
+	exitErr := &CommandError{Kind: CommandErrorExitNonZero, Err: errors.New("exit status 1")}
+
+	claude := ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s1","result":"api overloaded"}`), exitErr)
+	if claude.Normal {
+		t.Fatalf("claude non-zero exit must stay interrupted: %+v", claude)
+	}
+	if claude.Reason != TerminalReasonClaudeResultError {
+		t.Fatalf("claude reason = %q, want %q", claude.Reason, TerminalReasonClaudeResultError)
+	}
+	if claude.RunError == "" || claude.SessionID != "s1" || claude.Status != "error_during_execution" || claude.Message != "api overloaded" {
+		t.Fatalf("claude provider detail not retained alongside run error: %+v", claude)
+	}
+
+	codex := CodexTerminal([]byte(`{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}`), exitErr)
+	if codex.Normal || codex.Reason != TerminalReasonCodexTurnFailed {
+		t.Fatalf("codex non-zero exit must stay codex_turn_failed: %+v", codex)
+	}
+	if codex.RunError == "" || codex.Code != "rate_limit" || codex.Message != "model overloaded" {
+		t.Fatalf("codex provider detail not retained alongside run error: %+v", codex)
+	}
+
+	grok := GrokTerminal([]byte(`{"text":"partial","stopReason":"MaxTokens","sessionId":"g1"}`), exitErr)
+	if grok.Normal || grok.Reason != TerminalReasonGrokNonEndTurn {
+		t.Fatalf("grok non-zero exit must stay grok_non_end_turn: %+v", grok)
+	}
+	if grok.RunError == "" || grok.StopReason != "MaxTokens" || grok.SessionID != "g1" {
+		t.Fatalf("grok provider detail not retained alongside run error: %+v", grok)
+	}
+}
+
+func TestExecutorTerminalRejectsConflictingStreams(t *testing.T) {
+	claude := ClaudeTerminal("claude", []byte(
+		`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s1"}`+"\n"+
+			`{"type":"result","subtype":"success","is_error":false,"session_id":"s2"}`), nil)
+	if claude.Normal || claude.Reason != TerminalReasonClaudeResultError {
+		t.Fatalf("claude error-then-success must stay interrupted: %+v", claude)
+	}
+
+	codex := CodexTerminal([]byte(
+		`{"type":"turn.failed","error":{"message":"boom","code":"x"}}`+"\n"+
+			`{"type":"turn.completed"}`), nil)
+	if codex.Normal || codex.Reason != TerminalReasonCodexTurnFailed {
+		t.Fatalf("codex turn.failed-then-completed must stay interrupted: %+v", codex)
 	}
 }
 

--- a/internal/runner/terminal_test.go
+++ b/internal/runner/terminal_test.go
@@ -187,14 +187,14 @@ func TestClaudeTerminalPreservesProviderIdentity(t *testing.T) {
 func TestExecutorTerminalRetainsProviderDetailOnNonZeroExit(t *testing.T) {
 	exitErr := &CommandError{Kind: CommandErrorExitNonZero, Err: errors.New("exit status 1")}
 
-	claude := ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s1","result":"api overloaded"}`), exitErr)
+	claude := ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"success","is_error":true,"api_error_status":529,"terminal_reason":"api_error","stop_reason":"stop_sequence","session_id":"s1","result":"api overloaded"}`), exitErr)
 	if claude.Normal {
 		t.Fatalf("claude non-zero exit must stay interrupted: %+v", claude)
 	}
 	if claude.Reason != TerminalReasonClaudeResultError {
 		t.Fatalf("claude reason = %q, want %q", claude.Reason, TerminalReasonClaudeResultError)
 	}
-	if claude.RunError == "" || claude.SessionID != "s1" || claude.Status != "error_during_execution" || claude.Message != "api overloaded" {
+	if claude.RunError == "" || claude.SessionID != "s1" || claude.Status != "api_error" || claude.Code != "529" || claude.StopReason != "stop_sequence" || claude.Message != "api overloaded" {
 		t.Fatalf("claude provider detail not retained alongside run error: %+v", claude)
 	}
 
@@ -228,20 +228,5 @@ func TestExecutorTerminalRejectsConflictingStreams(t *testing.T) {
 			`{"type":"turn.completed"}`), nil)
 	if codex.Normal || codex.Reason != TerminalReasonCodexTurnFailed {
 		t.Fatalf("codex turn.failed-then-completed must stay interrupted: %+v", codex)
-	}
-}
-
-func TestExecutorTerminalRetainsProviderDetail(t *testing.T) {
-	codex := CodexTerminal([]byte(`{"type":"turn.failed","error":{"message":"model overloaded","code":"rate_limit"}}`), nil)
-	if codex.Code != "rate_limit" || codex.Message != "model overloaded" {
-		t.Fatalf("codex detail not retained: %+v", codex)
-	}
-	grok := GrokTerminal([]byte(`{"text":"partial","stopReason":"MaxTokens","sessionId":"g9"}`), nil)
-	if grok.StopReason != "MaxTokens" || grok.SessionID != "g9" {
-		t.Fatalf("grok detail not retained: %+v", grok)
-	}
-	claude := ClaudeTerminal("claude", []byte(`{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"s9"}`), nil)
-	if claude.SessionID != "s9" || claude.Status != "error_during_execution" {
-		t.Fatalf("claude detail not retained: %+v", claude)
 	}
 }

--- a/scripts/smoke-local.sh
+++ b/scripts/smoke-local.sh
@@ -22,6 +22,7 @@ fi
 cat > /dev/null
 echo "smoke" > smoke-output.txt
 echo '{"status":"completed","summary":"smoke done","files_modified":["smoke-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["smoke-output.txt"],"notes":"created smoke output"}],"verification":[{"command":"test -f smoke-output.txt","status":"passed","reason":"file exists","output_excerpt":"ok"}],"decisions":[],"risks":[]}'
+echo '{"type":"result","subtype":"success","is_error":false,"session_id":"smoke-session"}'
 SH
 chmod +x "$BIN_DIR/claude"
 


### PR DESCRIPTION
## Goal

Stop executor provider or runtime interruptions before normal Supervisor review, preserve partial work and run evidence, and let operators resume the retained worktree through the existing requeue workflow.

## Acceptance Criteria

- `AC1` When an executor process ends, Galley shall decide whether the attempt reached a normal provider terminal using runner state and machine-readable provider output. Claude and GLM successful result events, Codex `turn.completed`, and Grok `EndTurn` are normal terminals; explicit failed or non-normal terminals, start failures, timeouts, kills, and output without a reliable normal terminal are interruptions. The decision shall not depend on process exit code or human-language error matching alone.
  - Verification: Table-driven runner and daemon tests cover Claude/GLM normal result versus API-error result, Codex `turn.completed` versus `turn.failed`, Grok `EndTurn` versus non-EndTurn with exit code 0, and runner start/timeout/kill failures; claim: every executor supplies the same normal-terminal versus interruption decision; primary failure mode: a provider/runtime interruption is treated as completed or a normal terminal is treated as interrupted; boundary: provider output and runner result -> common attempt routing; state: executor ends -> terminal evidence is evaluated -> one routing decision is produced; residual: none.
  - Status: satisfied
- `AC2` When an executor reaches a normal provider terminal without a runner failure, Galley shall preserve the existing Supervisor path. An executor-result parse or schema-validation failure after that normal terminal shall remain reviewable, and a Supervisor `needs_revision` verdict shall continue to start the next executor attempt under the existing loop budget.
  - Verification: Focused daemon tests exercise valid and invalid executor results after representative normal terminals, assert that Supervisor receives the attempt evidence, and assert that `needs_revision` starts the next attempt; claim: ordinary executor-result failures retain the existing AFK correction loop; primary failure mode: the interruption path stops a normally completed attempt before review; boundary: normal terminal -> Supervisor loop; state: normal terminal -> review -> accepted or needs_revision; residual: none.
  - Status: satisfied
- `AC3` When an executor attempt is interrupted, Galley shall not invoke Supervisor and shall not start another executor attempt in the same run, regardless of whether the worktree contains a diff or how much loop budget remains. The task shall move to `tasks/failed` without recording an `accepted` or `needs_revision` verdict that no Supervisor produced.
  - Verification: Daemon lifecycle tests run interrupted executors with empty and dirty worktrees and `loop_budget` greater than one, then assert zero Supervisor calls, exactly one executor attempt, final placement under `tasks/failed`, and a non-verdict marker such as `not_reviewed`; claim: provider/runtime interruptions cannot consume the normal revision loop; primary failure mode: interruption reaches Supervisor or starts attempt 2; boundary: interrupted executor outcome -> task lifecycle publication; state: running task -> interruption -> failed task awaiting recovery; residual: none.
  - Status: satisfied
- `AC4` When an executor is interrupted after modifying its workspace, Galley shall preserve tracked and untracked changes and persist the available command plan, run result, raw provider output, git status, and diff evidence before publishing the failed task. Requeueing that task shall reuse the existing dirty worktree so the next executor can continue from the retained changes.
  - Verification: An integration test uses a fake executor that changes a tracked file and creates an untracked file before interruption, then asserts the attempt artifacts contain both changes, the failed worktree retains them, and a requeued run reports a reused worktree with the same changes visible; claim: interruption is resumable without lost implementation work; primary failure mode: failure publication or requeue resets or removes partial changes; boundary: executor process -> run artifacts -> failed task -> requeued workspace; state: clean worktree -> partial edits -> interruption -> requeue -> edits remain; residual: executor-created commits remain governed by the existing branch behavior.
  - Status: satisfied
- `AC5` When an executor is interrupted, the latest attempt shall record an executor-owned structured error distinct from an ordinary completed-result failure, and `galley task show` shall surface the interruption, evidence location, and recovery action. When the provider exposes structured status, code, stop reason, session ID, or message detail, Galley shall retain that detail for diagnosis; unavailable or unparseable detail shall fall back to a generic interruption reason without changing routing.
  - Verification: Focused tests cover Claude/GLM structured API failure, Codex `turn.failed` with and without parseable nested detail, Grok non-EndTurn, and an unknown interruption, then assert the task attempt and `task show` identify the executor interruption, preserve available provider detail and artifact directory, and recommend resolving the cause then requeueing; claim: operators can diagnose and resume an interruption without error-text classification controlling behavior; primary failure mode: interruption collapses into a normal Supervisor failure or missing detail prevents correct routing; boundary: provider terminal evidence -> task YAML -> task show; state: interruption recorded -> operator inspects task -> evidence and next action are visible; residual: unknown provider causes retain a generic reason.
  - Status: satisfied
- `AC6` User-facing supervision and operations documentation shall explain that executor interruptions stop before Supervisor, preserve the worktree and run evidence, and resume through the existing `galley task requeue` workflow after the interruption cause is resolved. The behavior change shall be recorded under CHANGELOG Unreleased.
  - Verification: Review `docs/supervision.md`, `docs/task-yaml.md`, `docs/operations.md`, and `CHANGELOG.md`; run schema check and task/profile example validation; claim: operators understand that interrupted work is retained and resumable; primary failure mode: documentation still describes every executor failure as a Supervisor retry or implies that partial work is discarded; boundary: documented daemon and CLI workflow; state: task interrupted -> operator follows documented recovery -> retained task is requeued; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml && profile validate quality+environment`: passed
- `python3 -m json.tool over all required schema/plugin/marketplace JSON`: passed
- `python3 -m json.tool on all 9 schema/plugin/marketplace JSON files`: passed
- `GOOS=windows GOARCH=amd64 go build ./... && GOOS=windows GOARCH=amd64 go vet ./internal/runner ./internal/daemon ./internal/cli ./internal/task && GOOS=windows GOARCH=amd64 go test -c for touched packages`: passed
- `python3 -m json.tool <each schema/plugin/marketplace json> >/dev/null`: passed
- `git diff --check`: passed
- `go vet ./...`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml; go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool on all 9 configured JSON artifacts`: passed
- `GOOS=windows GOARCH=amd64 go build ./... && GOOS=windows GOARCH=amd64 go vet ./internal/runner ./internal/daemon ./internal/cli ./internal/task`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go test ./...`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml`: passed
- `go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool over all 9 required JSON artifacts`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` What decides whether an executor attempt enters normal Supervisor review? -> Use only whether the runner succeeded and the provider emitted a reliable normal terminal; do not route by detailed error category.
  - Rationale: The product decision is whether Supervisor can review a completed attempt, while provider-specific failure detail is diagnostic and may be absent or unstable.
  - Reversibility: high
- `D2` How should an interrupted task be published and resumed? -> Publish it through the existing failed-task state with preserved attempt evidence and worktree, then resume it through the existing `galley task requeue` workflow after the cause is resolved.
  - Rationale: Existing failed-task inspection, worktree reuse, and requeue behavior already provide the required operator recovery path.
  - Reversibility: high
- `D3` How should provider-specific failure detail affect behavior? -> Retain structured provider detail when available, but use it only for diagnosis and never as the condition for Supervisor routing.
  - Rationale: This preserves actionable evidence without introducing brittle or provider-specific control flow.
  - Reversibility: high
- `executor-decision-4` How should a normal terminal be detected for Claude/Codex when the real provider always emits a session terminal event but test fakes emit only a bare structured result? -> Treat a provider success terminal event (Claude result is_error=false, Codex turn.completed, Grok EndTurn) as authoritative, and additionally accept a complete well-formed structured executor result as a fallback normal terminal.
  - Rationale: Preserves fail-closed routing for real providers (which always emit terminal events) while a fully formed final result still counts as a normal completion; keeps ~40 existing executor tests valid and satisfies AC2 (invalid result after a real terminal event still routes to Supervisor).
  - Reversibility: medium
- `executor-decision-5` What AttemptError kind should an interruption use given an existing test asserts executor_failed/idle_timeout/timed_out kinds? -> Runner-state interruptions keep classifyFailureKind (executor_failed/idle_timeout/timed_out); provider-reported non-normal terminals with a successful runner use the distinct kind executor_interrupted; all interruptions set supervisor_verdict=not_reviewed.
  - Rationale: Keeps the actionable timeout/idle signal and the existing generic-classification regression test intact while giving AC5 a distinct executor-owned marker and AC3 its non-verdict marker.
  - Reversibility: high
- `executor-decision-6` Two existing daemon tests failed under the new (correct) behavior. Change behavior or tests? -> Updated the two test fakes to be realistic (parse-failure test now emits a Claude success result event; supervisor-timeout test raises the shared 50ms timeout to 500ms so the fast executor reaches its terminal before the sleeping supervisor times out).
  - Rationale: Both tests' fakes were unrealistic for real provider output; their true intent (invalid result reaches Supervisor; supervisor timeout recorded) is preserved under the new contract without weakening coverage.
  - Reversibility: high
- `executor-decision-7` How to prove the task-show boundary for the matrix without an import cycle (cli transitively imports daemon)? -> Prove the Galley-owned publication boundary (executor_terminal.json + task YAML) with real daemon runs in the daemon matrix test, and prove task-show presentation with a table-driven cli test whose representative messages mirror the daemon's interruptionMessage format.
  - Rationale: package daemon cannot import cli (cli -> daemoncmd -> daemon), so the daemon test cannot call task show directly; this split mirrors the existing task_show_supervisor_idle_timeout_test pattern and still exercises both boundaries.
  - Reversibility: medium
- `executor-decision-8` Should CodexTerminal keep classifying turn.failed when its nested error detail is unparseable? -> Decode the terminal type first, then decode detail best-effort so an unparseable error keeps codex_turn_failed routing with a generic reason.
  - Rationale: AC5 requires unavailable/unparseable detail to fall back to a generic reason without changing routing; collapsing to no_normal_terminal would lose the turn.failed diagnosis.
  - Reversibility: high
- `executor-decision-9` Delete the flagged mixed comments entirely or trim to their non-obvious rationale? -> Deleted pure restatement (test-name/AC/assertion echoes) and trimmed comments that also carried a non-obvious constraint (exit-0 routing independence, Grok EndTurn payload independence, daemon-owned message mirroring) down to only that constraint.
  - Rationale: The comment-quality dimension and the requeue guidance both direct retaining only non-obvious protocol/fixture rationale, so trimming preserves genuinely useful information while removing the flagged restatement.
  - Reversibility: high
- `executor-decision-10` Which comments to remove given attempt-4 listed a broader set but attempt-5 named only three blocks? -> Follow the latest attempt-5 guidance and finding: remove exactly the three named blocks; treat the broader attempt-4 list as already resolved in prior attempts.
  - Rationale: The attempt-5 supervisor guidance is the most recent authoritative instruction and explicitly states 'Remove these three comment blocks'; the other attempt-4 locations were already revised (current file state shows rationale-bearing comments the guidance lists for retention).
  - Reversibility: high
- `requeue-11` Why was this task requeued? -> Requeue after deploying supervisor progress and verdict contract fixes from PR #118.
  - Rationale: A reviewer or PR comment requested another executor attempt.
  - Reversibility: high
- `executor-decision-12` Did the scope-compliance revision require any code changes, or only reporting? -> Report the two outside-allowed files in scope_expansions and re-verify checks; make no code changes.
  - Rationale: supervisor-attempt-6-finding-1 explicitly states both files are necessary and non-forbidden, and the only blocker was the missing scope_expansions declarations. The requeue guidance directs preserving the implementation and re-running/citing the unchanged required checks.
  - Reversibility: high

## Discussion Items

- `discussion-1` Accepted scope expansion: Accepted the necessary, minimal scope expansion covering `internal/runartifact/artifact.go` and `scripts/smoke-local.sh`; neither path is forbidden, and each is directly tied to the interruption evidence or required smoke-verification contract.
- `discussion-2` Scope expansion: Accepted diff includes changes outside task.scope.allowed_paths: internal/runartifact/artifact.go, scripts/smoke-local.sh. Review whether this scope expansion belongs in this PR.
  - Human decision required: true

## Risks

- `R1` compatibility: Provider CLI versions may omit or change optional terminal detail while retaining their normal completion markers.
  - Mitigation: Base routing on the smallest stable structured normal-terminal contract, fail closed to interruption when normal completion cannot be established, and cover missing optional detail in tests.
- `R2` regression: A normal provider terminal followed by an invalid executor result could be misclassified as an interruption and lose the existing AFK Supervisor correction loop.
  - Mitigation: Test normal-terminal attempts with invalid result payloads and require them to enter the existing Supervisor path.
- `R3` state-safety: Publishing an interrupted task before capturing executor output could hide or lose partial tracked and untracked work.
  - Mitigation: Keep evidence capture and worktree preservation before terminal task publication, with an interruption-and-requeue lifecycle test.
- `supervisor-invalid-verdict-7` partial_verification: Supervisor evaluation failed (supervisor_invalid_verdict): supervisor verdict has invalid quality coverage: quality_coverage missing criterion "acceptance"
  - Mitigation: Inspect the supervisor-try-1 validation evidence and requeue with the same or another supervisor after correcting the output-contract issue.
