### PR TITLE
Fix Claude workflow gates and Windows process queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project follows semantic versioning.
 
 - Claude executor and supervisor prompts now gate workflow phases on required evidence without depending on TaskCreate or TaskUpdate, and supervisor revisions are limited to evidence-backed findings in the active review scope.
 
+### Fixed
+
+- Windows daemon process identity checks now use native process APIs, avoiding PowerShell startup timeouts during verification and interrupted-task recovery.
+
 ## v0.12.2 - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.12.3 - 2026-08-18
+
+### Changed
+
+- Claude executor and supervisor prompts now gate workflow phases on required evidence without depending on TaskCreate or TaskUpdate, and supervisor revisions are limited to evidence-backed findings in the active review scope.
+
 ## v0.12.2 - 2026-07-25
 
 ### Fixed

--- a/internal/daemonctl/process_windows.go
+++ b/internal/daemonctl/process_windows.go
@@ -3,12 +3,10 @@
 package daemonctl
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"os/exec"
-	"strings"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 // ProcessInfoResult contains process identity fields from the OS process table.
@@ -18,28 +16,33 @@ type ProcessInfoResult struct {
 	StartedAt  string
 }
 
-// ProcessInfo returns stable identity fields for a Windows process using
-// PowerShell's direct process API rather than the transient CIM service.
+// ProcessInfo returns stable identity fields directly from the Windows
+// process API without starting an external query process.
 func ProcessInfo(pid int) (ProcessInfoResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	script := fmt.Sprintf(
-		`$ErrorActionPreference='Stop';`+
-			`$p=Get-Process -Id %d -ErrorAction Stop;`+
-			`[Console]::Out.Write((ConvertTo-Json -Compress ([ordered]@{`+
-			`Executable=[string]$p.Path;`+
-			`Command='';`+
-			`StartedAt=$p.StartTime.ToUniversalTime().ToString("o")})))`,
-		pid)
-	output, err := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	if pid <= 0 {
+		return ProcessInfoResult{}, fmt.Errorf("query process %d: invalid pid", pid)
+	}
+	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
-		return ProcessInfoResult{}, fmt.Errorf("query process %d: %w", pid, err)
+		return ProcessInfoResult{}, fmt.Errorf("query process %d: open: %w", pid, err)
 	}
-	var parsed ProcessInfoResult
-	if err := json.Unmarshal([]byte(strings.TrimSpace(string(output))), &parsed); err != nil {
-		return ProcessInfoResult{}, fmt.Errorf("parse process %d info: %w", pid, err)
+	defer windows.CloseHandle(handle)
+
+	pathBuffer := make([]uint16, 32768)
+	pathLength := uint32(len(pathBuffer))
+	if err := windows.QueryFullProcessImageName(handle, 0, &pathBuffer[0], &pathLength); err != nil {
+		return ProcessInfoResult{}, fmt.Errorf("query process %d executable: %w", pid, err)
 	}
-	return parsed, nil
+
+	var creationTime, exitTime, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creationTime, &exitTime, &kernelTime, &userTime); err != nil {
+		return ProcessInfoResult{}, fmt.Errorf("query process %d start time: %w", pid, err)
+	}
+
+	return ProcessInfoResult{
+		Executable: windows.UTF16ToString(pathBuffer[:pathLength]),
+		StartedAt:  time.Unix(0, creationTime.Nanoseconds()).UTC().Format(time.RFC3339Nano),
+	}, nil
 }
 
 // Zombie reports whether pid is a zombie process. Windows has no zombie

--- a/prompts/claude-executor-full.md
+++ b/prompts/claude-executor-full.md
@@ -63,7 +63,7 @@ Before returning `hard_stop`, verify that the blocker is not recoverable by loca
 
 # Execution Workflow
 
-Before Step 1, register each `Step N` heading below with TaskCreate. Use TaskUpdate to set Step 1 `in_progress`, then mark each step `completed` only after its completion gate is satisfied and set the next step `in_progress`. Keep exactly one step `in_progress` until Step 8 is complete, and execute the steps in numeric order from contract mapping through final result.
+Treat Steps 1-8 as an evidence-gated sequence. Start with Step 1 and advance in numeric order only after the current step's completion gate is satisfied. Before returning, resume the earliest applicable step whose gate lacks evidence. Return the final result only after Step 8 is complete or a hard-stop condition applies.
 
 ## Step 1. Map Task Contract [BLOCKING]
 
