### PR TITLE
Make Codex structured-output compatibility unavoidable by normalizing each canonical Galley schema while materializing the provider-facing file at one runner-owned boundary shared by implementation, setup, acceptance-skeleton, and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project follows semantic versioning.
 - Successful `galley daemon stop --force` now moves tasks owned by that daemon to `failed` with interruption evidence while retaining their worktrees for requeue or archive.
 - Packaged Galley plugins are now versioned as `0.1.30`; task authoring uses a 60-minute per-attempt timeout baseline so productive executors can complete without interruption, and the executor override helper preserves hand-authored and daemon-serialized YAML indentation.
 
+### Fixed
+
+- Codex structured-output schemas are now normalized at a single runner-owned boundary shared by the implementation executor, setup, acceptance-skeleton creator, and supervisor invocations, so no Codex surface can pass a canonical Galley schema to `codex exec --output-schema` without Codex-compatible adaptation.
+
 ## v0.12.0 - 2026-07-19
 
 ### Added

--- a/internal/daemonctl/process_windows.go
+++ b/internal/daemonctl/process_windows.go
@@ -21,7 +21,7 @@ type ProcessInfoResult struct {
 // ProcessInfo returns stable identity fields for a Windows process using
 // PowerShell's direct process API rather than the transient CIM service.
 func ProcessInfo(pid int) (ProcessInfoResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	script := fmt.Sprintf(
 		`$ErrorActionPreference='Stop';`+

--- a/internal/preflight/setup/codex_schema_test.go
+++ b/internal/preflight/setup/codex_schema_test.go
@@ -1,0 +1,58 @@
+package setup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runner"
+	"github.com/shinpr/galley/internal/task"
+)
+
+// AC2: the setup executor feeds the canonical SetupResult schema; the
+// runner boundary materializes the normalized artifact in RunDir.
+func TestBuildCodexSetupExecutorCommandPlanMaterializesNormalizedSchema(t *testing.T) {
+	t.Parallel()
+	opts := Options{
+		Task: task.Task{
+			ID:       "task-codex-setup-schema",
+			Executor: task.Executor{CLI: "codex", Model: "gpt-5-codex", Effort: "medium"},
+		},
+		WorkDir: t.TempDir(),
+		RunDir:  t.TempDir(),
+	}
+	cmd, provider, err := BuildExecutorCommandPlan(opts, []byte("{}"))
+	if err != nil {
+		t.Fatalf("BuildExecutorCommandPlan: %v", err)
+	}
+	if provider != "codex" {
+		t.Fatalf("provider = %q, want codex", provider)
+	}
+	joined := strings.Join(cmd.Argv, "\n")
+	if !strings.Contains(joined, "--output-schema") {
+		t.Fatalf("codex setup argv missing --output-schema: %v", cmd.Argv)
+	}
+	body, err := os.ReadFile(filepath.Join(opts.RunDir, runner.CodexOutputSchemaFilename))
+	if err != nil {
+		t.Fatalf("read materialized setup schema: %v", err)
+	}
+	if !strings.Contains(string(body), "Galley Setup Executor Result") {
+		t.Fatalf("setup schema derivative lost canonical title: %s", string(body))
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("setup schema derivative invalid JSON: %v", err)
+	}
+	required, _ := doc["required"].([]any)
+	props, _ := doc["properties"].(map[string]any)
+	if len(required) != len(props) {
+		t.Fatalf("normalized setup schema must require every property: required=%d props=%d", len(required), len(props))
+	}
+	for _, bad := range []string{`"allOf"`, `"pattern"`, `"uniqueItems"`} {
+		if strings.Contains(string(body), bad) {
+			t.Fatalf("setup schema derivative must not contain %s: %s", bad, string(body))
+		}
+	}
+}

--- a/internal/preflight/setup/provider.go
+++ b/internal/preflight/setup/provider.go
@@ -120,11 +120,7 @@ func buildCodexSetupExecutorCommandPlan(opts Options, payload []byte) (runner.Co
 	codexOpts.WorkDir = opts.WorkDir
 	codexOpts.Prompt = string(payload)
 	codexOpts.SystemPrompt = prompts.SetupExecutorCodex()
-	schema, err := runner.CodexCompatibleOutputSchema(schemas.SetupResult)
-	if err != nil {
-		return runner.Command{}, fmt.Errorf("prepare setup executor schema: %w", err)
-	}
-	codexOpts.JSONSchema = schema
+	codexOpts.JSONSchema = schemas.SetupResult
 	codexOpts.AttemptDir = opts.RunDir
 
 	commandPlan, err := runner.CodexCommandPlan(codexOpts)

--- a/internal/preflight/skeleton/creator_codex.go
+++ b/internal/preflight/skeleton/creator_codex.go
@@ -31,11 +31,7 @@ func buildCodexCreatorCommandPlan(opts Options, payload []byte) (runner.Command,
 	codexOpts.WorkDir = opts.WorkDir
 	codexOpts.Prompt = string(payload)
 	codexOpts.SystemPrompt = prompts.AcceptanceSkeletonCreatorCodex()
-	schema, err := runner.CodexCompatibleOutputSchema(schemas.AcceptanceSkeletonManifest)
-	if err != nil {
-		return runner.Command{}, creatorErr("prepare built-in creator schema: %v", err)
-	}
-	codexOpts.JSONSchema = schema
+	codexOpts.JSONSchema = schemas.AcceptanceSkeletonManifest
 	codexOpts.AttemptDir = opts.RunDir
 
 	commandPlan, err := runner.CodexCommandPlan(codexOpts)

--- a/internal/preflight/skeleton/creator_codex_schema_test.go
+++ b/internal/preflight/skeleton/creator_codex_schema_test.go
@@ -1,0 +1,49 @@
+package skeleton
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/runner"
+	"github.com/shinpr/galley/internal/task"
+	"github.com/shinpr/galley/schemas"
+)
+
+// AC2: the skeleton creator feeds the canonical manifest schema; the
+// runner boundary materializes the normalized artifact in RunDir.
+func TestBuildCodexCreatorCommandPlanMaterializesNormalizedSchema(t *testing.T) {
+	t.Parallel()
+	opts := Options{
+		Task: task.Task{
+			ID:       "task-codex-skeleton-schema",
+			Executor: task.Executor{CLI: "codex", Model: "gpt-5-codex", Effort: "medium"},
+		},
+		WorkDir: t.TempDir(),
+		RunDir:  t.TempDir(),
+	}
+	payload := []byte(`{"task":{},"allowed_paths":[],"profiles":{},"reference_files":[]}`)
+	cmd, perr := buildBuiltinCreatorCommandPlan(opts, payload)
+	if perr != nil {
+		t.Fatalf("buildBuiltinCreatorCommandPlan: %v", perr)
+	}
+	joined := strings.Join(cmd.Argv, "\n")
+	if !strings.Contains(joined, "--output-schema") {
+		t.Fatalf("codex creator argv missing --output-schema: %v", cmd.Argv)
+	}
+	body, err := os.ReadFile(filepath.Join(opts.RunDir, runner.CodexOutputSchemaFilename))
+	if err != nil {
+		t.Fatalf("read materialized creator schema: %v", err)
+	}
+	if !strings.Contains(string(body), `"outputs"`) || !strings.Contains(string(body), `"no_skeletons"`) {
+		t.Fatalf("creator schema derivative lost canonical manifest markers: %s", string(body))
+	}
+	expected, err := runner.CodexCompatibleOutputSchema(schemas.AcceptanceSkeletonManifest)
+	if err != nil {
+		t.Fatalf("compute expected normalized manifest: %v", err)
+	}
+	if string(body) != expected {
+		t.Fatalf("creator derivative must equal normalized canonical manifest; got %s", string(body))
+	}
+}

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -47,11 +47,11 @@ type CodexOptions struct {
 	JSONSchemaFile        string
 	JSONSchema            string
 	OutputLastMessageFile string
-	OutputSchemaFile      string
-	// AttemptDir, when set, lets CodexCommandPlan materialize attempt-scoped
-	// derivative files (the output schema file when only embedded schema
-	// content is available, and the --output-last-message capture file) so the
-	// upstream `codex exec` CLI flags receive real paths.
+	// OutputSchemaFile is exclusively the caller-selected destination for the
+	// normalized provider bytes; it is never treated as a canonical schema source.
+	OutputSchemaFile string
+	// AttemptDir is the attempt-scoped destination for derivative files: the
+	// normalized output schema and the --output-last-message capture file.
 	AttemptDir string
 	Prompt     string
 }
@@ -98,11 +98,7 @@ func CodexCommandPlan(opts CodexOptions) (Command, error) {
 	if opts.Prompt == "" {
 		return Command{}, fmt.Errorf("prompt is required")
 	}
-	var err error
-	opts, err = withDefaultEmbeddedCodexOptions(opts)
-	if err != nil {
-		return Command{}, err
-	}
+	opts = applyDefaultCodexSystemPrompt(opts)
 	resolvedOpts, err := resolveCodexAttemptFiles(opts)
 	if err != nil {
 		return Command{}, err
@@ -173,24 +169,87 @@ func CodexEffectiveSystemPrompt(opts CodexOptions) (string, error) {
 	return prompts.CodexExecutorFull(), nil
 }
 
-func withDefaultEmbeddedCodexOptions(opts CodexOptions) (CodexOptions, error) {
+// applyDefaultCodexSystemPrompt embeds the default Codex executor system
+// prompt when the caller supplies neither a prompt body nor a prompt file.
+func applyDefaultCodexSystemPrompt(opts CodexOptions) CodexOptions {
 	if opts.SystemPromptFile == "" && opts.SystemPrompt == "" {
 		opts.SystemPrompt = prompts.CodexExecutorFull()
 	}
-	if opts.JSONSchemaFile == "" && opts.JSONSchema == "" {
-		schema, err := CodexExecutorResultSchema()
-		if err != nil {
-			return opts, err
-		}
-		opts.JSONSchema = schema
-	}
-	return opts, nil
+	return opts
 }
 
-// CodexExecutorResultSchema removes unsupported generation constraints;
-// ExecutorResult.Validate enforces them after parsing.
-func CodexExecutorResultSchema() (string, error) {
-	return CodexCompatibleOutputSchema(schemas.ClaudeResult)
+// PrepareCodexOutputSchema normalizes opts' canonical schema and writes the
+// provider artifact to destDir/filename; it is the sole Codex normalization site.
+func PrepareCodexOutputSchema(opts CodexOptions, destDir, filename string) (string, error) {
+	canonical, err := codexCanonicalSchema(opts)
+	if err != nil {
+		return "", err
+	}
+	normalized, err := CodexCompatibleOutputSchema(canonical)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(destDir, filename)
+	if codexSchemaDestinationAliasesSource(opts.JSONSchemaFile, path) {
+		return "", fmt.Errorf("codex output schema destination %s aliases canonical source %s: use a distinct OutputSchemaFile or AttemptDir", path, opts.JSONSchemaFile)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create codex output-schema dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(normalized), 0o600); err != nil {
+		return "", fmt.Errorf("write codex output-schema file %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// codexSchemaDestinationAliasesSource reports whether destPath resolves to the
+// same physical file as sourcePath, catching exact-path, symlink, and hard-link aliases.
+func codexSchemaDestinationAliasesSource(sourcePath, destPath string) bool {
+	if sourcePath == "" {
+		return false
+	}
+	if sameCodexSchemaPath(sourcePath, destPath) {
+		return true
+	}
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return false
+	}
+	destInfo, err := os.Stat(destPath)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(sourceInfo, destInfo)
+}
+
+// sameCodexSchemaPath reports whether two paths are textually identical after
+// cleaning, so an exact-path alias is caught even before the destination exists.
+func sameCodexSchemaPath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		return filepath.Clean(absA) == filepath.Clean(absB)
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+// codexCanonicalSchema returns the canonical schema bytes resolved from
+// JSONSchemaFile, JSONSchema, or the embedded executor result schema default.
+func codexCanonicalSchema(opts CodexOptions) (string, error) {
+	if opts.JSONSchemaFile != "" {
+		body, err := os.ReadFile(opts.JSONSchemaFile)
+		if err != nil {
+			return "", fmt.Errorf("read codex output schema file %s: %w", opts.JSONSchemaFile, err)
+		}
+		return string(body), nil
+	}
+	if opts.JSONSchema != "" {
+		return opts.JSONSchema, nil
+	}
+	return schemas.ClaudeResult, nil
 }
 
 // CodexCompatibleOutputSchema adapts Galley's persisted JSON schemas for the
@@ -211,36 +270,73 @@ func CodexCompatibleOutputSchema(schema string) (string, error) {
 func normalizeCodexOutputSchema(node any) {
 	switch v := node.(type) {
 	case map[string]any:
-		delete(v, "allOf")
-		delete(v, "pattern")
-		delete(v, "uniqueItems")
-		props, _ := v["properties"].(map[string]any)
-		originalRequired := requiredNameSet(v["required"])
-		if props != nil {
-			names := make([]string, 0, len(props))
-			for name := range props {
-				names = append(names, name)
-			}
-			sort.Strings(names)
-			required := make([]any, 0, len(names))
-			for _, name := range names {
-				required = append(required, name)
-				prop := props[name]
-				if !originalRequired[name] {
-					allowNullSchema(prop)
-				}
-				normalizeCodexOutputSchema(prop)
-			}
-			v["required"] = required
-		}
-		if items, ok := v["items"]; ok {
-			normalizeCodexOutputSchema(items)
-		}
+		normalizeCodexObjectSchema(v)
 	case []any:
 		for _, item := range v {
 			normalizeCodexOutputSchema(item)
 		}
 	}
+}
+
+// normalizeCodexObjectSchema strips incompatible keywords from one object
+// node, forces required properties, null-allows optionals, then recurses.
+func normalizeCodexObjectSchema(m map[string]any) {
+	delete(m, "allOf")
+	delete(m, "pattern")
+	delete(m, "uniqueItems")
+	props, _ := m["properties"].(map[string]any)
+	originalRequired := requiredNameSet(m["required"])
+	if props != nil {
+		names := make([]string, 0, len(props))
+		for name := range props {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		required := make([]any, 0, len(names))
+		for _, name := range names {
+			required = append(required, name)
+			if !originalRequired[name] {
+				allowNullSchema(props[name])
+			}
+		}
+		m["required"] = required
+	}
+	for _, key := range codexSubschemaObjectKeys {
+		if child, ok := m[key].(map[string]any); ok {
+			normalizeCodexOutputSchema(child)
+		}
+	}
+	for _, key := range codexSubschemaArrayKeys {
+		if children, ok := m[key].([]any); ok {
+			for _, child := range children {
+				normalizeCodexOutputSchema(child)
+			}
+		}
+	}
+	for _, key := range codexSubschemaMapKeys {
+		if children, ok := m[key].(map[string]any); ok {
+			for _, child := range children {
+				normalizeCodexOutputSchema(child)
+			}
+		}
+	}
+}
+
+// Single-subschema JSON Schema keyword locations Galley recurses through.
+var codexSubschemaObjectKeys = []string{
+	"items", "additionalProperties", "propertyNames", "contains",
+	"if", "then", "else", "not", "unevaluatedItems", "unevaluatedProperties",
+	"contentSchema",
+}
+
+// Array-of-subschema JSON Schema keyword locations Galley recurses through.
+var codexSubschemaArrayKeys = []string{
+	"prefixItems", "anyOf", "oneOf",
+}
+
+// Map<string, subschema> JSON Schema keyword locations Galley recurses through.
+var codexSubschemaMapKeys = []string{
+	"properties", "patternProperties", "$defs", "definitions", "dependentSchemas",
 }
 
 func requiredNameSet(raw any) map[string]bool {
@@ -303,36 +399,43 @@ func combineRolePrompt(systemPrompt, workOrder string) string {
 	return systemPrompt + "\n\n# Work Order\n\n" + workOrder
 }
 
-// resolveCodexAttemptFiles maps the JSONSchemaFile/JSONSchema fields into a
-// concrete `codex exec --output-schema <file>` path and, when AttemptDir is
-// available, makes sure `--output-last-message <file>` is requested as well.
-//
-// The Codex CLI rejects --output-schema arguments that point at non-existent
-// files, so when only embedded schema content is available the runner writes
-// it to attemptDir/CodexOutputSchemaFilename before invoking the CLI. The
-// last-message path is similarly attempt-scoped so per-attempt evidence is
-// preserved alongside the other run artifacts. Callers that supply their own
-// OutputSchemaFile or OutputLastMessageFile keep those values intact.
+// resolveCodexAttemptFiles routes the canonical schema through the runner-owned
+// normalization boundary and ensures the last-message capture path is set.
 func resolveCodexAttemptFiles(opts CodexOptions) (CodexOptions, error) {
-	if opts.OutputSchemaFile == "" {
-		switch {
-		case opts.JSONSchemaFile != "":
-			opts.OutputSchemaFile = opts.JSONSchemaFile
-		case opts.AttemptDir != "" && opts.JSONSchema != "":
-			path := filepath.Join(opts.AttemptDir, CodexOutputSchemaFilename)
-			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-				return opts, fmt.Errorf("create codex output-schema dir: %w", err)
-			}
-			if err := os.WriteFile(path, []byte(opts.JSONSchema), 0o600); err != nil {
-				return opts, fmt.Errorf("write codex output-schema file %s: %w", path, err)
-			}
-			opts.OutputSchemaFile = path
+	if codexSchemaActive(opts) {
+		destDir, filename, err := codexSchemaDestination(opts)
+		if err != nil {
+			return opts, err
 		}
+		path, err := PrepareCodexOutputSchema(opts, destDir, filename)
+		if err != nil {
+			return opts, err
+		}
+		opts.OutputSchemaFile = path
 	}
 	if opts.OutputLastMessageFile == "" && opts.AttemptDir != "" {
 		opts.OutputLastMessageFile = filepath.Join(opts.AttemptDir, CodexLastMessageFilename)
 	}
 	return opts, nil
+}
+
+// codexSchemaActive reports whether the caller wants a Codex output schema:
+// a destination or an explicit canonical schema input activates normalization.
+func codexSchemaActive(opts CodexOptions) bool {
+	return opts.OutputSchemaFile != "" || opts.AttemptDir != "" ||
+		opts.JSONSchema != "" || opts.JSONSchemaFile != ""
+}
+
+// codexSchemaDestination resolves the derivative destination: OutputSchemaFile
+// is the caller-selected path, otherwise AttemptDir/CodexOutputSchemaFilename.
+func codexSchemaDestination(opts CodexOptions) (string, string, error) {
+	if opts.OutputSchemaFile != "" {
+		return filepath.Dir(opts.OutputSchemaFile), filepath.Base(opts.OutputSchemaFile), nil
+	}
+	if opts.AttemptDir != "" {
+		return opts.AttemptDir, CodexOutputSchemaFilename, nil
+	}
+	return "", "", fmt.Errorf("codex output schema destination is required: set CodexOptions.AttemptDir or OutputSchemaFile")
 }
 
 // ExtractCodexLastMessageFile parses a Codex final-message capture.

--- a/internal/runner/codex.go
+++ b/internal/runner/codex.go
@@ -12,10 +12,8 @@ import (
 	"github.com/shinpr/galley/schemas"
 )
 
-// CodexOutputSchemaFilename is the attempt-scoped filename Galley writes when
-// the caller supplies the executor result schema as inline content rather than
-// a real file. `codex exec --output-schema` requires a real path, so Galley
-// materializes the embedded schema here before invoking the CLI.
+// CodexOutputSchemaFilename is the attempt-scoped filename for the normalized
+// provider schema artifact Galley materializes before invoking Codex.
 const CodexOutputSchemaFilename = "codex.output-schema.json"
 
 // CodexLastMessageFilename is the attempt-scoped filename Galley requests for
@@ -298,45 +296,13 @@ func normalizeCodexObjectSchema(m map[string]any) {
 			if !originalRequired[name] {
 				allowNullSchema(props[name])
 			}
+			normalizeCodexOutputSchema(props[name])
 		}
 		m["required"] = required
 	}
-	for _, key := range codexSubschemaObjectKeys {
-		if child, ok := m[key].(map[string]any); ok {
-			normalizeCodexOutputSchema(child)
-		}
+	if items, ok := m["items"]; ok {
+		normalizeCodexOutputSchema(items)
 	}
-	for _, key := range codexSubschemaArrayKeys {
-		if children, ok := m[key].([]any); ok {
-			for _, child := range children {
-				normalizeCodexOutputSchema(child)
-			}
-		}
-	}
-	for _, key := range codexSubschemaMapKeys {
-		if children, ok := m[key].(map[string]any); ok {
-			for _, child := range children {
-				normalizeCodexOutputSchema(child)
-			}
-		}
-	}
-}
-
-// Single-subschema JSON Schema keyword locations Galley recurses through.
-var codexSubschemaObjectKeys = []string{
-	"items", "additionalProperties", "propertyNames", "contains",
-	"if", "then", "else", "not", "unevaluatedItems", "unevaluatedProperties",
-	"contentSchema",
-}
-
-// Array-of-subschema JSON Schema keyword locations Galley recurses through.
-var codexSubschemaArrayKeys = []string{
-	"prefixItems", "anyOf", "oneOf",
-}
-
-// Map<string, subschema> JSON Schema keyword locations Galley recurses through.
-var codexSubschemaMapKeys = []string{
-	"properties", "patternProperties", "$defs", "definitions", "dependentSchemas",
 }
 
 func requiredNameSet(raw any) map[string]bool {

--- a/internal/runner/codex_output_capture_test.go
+++ b/internal/runner/codex_output_capture_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -36,6 +37,9 @@ func TestCodexCommandPlanMaterializesEmbeddedSchemaWhenOnlyContentAvailable(t *t
 	}
 	if strings.Contains(string(body), `"allOf"`) {
 		t.Fatalf("Codex output schema must not contain allOf; schema=%s", string(body))
+	}
+	if strings.Contains(string(body), `"pattern"`) {
+		t.Fatalf("Codex output schema must not contain pattern; schema=%s", string(body))
 	}
 	var doc map[string]any
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -142,48 +146,483 @@ func TestCodexCompatibleOutputSchemaRecursivelyRequiresObjectProperties(t *testi
 	}
 }
 
-func TestCodexExecutorResultSchemaRemovesUnsupportedPatterns(t *testing.T) {
+// AC1: normalization must descend through every supported schema-bearing branch
+// (anyOf, oneOf, $defs, additionalProperties) so nested gaps cannot survive.
+func TestCodexCompatibleOutputSchemaNormalizesNestedSchemaBranches(t *testing.T) {
 	t.Parallel()
-	body, err := CodexExecutorResultSchema()
+	schema := `{
+  "type": "object",
+  "$defs": {"Role": {"type": "string", "pattern": "^[a-z]+$", "enum": ["admin"]}},
+  "properties": {
+    "primary": {
+      "anyOf": [
+        {"type": "object", "allOf": [{"required": ["code"]}], "properties": {"code": {"type": "string", "pattern": "^[0-9]+$"}}, "required": []},
+        {"type": "null"}
+      ]
+    },
+    "extras": {"type": "object", "additionalProperties": {"type": "string", "pattern": "@"}, "properties": {"note": {"type": "string", "uniqueItems": true}}, "required": []},
+    "secondary": {"oneOf": [{"type": "object", "properties": {"kind": {"type": "string", "pattern": "^k-"}}, "required": []}]}
+  },
+  "required": ["primary", "extras", "secondary"]
+}`
+	body, err := CodexCompatibleOutputSchema(schema)
 	if err != nil {
-		t.Fatalf("CodexExecutorResultSchema: %v", err)
+		t.Fatalf("CodexCompatibleOutputSchema: %v", err)
 	}
-	var doc any
+	var doc map[string]any
 	if err := json.Unmarshal([]byte(body), &doc); err != nil {
-		t.Fatalf("compatible executor schema is not valid JSON: %v", err)
+		t.Fatalf("normalized nested schema invalid JSON: %v", err)
 	}
-	assertNoSchemaKeyword(t, doc, "pattern")
+	for _, bad := range []string{"allOf", "pattern", "uniqueItems"} {
+		assertNoSchemaKeyword(t, doc, bad)
+	}
+	props := objectProp(t, doc, "properties")
+
+	anyBranches := objectProp(t, props, "primary")["anyOf"].([]any)
+	anyBranch := anyBranches[0].(map[string]any)
+	if !requiredSet(t, anyBranch)["code"] {
+		t.Fatalf("anyOf branch optional 'code' must be required: %#v", anyBranch["required"])
+	}
+	code := objectProp(t, objectProp(t, anyBranch, "properties"), "code")
+	if !typeAllowsNull(code["type"]) {
+		t.Fatalf("anyOf branch optional 'code' must be null-allowed: %#v", code["type"])
+	}
+
+	extras := objectProp(t, props, "extras")
+	addl, ok := extras["additionalProperties"].(map[string]any)
+	if !ok {
+		t.Fatalf("extras.additionalProperties must remain a schema: %#v", extras["additionalProperties"])
+	}
+	if _, still := addl["pattern"]; still {
+		t.Fatalf("additionalProperties schema must strip pattern: %#v", addl)
+	}
+
+	defs, ok := doc["$defs"].(map[string]any)
+	if !ok {
+		t.Fatalf("$defs must remain a map after normalization: %#v", doc["$defs"])
+	}
+	if _, still := objectProp(t, defs, "Role")["pattern"]; still {
+		t.Fatalf("$defs Role must strip pattern: %#v", defs["Role"])
+	}
+
+	oneBranches := objectProp(t, props, "secondary")["oneOf"].([]any)
+	oneBranch := oneBranches[0].(map[string]any)
+	if !requiredSet(t, oneBranch)["kind"] {
+		t.Fatalf("oneOf branch optional 'kind' must be required: %#v", oneBranch["required"])
+	}
+	kind := objectProp(t, objectProp(t, oneBranch, "properties"), "kind")
+	if !typeAllowsNull(kind["type"]) {
+		t.Fatalf("oneOf branch optional 'kind' must be null-allowed: %#v", kind["type"])
+	}
 }
 
-func TestCodexCommandPlanReusesCallerSuppliedSchemaFile(t *testing.T) {
+func TestCodexCommandPlanConvergesCanonicalSchemaInputs(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	schemaPath := filepath.Join(dir, "external.schema.json")
-	if err := os.WriteFile(schemaPath, []byte(`{"type":"object"}`), 0o600); err != nil {
-		t.Fatal(err)
+	canonical := codexCanonicalTestSchema
+	cases := []struct {
+		name   string
+		inline string
+		file   string
+	}{
+		{name: "inline-json-schema", inline: canonical},
+		{name: "canonical-schema-file", file: writeCanonicalSchemaFile(t, canonical)},
 	}
-	attemptDir := t.TempDir()
+	derivatives := make([][]byte, 0, len(cases))
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			attemptDir := t.TempDir()
+			opts := CodexFromTask(minimalCodexTask())
+			opts.WorkDir = "/tmp/codex-schema-boundary"
+			opts.AttemptDir = attemptDir
+			opts.JSONSchema = tc.inline
+			opts.JSONSchemaFile = tc.file
+			opts.Prompt = "work order"
 
+			plan, err := CodexCommandPlan(opts)
+			if err != nil {
+				t.Fatalf("CodexCommandPlan: %v", err)
+			}
+			schemaFlag := flagValue(t, plan.Argv, "--output-schema")
+			if schemaFlag == "" {
+				t.Fatalf("argv missing --output-schema: %v", plan.Argv)
+			}
+			if filepath.Dir(schemaFlag) != attemptDir {
+				t.Fatalf("output-schema must be attempt-scoped derivative: got %q, want under %q", schemaFlag, attemptDir)
+			}
+			if tc.file != "" && schemaFlag == tc.file {
+				t.Fatalf("argv must reference normalized derivative, not canonical file %q", tc.file)
+			}
+			derivative, err := os.ReadFile(schemaFlag)
+			if err != nil {
+				t.Fatalf("read materialized derivative: %v", err)
+			}
+			assertCodexNormalized(t, derivative)
+			if tc.file != "" {
+				source, err := os.ReadFile(tc.file)
+				if err != nil {
+					t.Fatalf("read canonical source: %v", err)
+				}
+				if !bytes.Equal(source, []byte(canonical)) {
+					t.Fatalf("canonical source file must not be mutated")
+				}
+			}
+			derivatives = append(derivatives, derivative)
+		})
+	}
+	if !bytes.Equal(derivatives[0], derivatives[1]) {
+		t.Fatalf("canonical inputs must converge on one normalized artifact")
+	}
+}
+
+func TestCodexCommandPlanFailsBeforeExecOnInvalidSchema(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, opts *CodexOptions)
+		want  string
+	}{
+		{name: "attempt-dir-malformed-inline", setup: func(t *testing.T, o *CodexOptions) {
+			o.JSONSchema = `{not json`
+			o.AttemptDir = t.TempDir()
+		}, want: "decode codex output schema"},
+		{name: "caller-destination-malformed-inline", setup: func(t *testing.T, o *CodexOptions) {
+			o.JSONSchema = `{not json`
+			o.OutputSchemaFile = filepath.Join(t.TempDir(), "caller.schema.json")
+		}, want: "decode codex output schema"},
+		{name: "caller-destination-missing-file", setup: func(t *testing.T, o *CodexOptions) {
+			o.JSONSchemaFile = filepath.Join(t.TempDir(), "missing.schema.json")
+			o.OutputSchemaFile = filepath.Join(t.TempDir(), "caller.schema.json")
+		}, want: "read codex output schema file"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := CodexFromTask(minimalCodexTask())
+			opts.Prompt = "work order"
+			tc.setup(t, &opts)
+			_, err := CodexCommandPlan(opts)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// AC1/AC3: a preselected OutputSchemaFile is a destination only, so the
+// boundary still decodes and normalizes the canonical schema into it.
+func TestCodexCommandPlanMaterializesSchemaAtCallerSelectedDestination(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(t.TempDir(), "caller.schema.json")
 	opts := CodexFromTask(minimalCodexTask())
-	opts.WorkDir = "/tmp/codex-output-schema-file"
-	opts.JSONSchemaFile = schemaPath
-	opts.AttemptDir = attemptDir
+	opts.WorkDir = "/tmp/codex-output-schema-dest"
+	opts.JSONSchema = codexCanonicalTestSchema
+	opts.OutputSchemaFile = dest
 	opts.Prompt = "work order"
 
 	plan, err := CodexCommandPlan(opts)
 	if err != nil {
 		t.Fatalf("CodexCommandPlan: %v", err)
 	}
+	if schemaFlag := flagValue(t, plan.Argv, "--output-schema"); schemaFlag != dest {
+		t.Fatalf("argv --output-schema must reference caller destination: got %q want %q", schemaFlag, dest)
+	}
+	body, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read materialized derivative at caller destination: %v", err)
+	}
+	assertCodexNormalized(t, body)
+}
 
-	got := flagValue(t, plan.Argv, "--output-schema")
-	if got != schemaPath {
-		t.Fatalf("output-schema should reuse caller-supplied file: got %q, want %q", got, schemaPath)
+// AC3: explicit canonical schema input without a destination must fail before
+// execution rather than silently omitting --output-schema.
+func TestCodexCommandPlanErrorsOnCanonicalSchemaWithoutDestination(t *testing.T) {
+	t.Parallel()
+	opts := CodexFromTask(minimalCodexTask())
+	opts.WorkDir = "/tmp/codex-output-schema-dest"
+	opts.JSONSchema = codexCanonicalTestSchema
+	opts.Prompt = "work order"
+	_, err := CodexCommandPlan(opts)
+	if err == nil || !strings.Contains(err.Error(), "codex output schema destination is required") {
+		t.Fatalf("expected missing-destination error, got %v", err)
 	}
-	// The runner must not write a second attempt-scoped schema file when the
-	// caller already supplied a real path.
-	if _, err := os.Stat(filepath.Join(attemptDir, CodexOutputSchemaFilename)); !os.IsNotExist(err) {
-		t.Fatalf("attempt-scoped schema file should not be created when JSONSchemaFile is supplied: err=%v", err)
+}
+
+func TestPrepareCodexOutputSchemaReportsSchemaPreparationFailures(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		opts CodexOptions
+		want string
+	}{
+		{name: "malformed-inline-json", opts: CodexOptions{JSONSchema: `{not json`}, want: "decode codex output schema"},
+		{name: "malformed-file-json", opts: CodexOptions{JSONSchemaFile: writeCanonicalSchemaFile(t, `{not json`)}, want: "decode codex output schema"},
+		{name: "missing-schema-file", opts: CodexOptions{JSONSchemaFile: filepath.Join(dir, "missing.schema.json")}, want: "read codex output schema file"},
 	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := PrepareCodexOutputSchema(tc.opts, t.TempDir(), CodexOutputSchemaFilename)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q must identify %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// AC1: when the destination aliases the canonical source file (exact-path, symlink,
+// or hard link), the boundary must reject it before writing so canonical bytes survive.
+func TestPrepareCodexOutputSchemaRejectsAliasedDestination(t *testing.T) {
+	t.Parallel()
+	canonical := codexCanonicalTestSchema
+	sourcePath := writeCanonicalSchemaFile(t, canonical)
+	want := "aliases canonical source"
+
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) (destDir, filename string)
+	}{
+		{name: "exact-path", setup: func(t *testing.T) (string, string) {
+			return filepath.Dir(sourcePath), filepath.Base(sourcePath)
+		}},
+		{name: "cleaned-path", setup: func(t *testing.T) (string, string) {
+			return filepath.Dir(sourcePath), "./" + filepath.Base(sourcePath)
+		}},
+		{name: "symlink-alias", setup: func(t *testing.T) (string, string) {
+			linkDir := t.TempDir()
+			link := filepath.Join(linkDir, "link.schema.json")
+			if err := os.Symlink(sourcePath, link); err != nil {
+				t.Skipf("symlink unsupported: %v", err)
+			}
+			return linkDir, "link.schema.json"
+		}},
+		{name: "hard-link-alias", setup: func(t *testing.T) (string, string) {
+			linkDir := t.TempDir()
+			link := filepath.Join(linkDir, "hard.schema.json")
+			if err := os.Link(sourcePath, link); err != nil {
+				t.Skipf("hard link unsupported: %v", err)
+			}
+			return linkDir, "hard.schema.json"
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			destDir, filename := tc.setup(t)
+			before, err := os.ReadFile(sourcePath)
+			if err != nil {
+				t.Fatalf("read canonical source before: %v", err)
+			}
+			_, err = PrepareCodexOutputSchema(CodexOptions{JSONSchemaFile: sourcePath}, destDir, filename)
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("expected error containing %q, got %v", want, err)
+			}
+			after, err := os.ReadFile(sourcePath)
+			if err != nil {
+				t.Fatalf("read canonical source after: %v", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatalf("canonical source bytes must remain unchanged: before=%q after=%q", string(before), string(after))
+			}
+			if bytes.Equal(after, []byte(canonical)) == false {
+				t.Fatalf("canonical source must still equal original canonical bytes")
+			}
+		})
+	}
+}
+
+// AC1: a distinct caller destination must still succeed and normalize, proving
+// the alias rejection does not over-block legitimate distinct destinations.
+func TestPrepareCodexOutputSchemaAcceptsDistinctDestination(t *testing.T) {
+	t.Parallel()
+	sourcePath := writeCanonicalSchemaFile(t, codexCanonicalTestSchema)
+	destDir := t.TempDir()
+	path, err := PrepareCodexOutputSchema(CodexOptions{JSONSchemaFile: sourcePath}, destDir, CodexOutputSchemaFilename)
+	if err != nil {
+		t.Fatalf("PrepareCodexOutputSchema distinct destination: %v", err)
+	}
+	if filepath.Dir(path) != destDir {
+		t.Fatalf("distinct derivative must live in destDir: got %q", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read derivative: %v", err)
+	}
+	assertCodexNormalized(t, body)
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read canonical source: %v", err)
+	}
+	if !bytes.Equal(source, []byte(codexCanonicalTestSchema)) {
+		t.Fatalf("canonical source must remain unchanged for distinct destination")
+	}
+}
+
+// AC1 boundary: the alias rejection must surface through CodexCommandPlan so the
+// argv never references an aliased canonical source as --output-schema.
+func TestCodexCommandPlanRejectsAliasedOutputSchemaFile(t *testing.T) {
+	t.Parallel()
+	sourcePath := writeCanonicalSchemaFile(t, codexCanonicalTestSchema)
+	opts := CodexFromTask(minimalCodexTask())
+	opts.WorkDir = "/tmp/codex-alias-plan"
+	opts.JSONSchemaFile = sourcePath
+	opts.OutputSchemaFile = sourcePath
+	opts.Prompt = "work order"
+	_, err := CodexCommandPlan(opts)
+	if err == nil || !strings.Contains(err.Error(), "aliases canonical source") {
+		t.Fatalf("expected alias error through CodexCommandPlan, got %v", err)
+	}
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read canonical source: %v", err)
+	}
+	if !bytes.Equal(source, []byte(codexCanonicalTestSchema)) {
+		t.Fatalf("canonical source must remain unchanged when plan rejects alias")
+	}
+}
+
+// AC1: Draft 2020-12 contentSchema is a schema-bearing location; incompatible
+// keywords beneath it must be stripped and optional properties required/null-allowed.
+func TestCodexCompatibleOutputSchemaNormalizesContentSchema(t *testing.T) {
+	t.Parallel()
+	schema := `{
+  "type": "object",
+  "properties": {
+    "payload": {
+      "type": "string",
+      "contentMediaType": "application/json",
+      "contentSchema": {
+        "type": "object",
+        "pattern": "^.*$",
+        "uniqueItems": true,
+        "allOf": [{"required": ["code"]}],
+        "properties": {
+          "code": {"type": "string", "pattern": "^[0-9]+$"},
+          "note": {"type": "string", "enum": ["a", "b"]}
+        },
+        "required": ["code"]
+      }
+    }
+  },
+  "required": ["payload"]
+}`
+	body, err := CodexCompatibleOutputSchema(schema)
+	if err != nil {
+		t.Fatalf("CodexCompatibleOutputSchema: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("normalized contentSchema doc invalid JSON: %v", err)
+	}
+	for _, bad := range []string{"allOf", "pattern", "uniqueItems"} {
+		assertNoSchemaKeyword(t, doc, bad)
+	}
+	payload := objectProp(t, objectProp(t, doc, "properties"), "payload")
+	contentSchema := objectProp(t, payload, "contentSchema")
+	if _, still := contentSchema["allOf"]; still {
+		t.Fatalf("contentSchema must strip allOf: %#v", contentSchema)
+	}
+	if _, still := contentSchema["pattern"]; still {
+		t.Fatalf("contentSchema must strip pattern: %#v", contentSchema)
+	}
+	if _, still := contentSchema["uniqueItems"]; still {
+		t.Fatalf("contentSchema must strip uniqueItems: %#v", contentSchema)
+	}
+	contentProps := objectProp(t, contentSchema, "properties")
+	contentRequired := requiredSet(t, contentSchema)
+	if !contentRequired["note"] {
+		t.Fatalf("contentSchema optional 'note' must be required: %#v", contentSchema["required"])
+	}
+	note := objectProp(t, contentProps, "note")
+	if !typeAllowsNull(note["type"]) {
+		t.Fatalf("contentSchema optional 'note' must be null-allowed: %#v", note["type"])
+	}
+	if !enumAllowsNull(note["enum"]) {
+		t.Fatalf("contentSchema optional 'note' enum must allow null: %#v", note["enum"])
+	}
+	code := objectProp(t, contentProps, "code")
+	if _, still := code["pattern"]; still {
+		t.Fatalf("contentSchema nested 'code' must strip pattern: %#v", code)
+	}
+}
+
+// codexCanonicalTestSchema carries every Codex-incompatible keyword the
+// boundary must normalize away: allOf, pattern, uniqueItems, optional enums.
+const codexCanonicalTestSchema = `{
+  "title": "Galley Codex Schema Boundary Test",
+  "type": "object",
+  "allOf": [{"required": ["name"]}],
+  "properties": {
+    "name": {"type": "string", "pattern": "^[a-z]+$"},
+    "tags": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+    "profile": {
+      "type": "object",
+      "properties": {
+        "email": {"type": "string", "pattern": "@"},
+        "role": {"type": "string", "enum": ["admin", "user"]}
+      },
+      "required": ["email"]
+    },
+    "status": {"type": "string", "enum": ["active", "archived"]}
+  },
+  "required": ["name", "tags", "profile"]
+}`
+
+func writeCanonicalSchemaFile(t *testing.T, schema string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "canonical.schema.json")
+	if err := os.WriteFile(path, []byte(schema), 0o600); err != nil {
+		t.Fatalf("write canonical schema: %v", err)
+	}
+	return path
+}
+
+func assertCodexNormalized(t *testing.T, body []byte) {
+	t.Helper()
+	for _, bad := range []string{`"allOf"`, `"pattern"`, `"uniqueItems"`} {
+		if strings.Contains(string(body), bad) {
+			t.Fatalf("derivative must not contain %s: %s", bad, string(body))
+		}
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("derivative is not valid JSON: %v", err)
+	}
+	props := objectProp(t, doc, "properties")
+	status := objectProp(t, props, "status")
+	if !typeAllowsNull(status["type"]) {
+		t.Fatalf("optional status must be nullable: %#v", status["type"])
+	}
+	if !enumAllowsNull(status["enum"]) {
+		t.Fatalf("optional status enum must allow null: %#v", status["enum"])
+	}
+	role := objectProp(t, objectProp(t, objectProp(t, props, "profile"), "properties"), "role")
+	if !typeAllowsNull(role["type"]) {
+		t.Fatalf("optional nested role must be nullable: %#v", role["type"])
+	}
+	if !enumAllowsNull(role["enum"]) {
+		t.Fatalf("optional nested role enum must allow null: %#v", role["enum"])
+	}
+}
+
+func enumAllowsNull(raw any) bool {
+	items, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if item == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func TestExtractCodexLastMessageFileParsesCompletedResult(t *testing.T) {

--- a/internal/runner/codex_output_capture_test.go
+++ b/internal/runner/codex_output_capture_test.go
@@ -146,73 +146,32 @@ func TestCodexCompatibleOutputSchemaRecursivelyRequiresObjectProperties(t *testi
 	}
 }
 
-// AC1: normalization must descend through every supported schema-bearing branch
-// (anyOf, oneOf, $defs, additionalProperties) so nested gaps cannot survive.
-func TestCodexCompatibleOutputSchemaNormalizesNestedSchemaBranches(t *testing.T) {
+func TestCodexCompatibleOutputSchemaDoesNotRewriteLogicalSubschemas(t *testing.T) {
 	t.Parallel()
-	schema := `{
+	body, err := CodexCompatibleOutputSchema(`{
   "type": "object",
-  "$defs": {"Role": {"type": "string", "pattern": "^[a-z]+$", "enum": ["admin"]}},
-  "properties": {
-    "primary": {
-      "anyOf": [
-        {"type": "object", "allOf": [{"required": ["code"]}], "properties": {"code": {"type": "string", "pattern": "^[0-9]+$"}}, "required": []},
-        {"type": "null"}
-      ]
-    },
-    "extras": {"type": "object", "additionalProperties": {"type": "string", "pattern": "@"}, "properties": {"note": {"type": "string", "uniqueItems": true}}, "required": []},
-    "secondary": {"oneOf": [{"type": "object", "properties": {"kind": {"type": "string", "pattern": "^k-"}}, "required": []}]}
-  },
-  "required": ["primary", "extras", "secondary"]
-}`
-	body, err := CodexCompatibleOutputSchema(schema)
+  "not": {
+    "type": "object",
+    "properties": {
+      "blocked": {"type": "string", "pattern": "^x$"}
+    }
+  }
+}`)
 	if err != nil {
 		t.Fatalf("CodexCompatibleOutputSchema: %v", err)
 	}
 	var doc map[string]any
 	if err := json.Unmarshal([]byte(body), &doc); err != nil {
-		t.Fatalf("normalized nested schema invalid JSON: %v", err)
-	}
-	for _, bad := range []string{"allOf", "pattern", "uniqueItems"} {
-		assertNoSchemaKeyword(t, doc, bad)
-	}
-	props := objectProp(t, doc, "properties")
-
-	anyBranches := objectProp(t, props, "primary")["anyOf"].([]any)
-	anyBranch := anyBranches[0].(map[string]any)
-	if !requiredSet(t, anyBranch)["code"] {
-		t.Fatalf("anyOf branch optional 'code' must be required: %#v", anyBranch["required"])
-	}
-	code := objectProp(t, objectProp(t, anyBranch, "properties"), "code")
-	if !typeAllowsNull(code["type"]) {
-		t.Fatalf("anyOf branch optional 'code' must be null-allowed: %#v", code["type"])
+		t.Fatalf("normalized schema is not valid JSON: %v", err)
 	}
 
-	extras := objectProp(t, props, "extras")
-	addl, ok := extras["additionalProperties"].(map[string]any)
-	if !ok {
-		t.Fatalf("extras.additionalProperties must remain a schema: %#v", extras["additionalProperties"])
+	notSchema := objectProp(t, doc, "not")
+	if _, rewritten := notSchema["required"]; rewritten {
+		t.Fatalf("logical subschema must not gain required constraints: %#v", notSchema)
 	}
-	if _, still := addl["pattern"]; still {
-		t.Fatalf("additionalProperties schema must strip pattern: %#v", addl)
-	}
-
-	defs, ok := doc["$defs"].(map[string]any)
-	if !ok {
-		t.Fatalf("$defs must remain a map after normalization: %#v", doc["$defs"])
-	}
-	if _, still := objectProp(t, defs, "Role")["pattern"]; still {
-		t.Fatalf("$defs Role must strip pattern: %#v", defs["Role"])
-	}
-
-	oneBranches := objectProp(t, props, "secondary")["oneOf"].([]any)
-	oneBranch := oneBranches[0].(map[string]any)
-	if !requiredSet(t, oneBranch)["kind"] {
-		t.Fatalf("oneOf branch optional 'kind' must be required: %#v", oneBranch["required"])
-	}
-	kind := objectProp(t, objectProp(t, oneBranch, "properties"), "kind")
-	if !typeAllowsNull(kind["type"]) {
-		t.Fatalf("oneOf branch optional 'kind' must be null-allowed: %#v", kind["type"])
+	blocked := objectProp(t, objectProp(t, notSchema, "properties"), "blocked")
+	if blocked["pattern"] != "^x$" || blocked["type"] != "string" {
+		t.Fatalf("logical subschema must remain unchanged: %#v", blocked)
 	}
 }
 
@@ -485,71 +444,6 @@ func TestCodexCommandPlanRejectsAliasedOutputSchemaFile(t *testing.T) {
 	}
 	if !bytes.Equal(source, []byte(codexCanonicalTestSchema)) {
 		t.Fatalf("canonical source must remain unchanged when plan rejects alias")
-	}
-}
-
-// AC1: Draft 2020-12 contentSchema is a schema-bearing location; incompatible
-// keywords beneath it must be stripped and optional properties required/null-allowed.
-func TestCodexCompatibleOutputSchemaNormalizesContentSchema(t *testing.T) {
-	t.Parallel()
-	schema := `{
-  "type": "object",
-  "properties": {
-    "payload": {
-      "type": "string",
-      "contentMediaType": "application/json",
-      "contentSchema": {
-        "type": "object",
-        "pattern": "^.*$",
-        "uniqueItems": true,
-        "allOf": [{"required": ["code"]}],
-        "properties": {
-          "code": {"type": "string", "pattern": "^[0-9]+$"},
-          "note": {"type": "string", "enum": ["a", "b"]}
-        },
-        "required": ["code"]
-      }
-    }
-  },
-  "required": ["payload"]
-}`
-	body, err := CodexCompatibleOutputSchema(schema)
-	if err != nil {
-		t.Fatalf("CodexCompatibleOutputSchema: %v", err)
-	}
-	var doc map[string]any
-	if err := json.Unmarshal([]byte(body), &doc); err != nil {
-		t.Fatalf("normalized contentSchema doc invalid JSON: %v", err)
-	}
-	for _, bad := range []string{"allOf", "pattern", "uniqueItems"} {
-		assertNoSchemaKeyword(t, doc, bad)
-	}
-	payload := objectProp(t, objectProp(t, doc, "properties"), "payload")
-	contentSchema := objectProp(t, payload, "contentSchema")
-	if _, still := contentSchema["allOf"]; still {
-		t.Fatalf("contentSchema must strip allOf: %#v", contentSchema)
-	}
-	if _, still := contentSchema["pattern"]; still {
-		t.Fatalf("contentSchema must strip pattern: %#v", contentSchema)
-	}
-	if _, still := contentSchema["uniqueItems"]; still {
-		t.Fatalf("contentSchema must strip uniqueItems: %#v", contentSchema)
-	}
-	contentProps := objectProp(t, contentSchema, "properties")
-	contentRequired := requiredSet(t, contentSchema)
-	if !contentRequired["note"] {
-		t.Fatalf("contentSchema optional 'note' must be required: %#v", contentSchema["required"])
-	}
-	note := objectProp(t, contentProps, "note")
-	if !typeAllowsNull(note["type"]) {
-		t.Fatalf("contentSchema optional 'note' must be null-allowed: %#v", note["type"])
-	}
-	if !enumAllowsNull(note["enum"]) {
-		t.Fatalf("contentSchema optional 'note' enum must allow null: %#v", note["enum"])
-	}
-	code := objectProp(t, contentProps, "code")
-	if _, still := code["pattern"]; still {
-		t.Fatalf("contentSchema nested 'code' must strip pattern: %#v", code)
 	}
 }
 

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -242,21 +242,17 @@ func runCodexAdapter(ctx context.Context, opts AdapterOptions, request []byte) (
 
 	requestPath := filepath.Join(dir, "codex_supervisor_request.json")
 	promptPath := filepath.Join(dir, "codex_supervisor_prompt.md")
-	schemaPath := filepath.Join(dir, "supervisor-verdict.schema.json")
-	outPath := filepath.Join(dir, "codex_supervisor_last_message.json")
-	eventsPath := filepath.Join(dir, "codex_supervisor_events.jsonl")
-	prompt := prompts.CodexSupervisor() + "\n\n# Evidence JSON\n\n" + string(request)
-	schema, err := runner.CodexCompatibleOutputSchema(schemas.SupervisorVerdict)
+	schemaPath, err := runner.PrepareCodexOutputSchema(runner.CodexOptions{JSONSchema: schemas.SupervisorVerdict}, dir, "supervisor-verdict.schema.json")
 	if err != nil {
 		return nil, fmt.Errorf("prepare Codex supervisor schema: %w", err)
 	}
+	outPath := filepath.Join(dir, "codex_supervisor_last_message.json")
+	eventsPath := filepath.Join(dir, "codex_supervisor_events.jsonl")
+	prompt := prompts.CodexSupervisor() + "\n\n# Evidence JSON\n\n" + string(request)
 	if err := writeSupervisorFile(requestPath, request); err != nil {
 		return nil, err
 	}
 	if err := writeSupervisorFile(promptPath, []byte(prompt)); err != nil {
-		return nil, err
-	}
-	if err := writeSupervisorFile(schemaPath, []byte(schema)); err != nil {
 		return nil, err
 	}
 	args := []string{


### PR DESCRIPTION
## Goal

Make Codex structured-output compatibility unavoidable by normalizing each canonical Galley schema while materializing the provider-facing file at one runner-owned boundary shared by implementation, setup, acceptance-skeleton, and supervisor invocations.

## Acceptance Criteria

- `AC1` When a Codex invocation receives canonical schema content through runner.CodexOptions.JSONSchema or a canonical schema path through JSONSchemaFile, the runner-owned boundary shall decode and recursively normalize it, preserve the canonical source, materialize an attempt- or artifact-scoped derivative, and pass only that derivative to `codex exec --output-schema`.
  - Verification: go test ./internal/runner; focused table tests cover JSONSchema and JSONSchemaFile with nested objects containing allOf, pattern, uniqueItems, optional properties, and enums; claim: both canonical input forms converge on one normalized provider artifact without mutating the source file; primary failure mode: argv references the canonical file, inline content is written without normalization, or source bytes change; boundary: CodexOptions canonical input -> CodexCommandPlan -> --output-schema file; state: canonical schema supplied -> plan built -> source unchanged and argv references normalized scoped derivative; residual: none.
  - Status: satisfied
- `AC2` The Codex implementation executor, setup executor, acceptance-skeleton creator, and supervisor shall provide the canonical schemas schemas.ClaudeResult, schemas.SetupResult, schemas.AcceptanceSkeletonManifest, and schemas.SupervisorVerdict respectively, while the runner-owned boundary remains the only production call site that applies Codex compatibility normalization.
  - Verification: go test ./internal/runner ./internal/preflight/setup ./internal/preflight/skeleton ./internal/supervisor; reuse the existing runner, setup, acceptance-skeleton, and supervisor command-plan tests and add only missing assertions that each caller supplies a canonical schema and the final artifact is normalized; source inspection confirms production callers no longer call CodexCompatibleOutputSchema before planning; claim: every current Codex structured-output surface reaches the same normalization boundary with its canonical schema; primary failure mode: a caller pre-transforms, writes a raw provider file, or bypasses the boundary; boundary: four caller packages -> shared runner preparation -> Codex argv; state: each caller builds a request -> shared boundary normalizes -> argv references compatible artifact; residual: none.
  - Status: satisfied
- `AC3` If canonical schema content or a canonical schema file contains invalid JSON or cannot be read, command planning shall fail before Codex starts and identify whether decoding or reading the schema failed.
  - Verification: go test ./internal/runner; focused negative tests cover malformed inline JSON, malformed file JSON, and an unreadable or missing file; claim: schema preparation fails before argv can be executed and reports the failed operation; primary failure mode: Codex starts with invalid schema input or the error lacks schema preparation context; boundary: CodexCommandPlan error return; state: invalid canonical input -> plan requested -> actionable non-nil error and no provider artifact accepted; residual: none.
  - Status: satisfied
- `AC4` After Codex returns structured output, the existing executor-result, setup-result, acceptance-skeleton, and supervisor-verdict semantic validation paths shall remain authoritative and preserve the current accepted and rejected result set defined by Galley's canonical contracts.
  - Verification: Run the retained semantic-validation tests and go test ./...; add a focused parser or validator regression test only if implementation changes that parser or validator call path; claim: provider normalization changes generation constraints only and does not broaden Galley's accepted semantic results; primary failure mode: an output rejected before this refactor becomes accepted because the provider schema is weaker; boundary: captured Codex output -> existing parser and semantic validator -> accepted or rejected result; state: provider-compatible output violates a canonical invariant -> parser/validator runs -> rejection remains; residual: none.
  - Status: satisfied

## Final Verification

- `<galley:setup:glm>`: passed
- `go test ./internal/runner/ ./internal/supervisor/ ./internal/preflight/setup/ ./internal/preflight/skeleton/`: passed
- `go run ./cmd/galley schema check && go run ./cmd/galley task validate examples/afk-task.yaml && go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `grep -rn 'CodexCompatibleOutputSchema|CodexExecutorResultSchema' --include='*.go' internal/ cmd/ | grep -v _test.go`: passed
- `codex exec --skip-git-repo-check --output-schema /tmp/galley-codex-smoke/claude-result.schema.json --output-last-message ... (boundary-produced ClaudeResult artifact)`: passed
- `codex exec --skip-git-repo-check --output-schema /tmp/galley-codex-smoke/supervisor-verdict.schema.json --output-last-message ... (boundary-produced SupervisorVerdict artifact)`: passed
- `claude -p (glm)`: passed
- `go test ./internal/runner/ -run "Codex" -count=1`: passed
- `go test ./internal/runner ./internal/preflight/setup ./internal/preflight/skeleton ./internal/supervisor -count=1`: passed
- `go test ./...`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml && go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool <each of 9 schema/plugin/marketplace JSON files>`: passed
- `./scripts/smoke-local.sh`: passed
- `sed delete contentSchema line; run contentSchema test; restore`: passed
- `remove alias guard; run alias tests; restore`: passed

## Key Decisions

- `D1` Which layer owns Codex output-schema compatibility? -> A runner-owned preparation boundary reads canonical schema content or a canonical schema file, applies CodexCompatibleOutputSchema once, and writes the exact provider-facing artifact referenced by `--output-schema`.
  - Rationale: The current CodexCommandPlan materializes schemas but reuses JSONSchemaFile unchanged, while setup, skeleton, and supervisor callers pre-transform independently; combining transformation with final materialization closes both bypasses with one policy owner.
  - Reversibility: high
- `D2` Does provider schema normalization define Galley's semantic output contract? -> Galley's existing post-provider parsers and semantic validators define acceptance; Codex normalization only adapts generation constraints.
  - Rationale: Provider schema subsets must not silently weaken Galley's runtime correctness checks.
  - Reversibility: high
- `D3` What are the input and output roles of CodexOptions schema fields? -> JSONSchema and JSONSchemaFile are canonical inputs. OutputSchemaFile, if retained, is exclusively the destination for normalized provider bytes; every schema byte source is resolved from a canonical input.
  - Rationale: Distinguishing canonical input from provider artifact makes the final normalization boundary deterministic for inline, file-backed, and caller-selected destination paths.
  - Reversibility: medium
- `D4` How broad should the surrounding refactor and documentation change be? -> Share only the schema preparation needed by the four Codex surfaces and preserve their prompt, model, effort, timeout, capture, and artifact-evidence behavior. Canonical schemas and plugin versions remain unchanged; one concise Unreleased Fixed entry records the compatibility fix.
  - Rationale: The defect is duplicated provider adaptation, not the canonical output contracts or the rest of Codex command construction.
  - Reversibility: high
- `executor-decision-5` What shape should the runner-owned schema preparation boundary take so it serves all four Codex surfaces? -> PrepareCodexOutputSchema(opts CodexOptions, destDir, filename string) (string, error) resolves the canonical schema, normalizes once via CodexCompatibleOutputSchema, and writes destDir/filename, returning the artifact path.
  - Rationale: Matches prior decision D1 (boundary reads canonical content/file, applies CodexCompatibleOutputSchema once, writes the artifact referenced by --output-schema). Taking destDir+filename lets CodexCommandPlan use AttemptDir/CodexOutputSchemaFilename while the supervisor preserves its supervisor-verdict.schema.json evidence filename and its distinct codex_supervisor_last_message.json capture file, satisfying D4's artifact-evidence preservation.
  - Reversibility: high
- `executor-decision-6` Should the supervisor reuse the whole CodexCommandPlan planner or only the schema boundary? -> Supervisor calls PrepareCodexOutputSchema directly and keeps its existing hand-built argv (prompt, model, effort, -c override, output-last-message filename, artifact layout).
  - Rationale: R3 mitigation: the smallest runner-owned schema boundary reuse preserves the existing supervisor command plan, evidence filenames, and capture behavior, avoiding unintended supervisor regression. CodexCommandPlan still owns the other three surfaces.
  - Reversibility: high
- `executor-decision-7` How to handle the exported CodexCompatibleOutputSchema and the CodexExecutorResultSchema wrapper? -> Keep CodexCompatibleOutputSchema exported as the testable transform primitive (now called only by the boundary in production); remove the CodexExecutorResultSchema wrapper (dead once the boundary owns the schemas.ClaudeResult default).
  - Rationale: implementation-economy: one coherent responsibility per symbol, no redundant bypass surface. The schemas.ClaudeResult default now lives in codexCanonicalSchema so every Codex surface converges on the boundary when no schema input is supplied.
  - Reversibility: medium
- `executor-decision-8` Where does the default canonical schema (when neither JSONSchema nor JSONSchemaFile is supplied) get resolved? -> Moved from withDefaultEmbeddedCodexOptions (now applyDefaultCodexSystemPrompt, system-prompt only) into codexCanonicalSchema, which returns schemas.ClaudeResult as the default.
  - Rationale: Keeps schema resolution entirely inside the single normalization boundary so the default path cannot bypass normalization, and removes the prior double-default (normalized ClaudeResult written as inline JSONSchema).
  - Reversibility: high
- `executor-decision-9` Finding 1 allows either rejecting the aliased destination or selecting a distinct scoped derivative before writing. Which option keeps the boundary smallest and most predictable? -> Reject the aliased destination with an actionable planning error that names both paths and the distinct-path remedy.
  - Rationale: Rejecting is the smallest reversible change, makes the boundary violation visible, keeps argv predictable (no silent redirect), and is safe because no production caller sets JSONSchemaFile and an aliased OutputSchemaFile (verified: supervisor uses inline JSONSchema; setup/skeleton use inline JSONSchema + AttemptDir). The finding explicitly permits this option.
  - Reversibility: high
- `executor-decision-10` Where should the alias check live so every caller is protected? -> Inside PrepareCodexOutputSchema after the canonical schema is decoded/normalized but before os.WriteFile.
  - Rationale: PrepareCodexOutputSchema is already the single runner-owned normalization site invoked directly by the supervisor and via CodexCommandPlan by setup/skeleton, so the guard covers the argv boundary for all four Codex surfaces in one place. Reading the canonical first preserves the AC3 decode/read error surfacing for invalid or missing source files.
  - Reversibility: high
- `executor-decision-11` Is a new CHANGELOG entry needed for this refinement? -> No new entry; the existing Unreleased Fixed entry already describes the single runner-owned Codex schema normalization boundary.
  - Rationale: Alias protection and contentSchema recursion complete the same boundary the existing entry documents; both are internal runner-package behavior with no new user-visible CLI/contract surface, satisfying the release-and-documentation dimension.
  - Reversibility: high

## Discussion Items

- `discussion-1` Supervisor summary: The runner-owned boundary now preserves canonical schema sources, rejects exact and filesystem-aliased destinations before writing, recursively normalizes contentSchema, and remains the sole production compatibility-normalization site. Focused tests, affected-package tests, the full repository suite, go vet, diff checks, and a Windows-targeted runner compilation pass; all acceptance criteria, revision requests, and required quality dimensions are satisfied.

## Risks

- `R1` cross-platform: Centralizing schema materialization could change artifact paths or temporary-file handling across macOS, Linux, and Windows.
  - Mitigation: Use native Go path and file operations, preserve scoped artifact ownership and permissions, and cover paths containing spaces and non-ASCII characters without shell parsing.
- `R2` provider_contract_drift: Codex may change the JSON Schema subset accepted by `--output-schema`, while unit tests only prove Galley's current transformation policy.
  - Mitigation: After focused tests pass, run one smallest-valid-object Codex smoke with a provider-facing artifact naturally produced by the shared boundary; do not add production APIs or persistent test helpers solely for this smoke, and if provider access or an artifact is unavailable, record that exact residual instead of inferring live compatibility.
- `R3` regression: Reusing the whole implementation-executor command planner for the supervisor could unintentionally change supervisor prompts, model or effort flags, timeouts, output capture, or evidence filenames.
  - Mitigation: Reuse the smallest runner-owned schema preparation boundary unless a broader planner reuse preserves the existing supervisor command plan through focused parity tests.
