### PR TITLE
Fix executor override indentation handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "galley",
       "source": "./plugins/galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "author": {
         "name": "Shinsuke Kagawa",
         "url": "https://github.com/shinpr"

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "galley",
       "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "category": "development",
       "source": {
         "source": "local",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project follows semantic versioning.
 ### Changed
 
 - Successful `galley daemon stop --force` now moves tasks owned by that daemon to `failed` with interruption evidence while retaining their worktrees for requeue or archive.
-- Packaged Galley plugins are now versioned as `0.1.29`; task authoring uses a 60-minute per-attempt timeout baseline so productive executors can complete without interruption.
+- Packaged Galley plugins are now versioned as `0.1.30`; task authoring uses a 60-minute per-attempt timeout baseline so productive executors can complete without interruption, and the executor override helper preserves hand-authored and daemon-serialized YAML indentation.
 
 ## v0.12.0 - 2026-07-19
 

--- a/plugins/galley/.claude-plugin/plugin.json
+++ b/plugins/galley/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "galley",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "author": {
     "name": "Shinsuke Kagawa",
     "url": "https://github.com/shinpr"

--- a/plugins/galley/.codex-plugin/plugin.json
+++ b/plugins/galley/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/plugin.json
+++ b/plugins/galley/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Create, validate, queue, set up, and troubleshoot Galley AFK task workflows.",
   "author": {
     "name": "Shinsuke Kagawa",

--- a/plugins/galley/skills/galley/scripts/update_task_executor.py
+++ b/plugins/galley/skills/galley/scripts/update_task_executor.py
@@ -8,7 +8,7 @@ import json
 import pathlib
 import re
 import sys
-from typing import Final
+from typing import Final, NamedTuple
 
 
 FIELDS: Final = ("cli", "model", "effort")
@@ -16,7 +16,7 @@ UNCHANGED: Final = object()
 EXECUTOR_HEADER = re.compile(r"^executor:[ \t]*(?:\{\})?[ \t]*(?:\r?\n|$)", re.MULTILINE)
 ANY_EXECUTOR_HEADER = re.compile(r"^executor:", re.MULTILINE)
 TOP_LEVEL_KEY = re.compile(r"^[A-Za-z0-9_-]+:", re.MULTILINE)
-FIELD_LINE = re.compile(r"^  (cli|model|effort):[ \t]*(.*)$")
+FIELD_LINE = re.compile(r"^( +)(cli|model|effort):[ \t]*(.*)$")
 ANY_FIELD_LINE = re.compile(r"^\s+(cli|model|effort):")
 INSERT_BEFORE = re.compile(
     r"^(?:preflight|decisions|risks|discussion_items|revision_requests|attempts|verification|pr):",
@@ -26,6 +26,12 @@ INSERT_BEFORE = re.compile(
 
 class UpdateError(ValueError):
     """Raised when the canonical executor mapping cannot be updated."""
+
+
+class ExecutorFields(NamedTuple):
+    values: dict[str, str]
+    extras: list[str]
+    indent: str
 
 
 def executor_block(text: str) -> tuple[int, int, str] | None:
@@ -43,26 +49,35 @@ def executor_block(text: str) -> tuple[int, int, str] | None:
     return header.start(), end, text[header.end() : end]
 
 
-def existing_fields(body: str) -> tuple[dict[str, str], list[str]]:
+def existing_fields(body: str) -> ExecutorFields:
     values: dict[str, str] = {}
     extras: list[str] = []
+    indent = ""
     for line in body.splitlines():
         match = FIELD_LINE.fullmatch(line)
         if match:
-            field = match.group(1)
+            current_indent = match.group(1)
+            if indent and current_indent != indent:
+                raise UpdateError("executor fields must use consistent indentation")
+            indent = current_indent
+            field = match.group(2)
             if field in values:
                 raise UpdateError(f"executor.{field} appears more than once")
-            values[field] = match.group(2)
+            values[field] = match.group(3)
         elif ANY_FIELD_LINE.match(line):
-            raise UpdateError("executor fields must use two-space indentation")
+            raise UpdateError("executor fields must use consistent space indentation")
         elif line.strip():
             extras.append(line)
-    return values, extras
+    return ExecutorFields(values, extras, indent or "  ")
 
 
-def rendered_block(values: dict[str, str], extras: list[str], newline: str) -> str:
-    lines = [f"  {field}: {values[field]}" for field in FIELDS if field in values]
-    lines.extend(extras)
+def rendered_block(fields: ExecutorFields, newline: str) -> str:
+    lines = [
+        f"{fields.indent}{field}: {fields.values[field]}"
+        for field in FIELDS
+        if field in fields.values
+    ]
+    lines.extend(fields.extras)
     if not lines:
         return ""
     return newline.join(["executor:", *lines]) + newline
@@ -71,16 +86,16 @@ def rendered_block(values: dict[str, str], extras: list[str], newline: str) -> s
 def update_executor_yaml(text: str, changes: dict[str, object]) -> str:
     newline = "\r\n" if "\r\n" in text else "\n"
     block = executor_block(text)
-    values, extras = existing_fields(block[2]) if block else ({}, [])
+    fields = existing_fields(block[2]) if block else ExecutorFields({}, [], "  ")
     for field, requested in changes.items():
         if requested is UNCHANGED:
             continue
         if requested is None:
-            values.pop(field, None)
+            fields.values.pop(field, None)
         else:
-            values[field] = json.dumps(requested, ensure_ascii=False)
+            fields.values[field] = json.dumps(requested, ensure_ascii=False)
 
-    rendered = rendered_block(values, extras, newline)
+    rendered = rendered_block(fields, newline)
     if block:
         return text[: block[0]] + rendered + text[block[1] :]
     if not rendered:

--- a/tests/plugins/galley/skills/galley/test_update_task_executor.py
+++ b/tests/plugins/galley/skills/galley/test_update_task_executor.py
@@ -88,6 +88,42 @@ def test_updates_only_requested_executor_fields(tmpdir: pathlib.Path) -> None:
         raise AssertionError("unrequested executor fields were not preserved")
 
 
+def test_updates_daemon_serialized_executor_fields(tmpdir: pathlib.Path) -> None:
+    task_path = tmpdir / "task.yaml"
+    original = (
+        "id: task-1\n"
+        "executor:\n"
+        "    cli: kimi\n"
+        "    model: k3\n"
+        "    effort: high\n"
+        "risks: []\n"
+    )
+    write_task(task_path, original)
+
+    result = run_updater(
+        task_path,
+        "--cli",
+        "glm",
+        "--model",
+        "glm-5.2",
+        "--effort",
+        "xhigh",
+    )
+
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    expected = (
+        "id: task-1\n"
+        "executor:\n"
+        '    cli: "glm"\n'
+        '    model: "glm-5.2"\n'
+        '    effort: "xhigh"\n'
+        "risks: []\n"
+    )
+    if task_path.read_text(encoding="utf-8") != expected:
+        raise AssertionError("daemon-serialized executor indentation was not preserved")
+
+
 def test_removes_empty_executor_block(tmpdir: pathlib.Path) -> None:
     task_path = tmpdir / "task.yaml"
     write_task(task_path, "id: task-1\nexecutor:\n  cli: codex\nrisks: []\n")
@@ -164,6 +200,7 @@ def main() -> int:
     tests = (
         test_adds_executor_block_without_interpreting_task_status,
         test_updates_only_requested_executor_fields,
+        test_updates_daemon_serialized_executor_fields,
         test_removes_empty_executor_block,
         test_preserves_crlf_line_endings,
         test_preserves_bom_before_first_executor_block,


### PR DESCRIPTION
## Summary

- preserve the indentation of existing executor fields when applying task-level overrides
- cover daemon-serialized four-space task YAML while retaining hand-authored two-space behavior
- bump the packaged Galley plugins to 0.1.30 and merge the release note into the existing Unreleased plugin-version entry

## Verification

- `python3 tests/plugins/galley/skills/galley/test_create_task_skeleton.py`
- `python3 tests/plugins/galley/skills/galley/test_update_task_executor.py`
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/galley-update-executor ./cmd/galley`
- `go run ./cmd/galley schema check`
- example task and profile validation
- JSON manifest and schema validation
- `./scripts/smoke-local.sh`
- `claude plugin validate plugins/galley`
- `claude plugin validate .`