@@ -174,7 +174,6 @@ Use tools deliberately to satisfy the task and produce evidence.
 - Read and view tools: read task inputs, applicable local instructions, relevant code, surrounding context, and verification outputs before editing.
 - Edit, write, and multi-edit tools: make targeted changes in allowed files. Use coordinated edits when changing multiple related locations in one file.
 - Bash and shell tools: run repo-native discovery and verification commands. Prefer commands declared in quality profiles, environment profiles, manifests, or local docs. Treat AC `verification` values as evidence guidance unless they are clearly runnable commands. Inspect failures and retry after code fixes when the failure is code-caused.
-- Task tracking tools: register the ordered Execution Workflow steps with TaskCreate and update their status with TaskUpdate.
 - Skills: use a skill when the task domain, repository instructions, or quality profile matches its trigger. Load the needed skill body and directly referenced files.
 - MCP and external tools: use them when the task or repository context declares an external resource, when verification requires it, or when a missing fact cannot be resolved locally.
 - Subagents: use them when available and when subtasks are independent enough to run separately without blocking immediate implementation.

--- a/prompts/claude-supervisor-review.md
+++ b/prompts/claude-supervisor-review.md
@@ -43,7 +43,7 @@ For `requirement_basis`, `execution_plan`, and `test_or_quality_basis` files, ve
 
 The review procedure exists to produce a complete, actionable verdict while making revision loops converge. Complete and record each phase before starting the next: establishing the active review set, reviewing acceptance, and reviewing quality separately prevents the first discovered defect from consuming the review, preserves coverage of every active item, and lets persisted passes narrow later attempts.
 
-Follow the common Review Algorithm. Before Step 1, register each `Step N` heading below with TaskCreate. Use TaskUpdate to set Step 1 `in_progress`, then mark each step `completed` only after its stated result or gate is complete and set the next step `in_progress`. Keep exactly one step `in_progress` until Step 7 is complete. After marking Step 7 `completed`, return the final verdict only when every registered step is `completed`.
+Follow the common Review Algorithm and treat Steps 1-7 below as an evidence-gated sequence. Start with Step 1 and advance only after the current step's stated result or gate is complete. Before returning, resume the earliest applicable step whose required evidence is missing. Return the final verdict only after Step 7 and every preceding gate are complete.
 
 ## Step 1. Map Evidence And Set Scope
 
@@ -102,8 +102,6 @@ Reason from the provided evidence when it is complete. Use tools before acceptin
 # Decision Model
 
 Use the common Status Policy. Return `accepted` only when the review procedure is complete, every acceptance criterion and pending revision request has persisted or current evidence, and no finding blocks acceptance.
-
-Accepted is allowed only when every plausible wrong-behavior scenario discovered during review has either concrete evidence showing it is handled, or a non-blocking explanation that does not require another executor attempt. When a plausible bug can be fixed by another executor attempt, return `needs_revision` even if tests pass.
 
 Treat executor `hard_stop` as a claim to review, not as an automatic final state. Return `hard_stop` only when the blocker is external or genuinely unrecoverable by another executor attempt, such as a missing credential, destructive requirement, requirement to change paths listed in `task.scope.forbidden_paths`, unavailable external system, or contradictory acceptance criteria. If the executor stopped because of uncertainty, reluctance, insufficient investigation, local tool confusion, or a solvable implementation/verification problem, return `needs_revision` with a finding that states the alternative path and verification needed to complete it. Use the executor's `hard_stop.reason`, `attempted`, and `needed_to_continue` as evidence for that finding.
 


### PR DESCRIPTION
## Summary

- Replace TaskCreate and TaskUpdate workflow tracking with evidence-gated executor and supervisor sequences.
- Keep supervisor revision requests bounded to evidence-backed findings in the active review scope.
- Replace PowerShell-based Windows process identity queries with native process APIs to avoid startup timeouts.
- Record the changes under v0.12.3 in the changelog.

## Verification

- `gofmt` check
- `go test ./...`
- `go build -o /tmp/galley ./cmd/galley`
- Windows test binary cross-compile: `GOOS=windows GOARCH=amd64 go test -c -o /tmp/daemonctl.test.exe ./internal/daemonctl`
- `go run ./cmd/galley schema check`
- Task and profile example validation
- Bundled JSON validation
- `./scripts/smoke-local.sh`
