### PR TITLE
Refresh README and reorganize user documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Changed
+
+- Documentation now provides a goal-based guide, clearer model and review configuration, and task-state troubleshooting.
+
 ## v0.11.0 - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,21 +4,33 @@
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple)](https://claude.ai/code)
 [![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Supported-10a37f)](https://developers.openai.com/codex/cli)
+[![GLM](https://img.shields.io/badge/GLM-Backend-2f6bff)](https://z.ai/)
 [![Grok Build](https://img.shields.io/badge/Grok%20Build-Plugin-black)](https://x.ai/)
 [![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Spec%20Compliant-blue)](https://developers.openai.com/codex/skills/)
 [![CI](https://github.com/shinpr/galley/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/shinpr/galley/actions/workflows/ci.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/shinpr/galley)](https://github.com/shinpr/galley/releases)
 [![License: MIT](https://img.shields.io/github/license/shinpr/galley)](LICENSE)
 
-Galley is a local runtime for supervised AI coding tasks.
+Galley is a local runtime for supervised, multi-model AI coding.
 
-It runs Claude Code, Codex, GLM, or Grok Build in a git worktree, records evidence for each attempt, and asks a supervisor model to accept, retry, or escalate the result before the work is treated as done.
+Choose the executor that fits the task and select the supervisor independently. Galley helps define acceptance criteria and repository policy, runs the work in an isolated git worktree, and records each attempt so the result can be inspected later.
 
-Galley is for tasks where the output should be inspectable later: the request, scope, checks, diffs, and supervisor verdict stay on disk.
+This makes lower-cost, faster, or specialized models practical for implementation while keeping model configuration and acceptance criteria explicit. The recommended workflow hands accepted changes off as ordinary pull requests for final human review.
 
 Galley builds Galley: roughly half of this repository's merged implementation PRs were created from Galley-managed task branches.
 
 [Browse Galley-built PRs](https://github.com/shinpr/galley/pulls?q=is%3Apr+is%3Amerged+head%3Aagent)
+
+## Why Galley
+
+Interactive AI coding sessions work well for short tasks. Longer work needs explicit standards, visible model choices, and a reliable path back to human review.
+
+- **Explicit model configuration**: set the executor CLI, model, and effort for a task or repository, and choose the supervisor separately. Galley records the resolved configuration passed to each run.
+- **Repository-defined standards**: the skill inspects the repository, helps write acceptance criteria, and prepares quality and environment profiles before work is queued.
+- **Focused retries**: the supervisor reviews acceptance criteria before repository quality policy, preserves verified passes, and focuses the next attempt on unresolved work and regression risks.
+- **Auditable execution**: command plans, model output, checks, git status, diffs, and supervisor verdicts stay under the local workflow root.
+- **Isolated AFK work**: execution runs in a managed git worktree, with retry limits and escalation when the task needs human judgment.
+- **Review-ready handoff**: the recommended setup commits and opens accepted work as a pull request for final human review.
 
 ## Quick Start
 
@@ -101,21 +113,10 @@ plugins/galley/skills/galley/
 
 The standalone skill still expects the `galley` CLI on `PATH`. Some workflows also use `claude`, `codex`, `gh`, and `python3`.
 
-## Why Galley
-
-Interactive AI coding sessions work well for short tasks. They get harder to trust when the work becomes asynchronous, long-running, or review-heavy.
-
-- **Asynchronous execution with review**: run coding work away from the main checkout, then gate completion through a supervisor verdict.
-- **Git-visible changes**: executor work happens in a managed worktree, so normal git review still applies.
-- **Structured evidence**: every run records command plans, executor output, git status, diffs, and supervisor results under the workflow root.
-- **Retry and escalation**: tasks can retry while the loop budget remains, then escalate with recorded context when human judgment is needed.
-- **Repository-specific policy**: profiles describe expected checks, command names, network and secrets policy, PR behavior, and cleanup rules.
-- **Optional PR handoff**: accepted work can be committed, pushed, opened as a PR, and requeued from trusted PR comments.
-
 ## How It Works
 
 ```text
-task YAML
+task YAML + repository policy
     |
     | galley task queue
     v
@@ -125,22 +126,22 @@ queued task
     v
 isolated git worktree
     |
-    | Claude Code, Codex, GLM, or Grok implements
+    | selected executor implements
     v
 run evidence + git diff
     |
-    | supervisor review
-    +--> accepted ---------> done or PR opened
-    +--> needs revision ---> retry while budget remains
+    | independently selected supervisor reviews
+    +--> accepted ---------> PR opened or local completion
+    +--> needs revision ---> retry unresolved work while budget remains
     +--> needs review -----> failed for human review
     +--> hard stop --------> failed
 ```
 
 ## Core Concepts
 
-- **Task YAML**: trusted local input describing the goal, acceptance criteria, scope, executor, verification, worktree, and PR behavior. See [docs/task-yaml.md](docs/task-yaml.md).
-- **Quality profile**: optional repository expectations for required checks, review dimensions, evidence, and pass policy. See [docs/profiles.md](docs/profiles.md).
-- **Environment profile**: optional repository defaults for commands, executor CLI/model/effort, constraints, PR behavior, and cleanup. See [docs/profiles.md](docs/profiles.md).
+- **Task YAML**: trusted local input describing the goal, acceptance criteria, scope, executor overrides, verification, and worktree. See [docs/task-yaml.md](docs/task-yaml.md).
+- **Quality profile**: repository review policy for required checks, review dimensions, evidence, and pass criteria. The setup skill creates it from repository evidence and the user's chosen review strictness. See [docs/profiles.md](docs/profiles.md).
+- **Environment profile**: repository runtime defaults for commands, executor CLI/model/effort, constraints, PR behavior, and cleanup. The setup skill creates it from repository evidence and approved execution settings. See [docs/profiles.md](docs/profiles.md).
 - **Executor**: Claude Code, Codex, GLM, or Grok Build backend that implements the task. Each executor field resolves from the task, then the environment profile; only `cli` has a built-in default (`claude`), while an omitted `model` or `effort` defers to the selected provider CLI's own default. GLM requires `glm_api_key`; Grok uses its logged-in CLI state.
 - **Supervisor**: Claude, Codex, GLM, or Grok Build backend that reviews the result against acceptance criteria, required checks, and recorded evidence. It is the acceptance gate; the default is Claude.
 - **Worktree**: isolated git checkout used for AFK execution so the source repository stays clean.
@@ -189,11 +190,13 @@ See [SECURITY.md](SECURITY.md) for reporting and operational trust boundaries.
 
 ## Documentation
 
-- [Task YAML](docs/task-yaml.md): task fields, starter template, permissions, input files, worktree paths, and acceptance skeleton preflight.
-- [Profiles](docs/profiles.md): quality and environment profile fields with examples.
-- [Operations](docs/operations.md): daemon commands, queue layout, task commands, operational notes, and development checks.
-- [Supervision](docs/supervision.md): supervisor verdicts, retry behavior, executor selection, and evidence expectations.
-- [PR automation](docs/pr-automation.md): accepted-task commits, PR creation, PR comment requeueing, and worktree cleanup.
+Start with the [documentation guide](docs/README.md) to follow the workflow or find a topic by goal.
+
+- [Models and supervision](docs/supervision.md): executor and supervisor configuration, model roles, review convergence, and outcomes.
+- [Troubleshooting](docs/troubleshooting.md): task states, recovery decisions, and run evidence.
+- [Task YAML](docs/task-yaml.md) and [Profiles](docs/profiles.md): task and repository configuration references.
+- [Operations](docs/operations.md): daemon control, queue storage, notifications, timeouts, and platform behavior.
+- [PR automation](docs/pr-automation.md): accepted-task commits, PR creation, comment requeues, and worktree cleanup.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Galley Documentation
+
+Start with the main [README](../README.md) to install Galley and set up a repository with the Galley skill. The documents here explain how to configure, operate, and troubleshoot the resulting workflow.
+
+## The Workflow
+
+1. Use the Galley skill to inspect the repository and create its quality and environment profiles.
+2. Ask the skill to draft a task, then review its acceptance criteria, scope, executor settings, and loop budget.
+3. Queue the approved task. The daemon runs the executor in an isolated worktree.
+4. A separately configured supervisor reviews acceptance criteria first, then repository quality policy. Verified passes carry forward so later attempts can focus on unresolved work and regression risks.
+5. Accepted work is either left in the local worktree or committed and opened as a pull request, depending on the environment profile.
+
+## Documentation Map
+
+| Goal | Read |
+| --- | --- |
+| Choose an executor or supervisor, set model and effort, or understand retries | [Models and supervision](supervision.md) |
+| Review or hand-write a task file | [Task YAML reference](task-yaml.md) |
+| Understand or tune `quality.yaml` and `environment.yaml` | [Profiles](profiles.md) |
+| Start and stop the daemon, inspect the queue, or configure notifications | [Operations](operations.md) |
+| Understand a failed or stalled task and resume it safely | [Troubleshooting](troubleshooting.md) |
+| Configure pull requests, comment requeues, and cleanup | [PR automation](pr-automation.md) |
+| Understand security and trust boundaries | [Security policy](../SECURITY.md) |
+| Build, test, or contribute to Galley | [Contributing](../CONTRIBUTING.md) |
+
+## Configuration Files
+
+Galley keeps settings at the scope where they apply:
+
+| File | Scope | Contains |
+| --- | --- | --- |
+| Task YAML | One task | Goal, acceptance criteria, implementation scope, executor overrides, attempt budget, and worktree |
+| `quality.yaml` | One repository | Required checks, review dimensions, evidence expectations, and pass policy |
+| `environment.yaml` | One repository | Executor and supervisor defaults, commands, constraints, PR behavior, and worktree cleanup |
+| `daemon.yaml` | One Galley daemon | Concurrency, polling, timeouts, daemon-level supervisor default, GLM credentials, and notifications |
+
+The Galley skill is the recommended way to create task and profile files. The reference documents describe the resulting contracts for review, manual adjustment, and troubleshooting.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,15 +1,103 @@
 # Operations
 
-This document covers day-to-day Galley operation: queue layout, task commands, daemon control, recovery behavior, and local development checks.
+This document covers daemon control, task inspection, queue storage, notifications, and process behavior. Use the Galley skill for normal setup and task authoring. For help with a specific failure, start with [Troubleshooting](troubleshooting.md).
 
-For normal task authoring, prefer the Galley skill. It validates task YAML and profiles before queueing.
+## Daily Commands
 
-## Queue Layout
+```sh
+galley daemon start
+galley daemon status --output json
+galley task list
+galley task show TASK_ID
+galley daemon stop
+```
 
-The daemon root defaults to `~/.galley`:
+`task list` shows each task's queue state, status, PR URL, latest verdict, and latest summary. `task show` gives the latest attempt, supervisor verdict, risk, failed verification context, and recovery hint.
+
+Use the installed `galley` binary for background daemon control. PID verification records the executable path, so separate `go run ./cmd/galley` invocations cannot reliably start and later stop the same background process.
+
+## Daemon Control
+
+```sh
+galley daemon start
+galley daemon status --output json
+galley daemon stop
+galley daemon run --once
+```
+
+`daemon start` launches Galley in the background and writes its PID and log under the daemon root. `daemon run --once` drains the tasks currently available in the queue and exits. The background daemon also polls configured PR comments and cleans up worktrees for closed or merged PRs.
+
+The daemon root defaults to `~/.galley`. Use `--root` consistently when running an isolated or test workflow with a different root.
+
+By default, the background files are:
+
+```text
+~/.galley/galley-daemon.pid
+~/.galley/galley-daemon.log
+```
+
+`--pid-file` and `--log-file` override those paths. `daemon stop` sends a normal shutdown request, waits up to `--stop-timeout`, and removes the PID file after it verifies that the recorded process stopped.
+
+## Daemon Configuration
+
+`daemon start` and `daemon run` create `daemon.yaml` under the selected root on first use. Edit this file for durable daemon-wide defaults:
+
+```yaml
+supervisor: claude
+max_concurrent_tasks: 1
+max_concurrent_per_repo: 1
+poll_interval: 10s
+claim_ttl: 30m
+shutdown_timeout: 5m
+idle_timeout: 10m
+notifications:
+  enabled: false
+  on: [failed, needs_supervisor_review]
+```
+
+| Field | Purpose |
+| --- | --- |
+| `supervisor` | Daemon-level supervisor backend: `claude`, `codex`, `glm`, or `grok`. A repository environment profile can override it. |
+| `max_concurrent_tasks` | Maximum tasks run at once. Must be at least 1. |
+| `max_concurrent_per_repo` | Maximum concurrent tasks for one source repository. `0` disables the per-repository limit. |
+| `poll_interval` | Delay between queue and maintenance polls. |
+| `claim_ttl` | Age used to recover stale task claims; it also determines heartbeat cadence. |
+| `shutdown_timeout` | Time active attempts may finish after shutdown is requested. |
+| `idle_timeout` | Time an executor or supervisor process may produce no output before Galley kills it. |
+| `glm_api_key` | Z.ai credential used when GLM is selected as executor or supervisor. |
+| `notifications` | Optional terminal-state command hook described below. |
+
+Explicit flags on `daemon start` or `daemon run` override `daemon.yaml` for that process. Missing file values use built-in defaults. Unknown keys are ignored; invalid values for known keys fail daemon startup.
+
+Repository executor, supervisor, model, and effort defaults belong in `environment.yaml`, not `daemon.yaml`. See [Profiles](profiles.md) and [Models and supervision](supervision.md).
+
+## Task Commands
+
+```sh
+galley task validate ./TASK.yaml
+galley task work-order ./TASK.yaml
+galley task queue ./TASK.yaml --reason "queue for daemon"
+galley task list
+galley task show TASK_ID
+galley task requeue TASK_ID --reason "resolved the reported blocker"
+galley task archive ~/.galley/tasks/done/TASK.yaml
+```
+
+`task queue` validates a draft, records the queue reason, and copies it into `tasks/queued` without overwriting an existing task. Pass `--move` when the original draft should be removed after queueing.
+
+`task requeue` moves a reviewed task from `failed`, `done`, or `running` back to `queued`. It preserves the existing worktree and applicable review progress. Successful setup and acceptance-skeleton phases are reused when their earlier evidence is still valid.
+
+`task archive` records the archived state, moves the task into `tasks/archived`, and attempts to remove its managed worktree. Archive only tasks that no longer need to resume.
+
+For the authoring contract, see [Task YAML](task-yaml.md). For state-specific decisions, see [Troubleshooting](troubleshooting.md).
+
+## Queue and Evidence Layout
+
+The default daemon root contains:
 
 ```text
 ~/.galley/
+  daemon.yaml
   tasks/
     draft/
     queued/
@@ -23,96 +111,34 @@ The daemon root defaults to `~/.galley`:
       quality.yaml
       environment.yaml
   runtime/
-    claude-guard-plugin/
   galley-daemon.pid
   galley-daemon.log
 ```
 
-`profiles/` holds repository quality and environment YAML files. Galley resolves `<repo-key>` from `scope.cwd`; use `galley profile resolve --cwd <repo> --mkdir --output json` to find the exact paths and create their parent directory.
-
-Each executor attempt writes evidence under `runs/<run-id>/attempt-N/`, where `<run-id>` is generated as `<task-id>-<unix-nano>`.
-
-Attempt evidence includes:
-
-- `command_plan.json`
-- `run_result.json`
-- `executor_result.json` when the executor returns valid structured JSON
-- `supervisor_verdict.json`
-- `git_status.json`
-- `diff.patch`
-
-On the first supervisor attempt, every task AC is reviewed before every configured quality dimension. Galley stores passed items in daemon-owned `task.review_progress`; later attempts review only unfinished items plus passed items implicated by the executor's current-attempt summary. A normal `task requeue` preserves this progress. A new `task queue`, changed task direction or review contract, changed `scope.cwd`, or changed content in a placed task input resets it.
-
-Each verdict lists reviewed quality dimension IDs in `quality_passes` or `quality_gaps`. Galley combines those results with persisted passes and enforces the active required-dimension and weighted-score policy before accepting. A non-accepted verdict remains actionable when an AC or quality result array is malformed. That result kind cannot advance persisted passes, while recognized gap IDs still reopen them.
-
-Galley also records `workspace.json` for the effective execution workspace and writes `profiles.json` when quality or environment profiles are loaded.
-
-## Task Files
-
-For hand-authored task YAML, use [task-yaml.md](task-yaml.md) as the reference.
+Use this command to find a repository's profile directory instead of guessing `<repo-key>`:
 
 ```sh
-galley task list
-galley task show TASK_ID
-galley task validate ./TASK.yaml
-galley task work-order ./TASK.yaml
-galley task queue ./TASK.yaml --reason "queue for daemon"
-galley task requeue TASK_ID --reason "addressed review feedback"
-galley task archive ~/.galley/tasks/done/TASK.yaml
-```
-
-`galley task queue` validates a `draft` task, sets `status: queued`, records a queue attempt, and writes it into `tasks/queued` without overwriting an existing queued file. Drafts outside the daemon root are copied by default; pass `--move` when the source file should be removed after queueing.
-
-`galley task list` shows task state, status, PR URL, latest verdict, and latest summary across the workflow root.
-
-`galley task show` accepts a task file or task ID and prints the latest attempt, supervisor verdict, risk, and failed verification context. Accepted terminal tasks show prior attempt errors as audit history, not active failures. When the latest attempt is an executor interruption, `task show` marks it (`latest_executor_interruption: true`), points at the attempt evidence directory, and prints a `latest_recovery` line with the `galley task requeue` command to run after the interruption cause is resolved.
-
-`galley task requeue` accepts a task ID or task file, returns a reviewed task from `tasks/failed`, `tasks/done`, or `tasks/running` to `tasks/queued`, records an optional reason, and increments `supervisor.review_iterations`. When the task worktree is reused, successful setup and acceptance-skeleton phases are reused rather than repeated. An executor interruption preserves the dirty worktree, so requeueing resumes the next executor attempt from the retained tracked and untracked changes.
-
-## Profiles
-
-Use `galley profile` commands to validate profiles or locate the repository-specific profile directory.
-
-```sh
-galley profile validate --kind quality examples/quality-default.yaml
-galley profile validate --kind environment examples/environment-local.yaml
 galley profile resolve --cwd /path/to/repo --mkdir --output json
 ```
 
-See [profiles.md](profiles.md) for supported fields and examples.
+Each executor attempt writes evidence under `runs/<run-id>/attempt-N/`. Depending on how far the attempt progressed, it can include:
 
-## Daemon
+- `command_plan.json`
+- `run_result.json`
+- raw provider output
+- `executor_result.json`
+- `supervisor_verdict.json`
+- `git_status.json`
+- `diff.patch`
+- `workspace.json`
+- `profiles.json`
+- `supervisor.json`
 
-```sh
-galley daemon start
-galley daemon status --output json
-galley daemon stop
-galley daemon run --once
-```
+Run directory names begin with the task ID. Use `task show` to identify the latest attempt number and any reported error artifact path before opening these files. [Troubleshooting](troubleshooting.md#inspecting-run-evidence) maps common questions to the relevant artifact.
 
-`galley daemon run --once` drains queued tasks once and exits. Background `galley daemon start` also performs daemon maintenance such as PR comment polling and closed or merged PR worktree cleanup according to `environment.yaml`.
+## Notifications
 
-For PR automation and cleanup details, see [pr-automation.md](pr-automation.md).
-
-`--root` points at the daemon root and defaults to `~/.galley`. Use `--root .agent-workflow` only for repo-local or test workflows.
-
-`galley daemon start` launches the daemon in the background. It writes a PID file and appends stdout and stderr to a log file. By default those files are under `~/.galley`; override them with `--pid-file` and `--log-file`.
-
-`galley daemon stop` reads the PID file, sends `SIGTERM`, waits up to `--stop-timeout`, and removes the PID file when it still points at the stopped process. `galley daemon status` reports whether the PID file points at a live process.
-
-Use the installed `galley` binary for `start`, `status`, and `stop`. PID verification records the executable path, so `go run ./cmd/galley ... daemon start` is not suitable for background daemon control because later `go run` invocations use different temporary binaries.
-
-### Daemon startup defaults (`daemon.yaml`)
-
-Both `galley daemon run` and `galley daemon start` create `daemon.yaml` under the selected daemon root on first use. The file holds durable startup defaults such as `supervisor`, concurrency, polling, timeout, and notification settings. `galley daemon status` and `galley daemon stop` are read-only.
-
-CLI flags on `galley daemon run` or `galley daemon start` always override the matching `daemon.yaml` field for that run (including `--shutdown-timeout`). Anything you do not set on the CLI falls back to `daemon.yaml`; anything `daemon.yaml` does not set falls back to the built-in default.
-
-Runtime loading ignores unknown `daemon.yaml` keys while rejecting invalid values for known keys.
-
-### Notifications
-
-The daemon can run an opt-in, best-effort command hook after a task reaches a terminal published status. Notifications are configured only in `daemon.yaml`.
+The daemon can run an operator-owned command after a task reaches a configured terminal status. Notifications are best-effort and never change task state.
 
 ```yaml
 notifications:
@@ -121,143 +147,48 @@ notifications:
   command: "/absolute/path/to/docs/examples/notifications/notify-slack.sh"
 ```
 
-Fields:
+An empty `on` list uses `[failed, needs_supervisor_review]`. The command may also subscribe to `accepted` and `pr_opened`.
 
-- `enabled` (bool, default `false`): gates the hook. When `true`, `command` must be set.
-- `on` (list, optional): terminal task statuses that trigger the hook. Empty means `[failed, needs_supervisor_review]`.
-- `command` (string): the operator-owned shell command to run.
+Galley sends one JSON object on stdin:
 
-#### Hook input
+- `task_id`
+- `status`
+- `repo`
+- `summary`
+- `run_dir`
+- `show_hint`
 
-Task-derived data is passed to the command as data, never as part of the command string. Each invocation receives:
+The same values are available as `GALLEY_TASK_ID`, `GALLEY_TASK_STATUS`, `GALLEY_REPO`, `GALLEY_SUMMARY`, and `GALLEY_RUN_DIR`. Summary values are limited to 280 runes.
 
-- A single-line JSON object on stdin with these fields:
-  - `task_id` — the task ID.
-  - `status` — the terminal published status that triggered the hook.
-  - `repo` — the task `scope.cwd`.
-  - `summary` — a short human-readable summary (latest attempt summary, falling back to the latest risk detail, then the task goal), truncated to 280 runes with a trailing `…` when clipped.
-  - `run_dir` — the run evidence directory for the attempt, when available.
-  - `show_hint` — the inspection command an operator can run, `galley task show <task_id>`.
-- The same values mirrored as namespaced environment variables: `GALLEY_TASK_ID`, `GALLEY_TASK_STATUS`, `GALLEY_REPO`, `GALLEY_SUMMARY` (also truncated to 280 runes), and `GALLEY_RUN_DIR`.
+Task data is never inserted into the command string. The hook runs asynchronously with a fixed 30-second timeout. Failures are logged without retry and do not affect the task. Galley does not store webhook URLs or other notification secrets; the command environment owns them.
 
-#### Timeout and failure behavior
-
-The hook is best-effort and never changes task state. It runs asynchronously, has a fixed 30-second timeout, and logs failures without retrying delivery. During daemon shutdown, in-flight notifications may be canceled.
-
-#### Security boundary
-
-The `command` string is operator-owned. Task content is untrusted and is delivered only through stdin JSON and `GALLEY_*` environment variables. Sample hooks live under [`docs/examples/notifications/`](examples/notifications/).
-
-#### Non-goals
-
-- No built-in Slack, email, desktop, or other native notifier. Galley only runs the operator-provided command.
-- No secrets storage. Any webhook URL, token, or credential is owned by the operator's command/environment (for example `SLACK_WEBHOOK_URL` exported for `notify-slack.sh`); Galley never holds or persists the secret.
-- No operator-tunable timeout, retries, or delivery guarantees.
-
-### Supervisor resolution
-
-`--supervisor` selects the built-in supervisor adapter (`claude`, `codex`, `glm`, or `grok`). Grok uses the logged-in `grok` CLI. The daemon resolves the supervisor for each task in this order:
-
-1. The repository `environment.yaml` `supervisor.default_cli` (resolved from `scope.cwd`). This overrides every layer below for that task only.
-2. The daemon CLI `--supervisor` startup flag.
-3. The `supervisor` field in `daemon.yaml`.
-4. The built-in default (`claude`).
-
-`galley daemon status` omits startup defaults it cannot report accurately, such as effective supervisor and concurrency. `runs/<run-id>/supervisor.json` records the adapter, model, effort, and each setting's source.
-
-Set `supervisor.model` in the repository profile to pass an exact model name to every built-in supervisor evaluation. See [profiles.md](profiles.md#environmentyaml) for fallback behavior.
-
-On Unix, foreground and background daemons use the same shutdown path. On `SIGINT` or `SIGTERM`, Galley stops claiming new queued tasks, lets active attempts finish until the shutdown timeout, records evidence, and avoids starting another retry attempt after shutdown is requested.
-
-### Windows
-
-Windows has no SIGTERM equivalent that can be delivered to a console-less background process, so background `galley daemon start`/`stop` performs an immediate `TerminateProcess` rather than a graceful shutdown:
-
-- `galley daemon status` uses `OpenProcess` + `GetExitCodeProcess` to verify the recorded PID instead of the Unix `signal(0)` probe. `STILL_ACTIVE` (Windows exit code 259) reports alive; any other exit code reports stopped.
-- `galley daemon stop` terminates the daemon PID directly. Active executor/supervisor attempts running under that daemon do not get a chance to record graceful-shutdown evidence on Windows; the next daemon startup recovers any interrupted running task.
-- `galley daemon stop --force` terminates the daemon plus every recorded executor/supervisor child. On Windows, descendant processes spawned by those children may require OS-level cleanup.
-- For a graceful shutdown on Windows, run `galley daemon run` in the foreground and stop it with `Ctrl+C`. The foreground daemon shutdown path is the same on every OS: it stops claiming new tasks, lets active attempts finish until `--shutdown-timeout`, and records evidence.
+Sample hooks are in [`docs/examples/notifications/`](examples/notifications/).
 
 ## Force Stop
 
-`galley daemon stop --force` is an escape hatch for a stalled daemon. It:
+Use `galley daemon stop --force` only when normal stop cannot end a stalled daemon. Galley first tries normal shutdown, then terminates the verified daemon and its recorded executor and supervisor process groups.
 
-1. Tries the normal graceful shutdown first.
-2. Re-verifies process identity and sends `SIGKILL` when the daemon has not exited within `--stop-timeout`.
-3. After the daemon is gone, sends `SIGKILL` to every registered executor and supervisor child process group recorded under the daemon root, waiting up to the same `--stop-timeout`.
-4. If any child process group is still alive after that wait, prints an error naming the surviving PIDs and PGIDs and leaves the PID file in place so the operator can target the same daemon record.
+Force stop can interrupt active work. The next daemon startup recovers tasks left in `running`; inspect their latest state and evidence before deciding whether to requeue.
 
-A force kill can interrupt an active attempt; the next daemon startup recovers the interrupted running task.
+On Unix, normal foreground and background shutdown stops new claims and gives active attempts the configured shutdown timeout. On Windows, background stop uses immediate process termination because a console-less process has no SIGTERM equivalent. Run `galley daemon run` in the foreground and stop it with `Ctrl+C` when graceful Windows shutdown is required.
+
+On Windows, `stop --force` terminates the recorded daemon and direct child processes. Descendants created outside those process relationships may require OS-level cleanup.
 
 ## Timeouts
 
-Galley uses two timeout concepts:
+Galley uses two independent timeout boundaries:
 
-- `--idle-timeout`: kills executor or built-in supervisor subprocesses that stop producing output.
-- `execution_policy.timeout_ms`: bounds the total wall-clock duration of one executor attempt.
+- daemon `idle_timeout` or `--idle-timeout` stops an executor or supervisor that produces no output
+- task `execution_policy.timeout_ms` limits the total wall-clock duration of one executor attempt
 
-Executor idle timeouts are recorded as `error_kind: idle_timeout` and as `idle_timed_out: true` in run evidence, then the task loop continues according to the task loop budget.
+Executor idle timeouts are recorded as executor interruptions. A supervisor idle timeout preserves its supervisor artifacts and moves the task to `needs_supervisor_review`. Use `task show` before changing a timeout; an authentication or provider failure should be fixed rather than hidden behind a longer limit.
 
-Galley runs one built-in supervisor evaluation per executor attempt. A supervisor process or verdict failure writes evidence under `runs/<run-id>/attempt-N/supervisor-try-1/` and moves the task to supervisor review; requeue after changing the supervisor conditions or when the backend is healthy.
+## Filesystems and Concurrency
 
-If the supervisor is killed by the idle-output watchdog, Galley records `error_phase: supervisor` and `error_kind: supervisor_idle_timeout`. Requeue the task, or adjust `--idle-timeout` / `--supervisor`.
+- Use local filesystems for the daemon root and managed worktrees. Shared filesystems may not provide the rename and timestamp behavior queue claims expect.
+- Avoid very short claim TTLs. Filesystems with coarse timestamp resolution can make stale-claim recovery noisy.
+- Multiple daemons can share a root because queue claims reject conflicting ownership. Do not share one PID file across unrelated daemon processes.
+- Running tasks refresh their ownership record while the executor loop is active. On startup, Galley requeues tasks whose recorded daemon is dead or cannot be verified and leaves tasks owned by a live daemon untouched.
+- PR comment polling uses `gh api`. Choose a polling interval appropriate for the number of repositories and the account's GitHub API limits.
 
-## Operational Notes
-
-### Filesystems
-
-- Galley is intended for trusted local repositories and local filesystems. Queue claims rely on no-overwrite file creation plus atomic rename behavior on the same filesystem.
-- No-overwrite queue/task moves (`task queue`, `task requeue`, archive, and daemon claim/requeue) use `O_CREATE|O_EXCL` rather than `os.Link`, so they no longer require the destination filesystem to implement hardlinks. Duplicate destinations are still rejected on every supported OS.
-- Shared network filesystems may not provide the same rename and mtime behavior as a local disk.
-- Avoid very short `--claim-ttl` values. Filesystems with coarse mtime resolution can make overly aggressive stale-claim detection noisy.
-
-### Concurrency and Recovery
-
-- Running multiple daemon processes is supported by claim conflict handling.
-- Background control uses a local PID file. Avoid sharing the same `--pid-file` across unrelated processes, and prefer one workflow root per managed daemon.
-- Running tasks refresh their YAML mtime at `min(claim_ttl / 4, 1m)` while the executor loop is active. Heartbeat cadence has no separate daemon or CLI setting.
-- Each claimed running task records the owning daemon. On startup the daemon immediately requeues running tasks whose recorded owner is dead or cannot be verified, while leaving tasks still owned by a verified live daemon untouched.
-
-### External Services
-
-- PR comment polling uses `gh api`; choose a polling interval that respects GitHub API rate limits for your account and repository count.
-- Closed or merged PR cleanup treats the task worktree as disposable execution state. Keep anything that should survive cleanup outside the task worktree.
-- Executor process failures and infrastructure errors are reported after the current queue is drained.
-
-## Development
-
-### Schema References
-
-```sh
-galley schema check
-galley schema generate
-```
-
-`galley schema generate` writes the task, quality profile, and environment profile schemas into the packaged skill references. `galley schema check` verifies those reference files still match the Go contracts and is run in CI.
-
-The `examples/` directory is for Galley checkout development and CI validation. Normal users should prefer `~/.galley` tasks created by the plugin skill.
-
-Development build and tests:
-
-```sh
-go test ./...
-go build ./cmd/galley
-```
-
-Run the local smoke test:
-
-```sh
-./scripts/smoke-local.sh
-```
-
-The smoke test builds the binaries, creates a temporary git repository, installs a fake `claude` executable, queues a draft AFK task, runs the daemon once, and verifies that the task reaches `done/accepted` with run evidence.
-
-```sh
-galley task validate examples/afk-task.yaml
-galley task work-order examples/afk-task.yaml
-galley daemon run --once
-```
-
-For local development and release notes, see [../CONTRIBUTING.md](../CONTRIBUTING.md) and [../CHANGELOG.md](../CHANGELOG.md).
-
-Release assets are built by GitHub Actions when a GitHub Release is published. See [../.github/workflows/release.yml](../.github/workflows/release.yml) and [../.goreleaser.yaml](../.goreleaser.yaml).
+Development commands and release procedures are documented in [Contributing](../CONTRIBUTING.md).

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,8 +1,21 @@
 # Profiles
 
-Profiles are optional repository-specific YAML files that help Galley and the supervisor interpret expected quality gates and local execution constraints.
+Profiles hold repository-wide policy. The Galley skill creates them from repository evidence and your approved settings; edit them when the repository's normal quality or runtime expectations change.
 
-The plugin skill can create profiles interactively. For manual setup, resolve the repository profile directory first:
+Galley can run without profiles, but the recommended workflow uses both files so task authors do not have to repeat repository policy in every task.
+
+## Which File to Change
+
+| Change | File |
+| --- | --- |
+| Required checks, review dimensions, evidence, or pass thresholds | `quality.yaml` |
+| Default executor, supervisor, model, effort, commands, constraints, PR behavior, or cleanup | `environment.yaml` |
+| One task's goal, acceptance criteria, scope, executor override, or loop budget | Task YAML |
+| Daemon-wide concurrency, polling, timeouts, credentials, or notifications | `daemon.yaml` |
+
+Task executor fields override repository executor defaults. Repository supervisor settings override the daemon-level supervisor for that repository. See [Models and supervision](supervision.md) for the full resolution order.
+
+For manual setup, resolve the repository profile directory first:
 
 ```sh
 galley profile resolve --cwd /path/to/repo --mkdir --output json
@@ -27,7 +40,7 @@ These files are generated from the Go profile contracts with `galley schema gene
 
 ## quality.yaml
 
-`quality.yaml` defines review expectations for a repository.
+`quality.yaml` defines what acceptable work means for a repository. Keep task-specific requirements in task acceptance criteria; use this profile for standards that should apply to every task.
 
 ```yaml
 id: "default"
@@ -53,6 +66,14 @@ pass_policy:
     - medium
 ```
 
+### Writing a Useful Quality Profile
+
+- Add required checks for commands whose result can be captured mechanically, such as tests, builds, formatters, or schema validation.
+- Write each review dimension as an observable pass condition. A dimension should change an acceptance decision, not restate a general preference.
+- Mark a dimension required only when every task must satisfy it. Use weights and `min_score` for important but non-mandatory dimensions.
+- Avoid duplicating task acceptance criteria. ACs describe the requested outcome; quality dimensions protect repository-wide boundaries such as compatibility, security, or cross-platform behavior.
+- Keep the profile short enough to review as policy. Similar dimensions that lead to the same decision should usually be combined.
+
 Supported fields:
 
 - `id`: profile identifier.
@@ -63,7 +84,7 @@ Supported fields:
 - `review_dimensions[].weight`: non-negative relative weight for reporting.
 - `review_dimensions[].required`: whether the dimension is mandatory.
 - `review_dimensions[].pass`: observable pass condition for the dimension.
-- When review dimensions are configured, the supervisor records reviewed dimension IDs in `quality_passes` or `quality_gaps`. Passed dimensions persist in `task.review_progress`; later attempts cover unfinished dimensions and any passed dimensions implicated by the executor's current-attempt changes. Quality gaps reopen dimensions and drive required-dimension and weighted-score policy independently from consolidated finding categories.
+- When review dimensions are configured, the supervisor records reviewed dimension IDs in `quality_passes` or `quality_gaps`. Passed dimensions persist in `task.review_progress`; later attempts cover unfinished dimensions and revisit a passed dimension when the executor reports a current-attempt change that may affect it. Quality gaps reopen dimensions and drive required-dimension and weighted-score policy independently from consolidated finding categories.
 - `evidence_requirements.file_line_references`: ask for file/line evidence in review output.
 - `evidence_requirements.command_outputs`: ask for command output evidence.
 - `pass_policy.required_dimensions_must_pass`: require all mandatory dimensions to pass.
@@ -79,7 +100,7 @@ galley profile validate --kind quality ~/.galley/profiles/<repo-key>/quality.yam
 
 ## environment.yaml
 
-`environment.yaml` defines local commands and constraints for a repository.
+`environment.yaml` defines how Galley normally runs work for a repository. Task files can override executor settings for an individual job without changing these defaults.
 
 ```yaml
 id: "local-dev"
@@ -111,6 +132,8 @@ worktree:
   cleanup: true
 ```
 
+Use repository defaults for choices that should survive across tasks and requeues. Use task overrides when a single task needs a different executor, model, or effort. PR and cleanup settings belong here because they describe the repository workflow, not the daemon process.
+
 Supported fields:
 
 - `id`: profile identifier.
@@ -120,8 +143,8 @@ Supported fields:
 - `executor.model`: optional model name passed unchanged to the selected executor CLI when the task omits `executor.model`. Empty keeps the CLI default.
 - `executor.effort`: optional default for omitted task effort; effort resolves as task override, then this environment override, then the selected provider CLI's own default when both are empty. Claude and `glm` accept `low`, `medium`, `high`, `xhigh`, or `max`; Codex also accepts `minimal`; Grok also accepts `none` and `minimal`. Without `executor.default_cli`, profile validation accepts the provider union; Galley validates the resolved pair before executor roles run.
 - `supervisor.default_cli`: optional repository-scoped supervisor adapter. Values are `claude`, `codex`, `glm`, and `grok`. When set, it overrides daemon startup supervisor settings for tasks in this repository.
-- `supervisor.model`: optional model name passed unchanged to the selected Codex, Claude, or GLM supervisor CLI. Omit it or use an empty value to keep the CLI default; `runs/<run-id>/supervisor.json` records the effective setting.
-- `supervisor.effort`: optional reasoning effort. Claude and `glm` accept `low`, `medium`, `high`, `xhigh`, or `max`; Codex also accepts `minimal`. Empty uses the CLI default, invalid provider values fail before review, and `supervisor.json` records the value and source.
+- `supervisor.model`: optional model name passed unchanged to the selected supervisor CLI. Omit it or use an empty value to keep the CLI default; `runs/<run-id>/supervisor.json` records the effective setting.
+- `supervisor.effort`: optional reasoning effort. Claude and `glm` accept `low`, `medium`, `high`, `xhigh`, or `max`; Codex also accepts `minimal`; Grok also accepts `none` and `minimal`. Empty uses the CLI default, invalid provider values fail before review, and `supervisor.json` records the value and source.
 - `required_checks.shell`: optional shell for Galley-owned `quality.required_checks` execution. Values are `auto`, `sh`, `bash`, `cmd`, `powershell`, and `pwsh`.
 - `required_checks.shell_path`: optional executable path override for required-check shell selection. When both `shell` and `shell_path` are set, `shell_path` wins.
 - `constraints.network`: local network policy.
@@ -145,3 +168,5 @@ galley profile validate --kind environment ~/.galley/profiles/<repo-key>/environ
 When profiles are loaded, Galley records them in `runs/<run-id>/attempt-N/profiles.json`.
 
 Profiles shape work orders and supervisor review. They do not create a sandbox boundary by themselves; the task scope, worktree, shell environment, and local OS controls still define what can run.
+
+Daemon-wide settings live in `~/.galley/daemon.yaml`; see [Operations](operations.md#daemon-configuration).

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -1,69 +1,96 @@
-# Supervision
+# Models and Supervision
 
-Galley separates implementation from acceptance. The executor produces work and structured evidence; the supervisor reviews that evidence against the task and repository policy.
+Galley separates implementation from acceptance. The executor changes the repository; the supervisor reviews the result against the task and repository policy. You choose both roles explicitly.
 
-## Executors
+Galley does not route tasks to models automatically. This keeps cost, capability, and acceptance authority visible while still allowing different model combinations for different repositories and tasks.
 
-At every run start, Galley resolves each executor field independently:
+## Choosing a Model Setup
 
-1. explicit task `executor.cli` / `executor.model` / `executor.effort`
-2. current repository `environment.yaml` `executor.default_cli` / `executor.model` / `executor.effort`
-3. the built-in `cli: claude` default; an omitted effort or model lets the selected provider CLI choose its own reasoning effort and model
+Use the combination that fits the work and the level of review you need.
 
-Environment values remain runtime-only, so requeues pick up current profile defaults. All executor roles use the same resolution, validated before invocation.
+| Pattern | When it fits |
+| --- | --- |
+| Same backend for executor and supervisor | A simple default when one provider is already trusted for the repository. |
+| Faster or lower-cost executor with a stronger supervisor | Routine implementation where review quality matters more than using the strongest model for every attempt. |
+| Specialized executor with an independent supervisor | Tasks that benefit from a provider's tooling, context, or coding behavior while retaining a separate acceptance check. |
 
-Galley supports Claude Code, Codex, GLM, and Grok. GLM uses the `claude` binary and `glm_api_key`; Grok uses its logged-in CLI state. Galley owns provider prompt transport.
+The supervisor is not a substitute for suitable acceptance criteria or repository policy. A weaker executor can be useful when the task is bounded and the checks are strong; vague work with weak evidence remains difficult to supervise regardless of model choice.
 
-See [task-yaml.md](task-yaml.md) for the full `executor` block and [../examples/afk-task-codex.yaml](../examples/afk-task-codex.yaml) for a Codex task example.
+## Supported Backends
 
-## Supervisors
+Executors and supervisors support `claude`, `codex`, `glm`, and `grok`.
 
-Supervisor review defaults to Claude. Use `--supervisor codex` for Codex, `--supervisor glm` for GLM (the `claude` binary pointed at GLM's Z.ai endpoint; needs `glm_api_key` in `daemon.yaml`), or `--supervisor claude` to be explicit. The supervisor is the acceptance gate; the backend is your choice.
+- Claude uses the `claude` CLI.
+- Codex uses the `codex` CLI.
+- GLM uses the `claude` CLI with the Z.ai endpoint and requires `glm_api_key` in `daemon.yaml`.
+- Grok uses the logged-in `grok` CLI state.
 
-All supervisor backends use the same verdict contract and evidence layout. Repository-specific PR behavior, comment polling, and worktree cleanup live in the environment profile resolved from `scope.cwd`.
+All backends use Galley-owned prompt transport, result contracts, and evidence layout.
 
-Supervisor selection controls only review. It is independent from the executor backend in `executor.cli`.
+## Executor Configuration
+
+Galley resolves `cli`, `model`, and `effort` independently at the start of every run:
+
+1. the task's `executor` field
+2. the repository `environment.yaml` executor defaults
+3. the built-in `cli: claude` fallback
+
+There is no built-in model or effort default. When both the task and environment profile omit one of those fields, the selected provider CLI uses its own configured default.
+
+Task overrides are useful for a single job. Environment defaults define the repository's normal implementation setup. A requeued task picks up repository-level model changes because Galley reads the profile at the start of each run.
+
+See [Task YAML](task-yaml.md#execution-policy-and-executor) for task overrides, [Profiles](profiles.md#environmentyaml) for repository defaults, and the [Codex task example](../examples/afk-task-codex.yaml) for a complete file.
+
+## Supervisor Configuration
+
+The supervisor backend resolves in this order:
+
+1. repository `environment.yaml` `supervisor.default_cli`
+2. the daemon startup `--supervisor` flag
+3. `supervisor` in `daemon.yaml`
+4. the built-in `claude` default
+
+The repository environment profile also supplies the supervisor model and effort. `runs/<run-id>/supervisor.json` records the resolved backend, model, effort, and the source of each setting.
+
+Executor and supervisor choices are independent. Changing the task executor does not change the supervisor.
+
+## How Review Converges
+
+The first supervisor attempt reviews every acceptance criterion before reviewing every configured quality dimension. This ordering keeps task obligations primary while still applying repository-wide standards.
+
+Galley persists verified passes in daemon-owned task state. Later attempts review unfinished items and revisit a verified pass when the executor reports a current-attempt change that may affect it. The next executor receives the active revision work rather than an unstructured history of every earlier review.
+
+A normal requeue preserves review progress when the task direction and review contract remain the same. Galley resets stale passes when the goal, acceptance contract, review policy, source repository, or placed input content changes in a way that invalidates earlier review.
 
 ## Acceptance Requirements
 
-Accepted tasks must:
+An accepted implementation task needs:
 
-- report every task acceptance criterion by ID
-- mark every required acceptance criterion as `satisfied`
-- include evidence for satisfied acceptance criteria
-- report required quality checks as passed verification evidence
-- return valid structured JSON matching the executor result schema
+- a normal executor terminal with valid structured output
+- a repository diff unless the task is explicitly investigation or review-only
+- satisfied required acceptance criteria with evidence
+- passing evidence for required checks
+- all required quality dimensions and the configured weighted score
+- no unresolved finding at a blocking severity
 
-Otherwise the task is retried until `execution_policy.loop_budget` is exhausted; `loop_budget: 0` has no attempt cap.
+Incomplete work can continue while the loop budget remains when the supervisor returns actionable revision work. Human decisions, exhausted budgets, supervisor failures, and finalization problems move the task to `needs_supervisor_review`. A hard stop or executor interruption ends the run without another attempt.
 
-For implementation tasks, the supervisor should reject a no-diff result unless the task is explicitly investigation or review-only and the evidence explains why no repository change was expected.
+`completed_with_risks` means the executor considers the implementation coherent but has verification limits, assumptions, or residual risks for the supervisor to evaluate.
 
-## Verdict Outcomes
+## Outcomes
 
-| Condition | Result |
+| Outcome | What Galley does |
 | --- | --- |
-| `completed` with diff, satisfied ACs, evidence, and required checks | `tasks/done/` with status `accepted` |
-| `completed` with executor-actionable implementation, scope, acceptance, or verification blockers | retry, then `tasks/failed/` with status `needs_supervisor_review` if the loop budget is exhausted |
-| `completed` with blockers that require human judgment about product, design, environment, external services, or required-check policy | `tasks/failed/` with status `needs_supervisor_review` |
-| `completed` with an external or unrecoverable blocker that prevents meaningful progress | `tasks/failed/` with status `failed` |
-| `completed_with_risks` | retry, then `tasks/failed/` with status `needs_supervisor_review` |
-| Parse failure or schema validation failure | retry, then `tasks/failed/` with status `needs_supervisor_review` |
-| Two consecutive attempts with no git diff | stop early as a no-progress safeguard |
-| `hard_stop` | `tasks/failed/` with status `failed`, without retry |
-| Executor interruption (provider or runtime, before any normal terminal) | `tasks/failed/` with status `failed`, without Supervisor review or another attempt |
+| Accepted | Moves the task to `done/accepted`, then performs configured PR handoff. |
+| Executor-actionable revision | Starts another executor attempt while the loop budget remains. |
+| Human decision or exhausted loop | Moves the task to `failed/needs_supervisor_review` with the latest evidence and work order. |
+| Supervisor process or verdict failure | Preserves supervisor artifacts and moves the task to `needs_supervisor_review`. |
+| Hard stop | Moves the task to `failed/failed` without retry. |
+| Executor interruption before a normal terminal | Preserves the worktree and evidence, skips supervisor review, and moves the task to `failed/failed`. |
+| Two consecutive attempts with no diff | Stops early as a no-progress safeguard. |
 
-`needs_supervisor_review` is a task state, not a daemon process failure. `galley daemon run --once` can exit 0 after recording that state.
+`needs_supervisor_review` is a task state, not a daemon process failure. `galley daemon run --once` can exit successfully after recording it.
 
-## Executor Interruptions
+Hard stops are reserved for conditions that leave no useful executor action, such as missing required secrets, inaccessible required systems, contradictory acceptance criteria, protected destructive actions, or unreadable required files.
 
-Before normal Supervisor review, Galley decides whether an executor attempt reached a reliable normal provider terminal. Claude and GLM success result events, Codex `turn.completed`, and Grok `EndTurn` are normal terminals; explicit failed terminals, start failures, timeouts, kills, and output with no reliable normal terminal are interruptions. The decision uses runner state and machine-readable provider output, never the process exit code or error text alone.
-
-An interrupted attempt does not invoke the Supervisor and does not start another executor attempt in the same run, regardless of loop budget or worktree diff. Galley captures the command plan, run result, raw provider output, git status, diff, and a terminal-decision record, preserves the tracked and untracked worktree changes, and publishes the task to `tasks/failed/` with status `failed`. The attempt records an executor-owned error with the non-verdict marker `not_reviewed` and retains any provider status, code, stop reason, session ID, or message detail for diagnosis; unavailable detail falls back to a generic interruption reason without changing routing.
-
-An executor-result parse or schema-validation failure that follows a normal terminal is not an interruption: it stays reviewable, and a `needs_revision` verdict continues to start the next executor attempt under the existing loop budget.
-
-Resolve the interruption cause (for example a provider outage or a local dependency), then resume the retained worktree with `galley task requeue`.
-
-`completed_with_risks` means the executor believes the implementation is coherent, but verification limits, assumptions, or residual risks still need supervisor attention.
-
-Hard stops are reserved for blockers such as missing required secrets, inaccessible required systems, contradictory acceptance criteria, out-of-scope destructive actions, unreadable required files, or runtime failures that leave no useful next step.
+For state-specific recovery steps, see [Troubleshooting](troubleshooting.md).

--- a/docs/task-yaml.md
+++ b/docs/task-yaml.md
@@ -1,6 +1,6 @@
 # Task YAML
 
-Task YAML is the trusted local input that tells Galley what to execute, where to execute it, how to judge completion, and how to handle PR automation.
+Task YAML is the trusted local input that tells Galley what to execute, where to execute it, and how to judge completion. Repository-wide PR behavior belongs in `environment.yaml`.
 
 Use the plugin skill for normal authoring. This document is the reference for reviewing or hand-writing a task file.
 
@@ -66,7 +66,7 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `executor`: optional per-field overrides for CLI, model, and effort.
 - `preflight.acceptance_skeleton.enabled`: optional boolean that selects the fixed skeleton preflight flow.
 - `decisions`, `risks`: author and executor notes.
-- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state populated during lifecycle transitions. An attempt that ended in an executor interruption records `supervisor_verdict: not_reviewed` and an executor-phase `error` with the retained provider detail; see [supervision.md](supervision.md#executor-interruptions).
+- `supervisor`, `attempts`, `verification`, `pr`: daemon-owned runtime state populated during lifecycle transitions. An attempt that ended in an executor interruption records `supervisor_verdict: not_reviewed` and an executor-phase `error` with the retained provider detail; see [Troubleshooting](troubleshooting.md#executor-interruption).
 
 ## Execution Policy And Executor
 
@@ -77,7 +77,7 @@ galley task queue ./TASK.yaml --reason "queue for daemon"
 - `executor`: optional. Each `cli`, `model`, and `effort` field resolves from the task, then current `environment.yaml`. Only `cli` has a built-in fallback (`claude`); an omitted `effort` or `model` lets the selected provider CLI choose its own reasoning effort and model. Environment values remain runtime-only.
 - `executor.cli`: selects `claude`, `codex`, `glm`, or `grok`. Grok uses the logged-in `grok` CLI for setup, acceptance-skeleton creation, and implementation.
 - `executor.model`: optional model override. Omit it to use the selected CLI's configured default model.
-- `executor.effort`: optional effort hint. Claude and `glm` accept `low`, `medium`, `high`, `xhigh`, and `max`; Codex also accepts `minimal`; Grok also accepts `none`. Omit it to let the selected provider CLI use its own configured reasoning-effort default. Invalid provider combinations fail before executor roles run.
+- `executor.effort`: optional effort hint. Claude and `glm` accept `low`, `medium`, `high`, `xhigh`, and `max`; Codex also accepts `minimal`; Grok also accepts `none` and `minimal`. Omit it to let the selected provider CLI use its own configured reasoning-effort default. Invalid provider combinations fail before executor roles run.
 - Prompt transport is Galley-owned. Task YAML no longer accepts `executor.prompt_profile` or `executor.prompt_mode`; older files that still include those keys are ignored by the unknown-field-tolerant decoder.
 
 ## Permissions
@@ -186,6 +186,8 @@ galley task list
 galley task show TASK_ID
 galley task requeue TASK_ID --reason "retry after transient failure"
 ```
+
+See [Troubleshooting](troubleshooting.md) for the meaning of each terminal status and when to requeue instead of creating a new task.
 
 ## Compatibility
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,120 @@
+# Troubleshooting
+
+Start with the task, not the daemon log. Galley records the latest actionable state on the task and keeps detailed evidence for deeper inspection.
+
+```sh
+galley task list
+galley task show TASK_ID
+galley task show TASK_ID --output json
+galley daemon status --output json
+```
+
+`task list` locates the task and shows its current state. `task show` explains the latest attempt, verdict, error, risk, and recovery hint; JSON output includes the complete persisted task state. Check the daemon only when queued work is not being claimed or the task state does not match the running process.
+
+## What the Task State Means
+
+| State or status | Meaning | Next action |
+| --- | --- | --- |
+| `draft` | The task has not been queued. | Review and validate it, then queue it. |
+| `queued` | The task is waiting for a daemon. | Confirm the daemon is running and uses the same root. |
+| `running` | A daemon owns the task. | Let the attempt finish. If its daemon is gone, restart the daemon to recover the task. |
+| `needs_supervisor_review` | Galley preserved the result but needs a person to resolve a review, policy, or environment issue. | Read the latest verdict and work order. Change the relevant task, profile, model, or environment before requeueing. |
+| `failed` with `latest_executor_interruption: true` | The executor did not reach a reliable normal terminal. The supervisor was not run. | Resolve the provider or runtime problem, then requeue the retained worktree. |
+| `failed` | Galley reached a hard stop or another terminal failure. | Read the latest error and risk before deciding whether the task can safely resume. |
+| `accepted` | The work passed review and remains local. | Inspect the worktree or archive the task when it is no longer needed. |
+| `pr_opened` | The accepted work was committed, pushed, and opened as a pull request. | Continue normal review in GitHub. |
+| `closed` or `merged` | The recorded pull request reached its terminal GitHub state. | No action is normally required. |
+
+## A Queued Task Does Not Start
+
+Check the daemon and its root:
+
+```sh
+galley daemon status --output json
+galley daemon start
+```
+
+The task and daemon must use the same Galley root. The default is `~/.galley`; custom roots must be supplied consistently. If the daemon exits during startup, inspect `galley-daemon.log` and validate `daemon.yaml` values.
+
+If the daemon is running, `galley task show TASK_ID` usually exposes profile loading, workspace creation, or task validation failures after the task is claimed.
+
+## Executor Interruption
+
+An interruption means the selected provider or local runtime did not produce a reliable normal terminal. Common causes include provider outages, authentication failures, CLI startup errors, idle timeouts, process kills, and machine shutdown.
+
+Galley does not send interrupted output to the supervisor or retry it within the same run. It preserves tracked and untracked worktree changes and records the provider terminal details when available.
+
+Malformed executor JSON after a normal provider terminal is different: Galley keeps the diff reviewable and lets the supervisor decide whether another executor attempt is useful. `task show` marks only the pre-terminal failure path as `latest_executor_interruption: true`.
+
+After resolving the cause, resume the same worktree:
+
+```sh
+galley task requeue TASK_ID --reason "resolved executor interruption"
+```
+
+Requeueing is appropriate when the task direction is unchanged and the retained work is still useful. Queue a new task instead when the goal, repository, or acceptance contract has materially changed.
+
+## Supervisor Review Is Required
+
+`needs_supervisor_review` is a task result, not a daemon crash. Start with:
+
+```sh
+galley task show TASK_ID
+```
+
+The persisted supervisor requests and the latest verdict artifact should identify whether the next step belongs to the executor or a person. Typical cases are:
+
+- the loop budget ended with unresolved review findings
+- a required check or quality policy needs a human decision
+- the supervisor process or verdict failed
+- the accepted diff could not be finalized safely
+- an external service or credential is unavailable
+
+Change only the layer that owns the problem. Edit the task for task-specific scope or executor overrides, the repository profiles for persistent quality or runtime settings, and `daemon.yaml` for daemon-wide operation. Then requeue with a reason that records what changed.
+
+## A Running Task Outlives Its Daemon
+
+On startup, Galley recovers running tasks whose recorded owner is dead or cannot be verified. Start the daemon and check the task again:
+
+```sh
+galley daemon start
+galley task show TASK_ID
+```
+
+A normal daemon stop lets active attempts finish until the shutdown timeout. Use force stop only for a stalled daemon:
+
+```sh
+galley daemon stop --force
+```
+
+Force stop can interrupt active executor or supervisor processes. The next daemon startup recovers their tasks; inspect each recovered task before requeueing work that failed.
+
+See [Operations](operations.md#force-stop) for platform-specific process behavior.
+
+## PR Creation or Comment Handling Fails
+
+PR automation depends on an authenticated GitHub CLI and network access:
+
+```sh
+gh auth status
+```
+
+Use `task show` to distinguish an accepted implementation from a commit, push, or `gh pr create` failure. Fix the GitHub or repository condition before requeueing. For comment requeues, confirm that comments are enabled in `environment.yaml`, the daemon is running, the PR remains open, and the command comes from the recorded PR author.
+
+See [PR automation](pr-automation.md) for accepted command forms and cleanup behavior.
+
+## Inspecting Run Evidence
+
+Run directories begin with the task ID under `~/.galley/runs/`. `task show` reports the latest attempt number and, for errors that have a dedicated artifact directory, prints that path directly. Start with the artifact that matches the question:
+
+| Question | Evidence |
+| --- | --- |
+| What command did Galley run? | `command_plan.json` |
+| Did the provider process start, time out, or exit? | `run_result.json` and raw provider output |
+| What did the executor report? | `executor_result.json` |
+| Why did the supervisor accept or reject the work? | `supervisor_verdict.json` |
+| What changed in the worktree? | `git_status.json` and `diff.patch` |
+| Which profiles and workspace were used? | `profiles.json` and `workspace.json` |
+| Which supervisor model and setting source were used? | `supervisor.json` |
+
+Not every attempt produces every file. For example, an executor interruption records no supervisor verdict because review was intentionally skipped.


### PR DESCRIPTION
## Summary

- refresh the README around explicit executor and supervisor selection, repository policy, focused retries, and pull request handoff
- add a goal-based documentation index and task-state troubleshooting guide
- reorganize model configuration, profiles, daemon operation, evidence, and task reference material by user need
- correct stale task and provider configuration details found during the documentation audit

## Validation

- relative Markdown links and heading anchors: passed
- trailing whitespace check: passed
- `git diff --check`: passed
