### PR TITLE
When finalization of a Supervisor-accepted task fails during commit, push, or PR creation, Galley automatically routes the failure through its existing revision-request executor/Supervisor loop so retained work can still reach PR creation…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.12.5 - 2026-08-26
+
 ### Fixed
 
 - A failed commit, push, or PR creation for a Supervisor-accepted task is now routed into the existing revision-request loop with the captured command output and run-artifact location, and a requeued run keeps the original review base so a branch whose accepted commit already exists still finalizes instead of reporting no diff. A finalization that fails again stays pending with the latest failure until Galley's own finalization succeeds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+### Fixed
+
+- A failed commit, push, or PR creation for a Supervisor-accepted task is now routed into the existing revision-request loop with the captured command output and run-artifact location, and a requeued run keeps the original review base so a branch whose accepted commit already exists still finalizes instead of reporting no diff. A finalization that fails again stays pending with the latest failure until Galley's own finalization succeeds.
+
 ### Changed
 
 - Packaged Claude, Codex, and Grok Galley plugins are now versioned as `0.1.33`; task-authoring guidance now loads the bundled task schema before adding a field or collection item whose shape is absent from the generated skeleton.

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -74,7 +74,7 @@ The supervisor is instructed to accept implementation work only when it has:
 - all required quality dimensions and the configured weighted score
 - no unresolved finding at a blocking severity
 
-Incomplete work can continue while the loop budget remains when the supervisor returns actionable findings. `needs_supervisor_review` is reserved for a named decision that only a person can make. Exhausted budgets, provider failures, finalization failures, hard stops, and executor interruptions end the run as `failed` with their evidence preserved.
+Incomplete work can continue while the loop budget remains when the supervisor returns actionable findings. A failed commit, push, or PR creation for accepted work is captured as a pending finalization revision request and spends the next attempt of the same loop. `needs_supervisor_review` is reserved for a named decision that only a person can make. Exhausted budgets, provider failures, hard stops, and executor interruptions end the run as `failed` with their evidence preserved.
 
 Galley does not turn an incomplete pass list or an accepted finding into a daemon failure. Accepted work can proceed to PR creation, where missing acceptance and quality passes and any accepted findings remain visible for human review.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,7 @@ The latest verdict summary names the decision the loop cannot make. Typical case
 - an authoritative human request is ambiguous
 - required authority or destructive approval is missing
 
-Update the task or authoritative source that owns the decision, then requeue with a reason that records what changed. Provider, timeout, exhausted-loop, and finalization failures use `failed`; follow the recorded error and risk instead of treating them as review decisions.
+Update the task or authoritative source that owns the decision, then requeue with a reason that records what changed. Provider, timeout, exhausted-loop, and unrecovered finalization failures use `failed`; follow the recorded error, pending revision request, and risk instead of treating them as review decisions. A task that failed with a pending finalization request resumes through a plain requeue in its retained worktree.
 
 ## A Running Task Outlives Its Daemon
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -887,6 +887,7 @@ func prepareClaimedWorkspace(ctx context.Context, opts Options, profiles profile
 		appendFailureAttempt(loaded, "workspace", "workspace_failed", err, runDir)
 		return claimedWorkspace{}, err
 	}
+	retainPriorReviewBase(ctx, opts, *loaded, runDir, &prepared)
 	if err := writeJSON(runartifact.Path(runDir, runartifact.WorkspaceFilename), prepared); err != nil {
 		appendFailureAttempt(loaded, "run_evidence", "run_evidence_failed", err, runDir)
 		return claimedWorkspace{}, err

--- a/internal/daemon/finalize_recovery.go
+++ b/internal/daemon/finalize_recovery.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/shinpr/galley/internal/proc"
+	"github.com/shinpr/galley/internal/task"
+)
+
+// finalizeRevisionSource marks revision requests Galley itself raised from a
+// failed finalization, so they stay distinct from supervisor findings.
+const finalizeRevisionSource = "finalize"
+
+// finalizeOutputBudget bounds the captured command output Galley copies into
+// the revision request text, which is rendered into the next work order.
+const finalizeOutputBudget = 2000
+
+// finalizeFailure carries a finalization error from the accept path back to
+// the verdict path, which routes it into the existing revision loop.
+type finalizeFailure struct{ Err error }
+
+func (e *finalizeFailure) Error() string {
+	if e == nil || e.Err == nil {
+		return "finalization failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *finalizeFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func asFinalizeFailure(err error) (*finalizeFailure, bool) {
+	var failure *finalizeFailure
+	if errors.As(err, &failure) {
+		return failure, true
+	}
+	return nil, false
+}
+
+// finalizeRevisionRequest renders the pending revision request Galley persists
+// for one failed finalization attempt.
+func finalizeRevisionRequest(id, runDir string, err error) task.RevisionRequest {
+	var b strings.Builder
+	b.WriteString("Galley could not finalize this accepted task: ")
+	b.WriteString(boundedFinalizeText(err.Error()))
+	if output := finalizeCommandOutput(err); output != "" {
+		b.WriteString("\nCommand output: ")
+		b.WriteString(output)
+	}
+	fmt.Fprintf(&b, "\nRun artifacts (command argv, stdout, stderr, exit code): %s", runDir)
+	b.WriteString("\nRepair the cause of this failure in the workspace so Galley's own commit, push, and PR creation succeeds on the next attempt. Do not bypass or disable Git hooks, and do not run the commit, push, or PR creation yourself; Galley reruns finalization after this attempt is accepted.")
+	return task.RevisionRequest{
+		ID:     id,
+		Source: finalizeRevisionSource,
+		Text:   b.String(),
+		Status: "pending",
+	}
+}
+
+// finalizeCommandOutput extracts the bounded stderr/stdout tail captured for
+// the failed git or gh command, which the error string alone does not carry.
+func finalizeCommandOutput(err error) string {
+	var commandErr *proc.CommandError
+	if !errors.As(err, &commandErr) {
+		return ""
+	}
+	output := strings.TrimSpace(commandErr.Result.Stderr)
+	if output == "" {
+		output = strings.TrimSpace(commandErr.Result.Stdout)
+	}
+	return boundedFinalizeText(output)
+}
+
+// boundedFinalizeText keeps the tail of text, which holds the actionable end
+// of a hook or transport failure, within finalizeOutputBudget bytes.
+func boundedFinalizeText(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= finalizeOutputBudget {
+		return text
+	}
+	return "[truncated]" + text[len(text)-finalizeOutputBudget:]
+}
+
+// recordFinalizeRevision persists the pending finalization revision request so
+// the next loop attempt receives it as an ordinary revision request.
+func recordFinalizeRevision(req verdictApplication, failure *finalizeFailure) error {
+	id := finalizeRevisionID(req.Loaded.RevisionRequests, req.Attempt)
+	upsertFinalizeRevision(req.Loaded, finalizeRevisionRequest(id, req.RunDir, failure.Err))
+	return task.Save(req.RunningPath, *req.Loaded)
+}
+
+// finalizeRevisionID derives this attempt's request identity, skipping any ID a
+// request Galley does not own already holds.
+func finalizeRevisionID(requests []task.RevisionRequest, attempt int) string {
+	base := fmt.Sprintf("finalize-attempt-%d", attempt)
+	id := base
+	for suffix := 2; foreignRevisionHoldsID(requests, id); suffix++ {
+		id = fmt.Sprintf("%s-%d", base, suffix)
+	}
+	return id
+}
+
+// foreignRevisionHoldsID reports whether a request from another source holds
+// id, so its text, provenance, status, and evidence must survive untouched.
+func foreignRevisionHoldsID(requests []task.RevisionRequest, id string) bool {
+	for _, request := range requests {
+		if request.ID == id && request.Source != finalizeRevisionSource {
+			return true
+		}
+	}
+	return false
+}
+
+// upsertFinalizeRevision reopens Galley's own request for this attempt, so a
+// repeated failure is pending again without replacing another source's request.
+func upsertFinalizeRevision(loaded *task.Task, request task.RevisionRequest) {
+	for i := range loaded.RevisionRequests {
+		existing := &loaded.RevisionRequests[i]
+		if existing.ID == request.ID && existing.Source == finalizeRevisionSource {
+			*existing = request
+			return
+		}
+	}
+	loaded.RevisionRequests = append(loaded.RevisionRequests, request)
+}
+
+// markFinalizeRevisionsAddressed closes pending finalization requests once the
+// same finalize operation succeeded, which is the evidence they asked for.
+func markFinalizeRevisionsAddressed(loaded *task.Task) {
+	for i := range loaded.RevisionRequests {
+		request := &loaded.RevisionRequests[i]
+		if request.Source != finalizeRevisionSource || request.Status == "addressed" {
+			continue
+		}
+		request.Status = "addressed"
+		request.Evidence = "Galley reran the same finalize operation and it succeeded."
+	}
+}
+
+// hasPendingFinalizeRevision reports whether a finalization failure is still
+// waiting to be repaired for this task.
+func hasPendingFinalizeRevision(loaded task.Task) bool {
+	for _, request := range loaded.RevisionRequests {
+		if request.Source == finalizeRevisionSource && request.Status != "addressed" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/daemon/finalize_recovery.go
+++ b/internal/daemon/finalize_recovery.go
@@ -80,11 +80,13 @@ func finalizeCommandOutput(err error) string {
 // boundedFinalizeText keeps the tail of text, which holds the actionable end
 // of a hook or transport failure, within finalizeOutputBudget bytes.
 func boundedFinalizeText(text string) string {
-	text = strings.TrimSpace(text)
+	// Dropping invalid bytes keeps the persisted request text valid UTF-8 when
+	// the byte budget cuts through a multibyte character.
+	text = strings.ToValidUTF8(strings.TrimSpace(text), "")
 	if len(text) <= finalizeOutputBudget {
 		return text
 	}
-	return "[truncated]" + text[len(text)-finalizeOutputBudget:]
+	return "[truncated]" + strings.ToValidUTF8(text[len(text)-finalizeOutputBudget:], "")
 }
 
 // recordFinalizeRevision persists the pending finalization revision request so

--- a/internal/daemon/finalize_recovery_test.go
+++ b/internal/daemon/finalize_recovery_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/shinpr/galley/internal/proc"
 	"github.com/shinpr/galley/internal/task"
@@ -722,4 +723,126 @@ func nthRunDir(t *testing.T, root string, n int) string {
 		t.Fatalf("want at least %d run dirs, got %#v", n, matches)
 	}
 	return matches[n-1]
+}
+
+// AC1/AC2: a resolved supervisor revision request must not reappear in the
+// work order after an accepted attempt's finalization fails.
+func TestFinalizeFailureAfterAcceptedRevisionKeepsResolvedRequestsClosed(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-push")
+	writeMarkerFile(t, marker)
+	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	// Attempt 1 reports risks, which the shared fake supervisor turns into a
+	// needs_revision finding; attempt 2 addresses it and is accepted.
+	claudeBin := writeFakeClaude(t, `case "$*" in
+  *finalize-attempt-2*)
+    rm -f `+marker+`
+    echo '{"status":"completed","summary":"repaired finalization","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"},{"id":"revision:finalize-attempt-2","status":"satisfied","evidence":["removed the blocking condition"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+  *supervisor-attempt-1-finding-1*)
+    echo revised > daemon-revision.txt
+    echo '{"status":"completed","summary":"addressed the supervisor finding","files_modified":["daemon-revision.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"},{"id":"revision:supervisor-attempt-1-finding-1","status":"satisfied","evidence":["risk resolved"],"notes":"finding addressed"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+  *)
+    echo change > daemon-output.txt
+    echo '{"status":"completed_with_risks","summary":"done with a risk","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[{"type":"other","detail":"one open risk","mitigation":"resolve it","needs_human_review":false}]}'
+    ;;
+esac
+`)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/507
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 4)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The recovery attempt must carry only the still-pending finalization
+	// request, while the accepted supervisor finding stays a verified pass.
+	prompt := attemptPrompt(t, root, "attempt-3")
+	if strings.Contains(prompt, "`supervisor-attempt-1-finding-1` source=`supervisor`") {
+		t.Fatalf("attempt-3 work order reintroduced the resolved supervisor request:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "`finalize-attempt-2` source=`finalize`") {
+		t.Fatalf("attempt-3 work order missing the pending finalization request:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "- acceptance: `AC1`") {
+		t.Fatalf("attempt-3 work order lost the accepted review progress:\n%s", prompt)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/507" {
+		t.Fatalf("recovered task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	for _, request := range doneTask.RevisionRequests {
+		if request.Source == supervisorRevisionSource {
+			t.Fatalf("the accepted supervisor request was reintroduced on the task: %#v", request)
+		}
+	}
+	if request := findRevisionRequest(t, doneTask, "finalize-attempt-2"); request.Status != "addressed" {
+		t.Fatalf("finalization request got %#v", request)
+	}
+	if doneTask.ReviewProgress == nil || !containsString(doneTask.ReviewProgress.Acceptance, "AC1") {
+		t.Fatalf("prior review progress was lost: %#v", doneTask.ReviewProgress)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != gitOutputForTest(t, worktree, "rev-parse", "HEAD") {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD", got)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Truncation must not split a multibyte character, so the persisted request
+// text stays valid UTF-8 and readable text after task.Save.
+func TestFinalizeRevisionRequestTruncationIsUTF8Safe(t *testing.T) {
+	// Three-byte runes make the byte budget land inside a character.
+	stderr := strings.Repeat("日", finalizeOutputBudget) + "フックが拒否しました"
+	err := fmt.Errorf("git push failed: %w", &proc.CommandError{
+		Kind:   proc.CommandErrorExitNonZero,
+		Result: proc.RunResult{ExitCode: 1, Stderr: stderr},
+		Err:    errors.New("exit nonzero"),
+	})
+	request := finalizeRevisionRequest("finalize-attempt-1", "/runs/task-1", err)
+	if !utf8.ValidString(request.Text) {
+		t.Fatalf("truncated request text is not valid UTF-8: %q", request.Text)
+	}
+	if strings.ContainsRune(request.Text, utf8.RuneError) {
+		t.Fatalf("truncated request text contains a replacement character: %q", request.Text)
+	}
+	if !strings.Contains(request.Text, "フックが拒否しました") {
+		t.Fatalf("truncated request text lost the actionable output tail: %q", request.Text)
+	}
+
+	path := filepath.Join(t.TempDir(), "task.yaml")
+	writeDaemonTask(t, path, t.TempDir())
+	seedRevisionRequest(t, path, request)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "!!binary") {
+		t.Fatalf("task.Save persisted the request text as binary instead of text")
+	}
+	reloaded, loadErr := task.Load(path)
+	if loadErr != nil {
+		t.Fatalf("saved task did not reload: %v", loadErr)
+	}
+	if got := findRevisionRequest(t, reloaded, "finalize-attempt-1"); got.Text != request.Text {
+		t.Fatalf("persisted request text changed: got %q", got.Text)
+	}
 }

--- a/internal/daemon/finalize_recovery_test.go
+++ b/internal/daemon/finalize_recovery_test.go
@@ -1,0 +1,725 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinpr/galley/internal/proc"
+	"github.com/shinpr/galley/internal/task"
+)
+
+// finalizeRecoveryRepo builds the fixture shared by these tests: a source
+// repo with a bare origin, plus a queued Galley task.
+func finalizeRecoveryRepo(t *testing.T) (root, repo, remote, worktree, promptPath, schemaPath, taskPath string) {
+	t.Helper()
+	root = filepath.Join(t.TempDir(), ".agent-workflow")
+	repo = initDaemonGitRepo(t)
+	remote = filepath.Join(t.TempDir(), "remote.git")
+	runDaemonGit(t, t.TempDir(), "init", "--bare", remote)
+	runDaemonGit(t, repo, "remote", "add", "origin", remote)
+	promptPath, schemaPath = writeDaemonPromptFiles(t)
+	taskPath = filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	worktree = filepath.Join(filepath.Dir(repo), "worktrees", "task")
+	return root, repo, remote, worktree, promptPath, schemaPath, taskPath
+}
+
+// writeBlockingGitHook installs a real git hook that rejects the operation
+// while marker exists, so finalization runs through hooks rather than around.
+func writeBlockingGitHook(t *testing.T, repo, hook, marker, message string) {
+	t.Helper()
+	path := filepath.Join(repo, ".git", "hooks", hook)
+	body := fmt.Sprintf("#!/bin/sh\nif [ -f %q ]; then\n  echo %q >&2\n  exit 1\nfi\nexit 0\n", marker, message)
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMarkerFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("blocked\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// finalizeRepairExecutor removes marker (the simulated failure cause) only
+// after the pending finalization request arrives, and writes no file itself.
+func finalizeRepairExecutor(t *testing.T, marker string) string {
+	t.Helper()
+	return writeFakeClaude(t, `case "$*" in
+  *finalize-attempt-1*)
+    rm -f `+marker+`
+    echo '{"status":"completed","summary":"repaired finalization","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["removed the blocking condition"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+  *)
+    echo change > daemon-output.txt
+    echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+esac
+`)
+}
+
+func finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin string) Options {
+	return Options{
+		Root:               root,
+		SystemPromptFile:   promptPath,
+		JSONSchemaFile:     schemaPath,
+		Supervisor:         "claude",
+		ClaudeBin:          claudeBin,
+		Once:               true,
+		MaxConcurrentTasks: 1,
+		OpenPR:             true,
+		PRBase:             "main",
+		GHBin:              ghBin,
+	}
+}
+
+func gitOutputForTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func assertCommitsAheadOfBase(t *testing.T, worktree string, want int) {
+	t.Helper()
+	// The fixture repo has one initial commit, so the accepted work must add
+	// exactly want commits on top of it.
+	got := gitOutputForTest(t, worktree, "rev-list", "--count", "HEAD")
+	if got != fmt.Sprintf("%d", want+1) {
+		t.Fatalf("branch commit count got %s, want %d (initial + %d accepted)", got, want+1, want)
+	}
+}
+
+func attemptPrompt(t *testing.T, root, attemptDir string) string {
+	t.Helper()
+	planData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", attemptDir, "command_plan.json"))
+	var plan struct {
+		Argv []string `json:"argv"`
+	}
+	if err := json.Unmarshal(planData, &plan); err != nil {
+		t.Fatalf("decode %s command plan: %v", attemptDir, err)
+	}
+	if len(plan.Argv) == 0 {
+		t.Fatalf("%s command plan argv is empty", attemptDir)
+	}
+	return plan.Argv[len(plan.Argv)-1]
+}
+
+func findRevisionRequest(t *testing.T, loaded task.Task, id string) task.RevisionRequest {
+	t.Helper()
+	for _, request := range loaded.RevisionRequests {
+		if request.ID == id {
+			return request
+		}
+	}
+	t.Fatalf("revision request %q not found: %#v", id, loaded.RevisionRequests)
+	return task.RevisionRequest{}
+}
+
+// AC1/AC2/AC4: a pre-commit hook failure becomes a pending finalization
+// request in the next work order and recovers with exactly one commit.
+func TestFinalizeCommitFailureRecoversThroughRevisionLoop(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-commit")
+	writeMarkerFile(t, marker)
+	writeBlockingGitHook(t, repo, "pre-commit", marker, "pre-commit hook rejected the accepted change")
+	claudeBin := finalizeRepairExecutor(t, marker)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/501
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 3)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" {
+		t.Fatalf("status got %q, want pr_opened", doneTask.Status)
+	}
+	if doneTask.PR.URL != "https://github.com/example/galley/pull/501" {
+		t.Fatalf("pr got %#v", doneTask.PR)
+	}
+	if len(doneTask.Attempts) != 2 {
+		t.Fatalf("attempts got %d, want 2 (the finalization failure must spend one more loop attempt): %#v", len(doneTask.Attempts), doneTask.Attempts)
+	}
+	if doneTask.Attempts[0].SupervisorVerdict != "accepted" || doneTask.Attempts[1].SupervisorVerdict != "accepted" {
+		t.Fatalf("attempt verdicts got %#v, want two supervisor verdicts", doneTask.Attempts)
+	}
+	request := findRevisionRequest(t, doneTask, "finalize-attempt-1")
+	if request.Source != "finalize" || request.Status != "addressed" {
+		t.Fatalf("finalization revision request got %#v", request)
+	}
+	if !strings.Contains(request.Text, "pre-commit hook rejected the accepted change") {
+		t.Fatalf("finalization revision request lost the captured command output: %q", request.Text)
+	}
+	if !strings.Contains(request.Text, filepath.Join(root, "runs")) {
+		t.Fatalf("finalization revision request lost the run-artifact location: %q", request.Text)
+	}
+
+	summaries := 0
+	for _, item := range doneTask.DiscussionItems {
+		if item.Topic == "Supervisor summary" {
+			summaries++
+		}
+	}
+	if summaries != 1 {
+		t.Fatalf("recovered acceptance duplicated discussion items: %#v", doneTask.DiscussionItems)
+	}
+
+	prompt := attemptPrompt(t, root, "attempt-2")
+	for _, want := range []string{"finalize-attempt-1", "source=`finalize`", "pre-commit hook rejected the accepted change"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("attempt-2 work order missing %q:\n%s", want, prompt)
+		}
+	}
+
+	effective, err := task.Load(filepath.Join(mustSingleGlobDir(t, filepath.Join(root, "runs", "*")), "attempt-2", "task.effective.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective.Scope.CWD != worktree {
+		t.Fatalf("attempt-2 workspace got %q, want retained worktree %q", effective.Scope.CWD, worktree)
+	}
+	if effective.ReviewProgress == nil || len(effective.ReviewProgress.Acceptance) == 0 {
+		t.Fatalf("attempt-2 lost accepted review progress: %#v", effective.ReviewProgress)
+	}
+	if _, err := os.Stat(worktree); err != nil {
+		t.Fatalf("worktree was not preserved: %v", err)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != gitOutputForTest(t, worktree, "rev-parse", "HEAD") {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD", got)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "gh_pr_create_result.json"), 1)
+}
+
+// AC1/AC2: a pre-push hook failure after the accepted commit exists recovers
+// without a second commit, leaving the remote at the accepted HEAD.
+func TestFinalizePushFailureRecoversThroughRevisionLoop(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-push")
+	writeMarkerFile(t, marker)
+	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	claudeBin := finalizeRepairExecutor(t, marker)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/502
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 3)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/502" {
+		t.Fatalf("recovered task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	request := findRevisionRequest(t, doneTask, "finalize-attempt-1")
+	if !strings.Contains(request.Text, "pre-push hook rejected the accepted branch") {
+		t.Fatalf("finalization revision request lost the push failure output: %q", request.Text)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != gitOutputForTest(t, worktree, "rev-parse", "HEAD") {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD", got)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "gh_pr_create_result.json"), 1)
+}
+
+// AC1/AC2: a failed PR creation with no recoverable PR recovers with exactly
+// one recorded PR URL and no extra commit.
+func TestFinalizePRCreateFailureRecoversThroughRevisionLoop(t *testing.T) {
+	root, _, _, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-pr-create")
+	writeMarkerFile(t, marker)
+	claudeBin := finalizeRepairExecutor(t, marker)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  if [ -f `+marker+` ]; then
+    echo "gh pr create rejected the request: HTTP 422 base branch is protected" >&2
+    exit 1
+  fi
+  echo https://github.com/example/galley/pull/503
+elif [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  echo "no pull requests found for branch" >&2
+  exit 1
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 3)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/503" || doneTask.PR.Status != "open" {
+		t.Fatalf("recovered task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	request := findRevisionRequest(t, doneTask, "finalize-attempt-1")
+	if !strings.Contains(request.Text, "HTTP 422 base branch is protected") {
+		t.Fatalf("finalization revision request lost the gh pr create output: %q", request.Text)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+}
+
+// AC3: after attempt exhaustion, a plain requeue finalizes the retained
+// worktree whose accepted commit exists, without a false empty diff.
+func TestFinalizeFailureSurvivesRequeueAndFinalizesRetainedCommit(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-push")
+	writeMarkerFile(t, marker)
+	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	firstClaude := writeFakeClaude(t, `echo change > daemon-output.txt
+echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+`)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/504
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 1)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, firstClaude, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	failedTask, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatalf("first run did not publish a failed task: %v", err)
+	}
+	if failedTask.Status != "failed" {
+		t.Fatalf("first run status got %q, want failed", failedTask.Status)
+	}
+	pending := findRevisionRequest(t, failedTask, "finalize-attempt-1")
+	if pending.Status != "pending" || !strings.Contains(pending.Text, "pre-push hook rejected the accepted branch") {
+		t.Fatalf("pending finalization revision was not preserved: %#v", pending)
+	}
+	acceptedHead := gitOutputForTest(t, worktree, "rev-parse", "HEAD")
+	assertCommitsAheadOfBase(t, worktree, 1)
+	firstBase := runBaseSHA(t, root)
+
+	// A plain requeue: no new revision request and no human-authored guidance.
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+
+	// The second run's executor changes nothing: recovery comes from the
+	// retained worktree, retained review base, and the pending request.
+	secondClaude := writeFakeClaude(t, `echo '{"status":"completed","summary":"finalization blocker cleared","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["retained commit"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["blocking condition resolved"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+`)
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, secondClaude, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("requeued task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/504" {
+		t.Fatalf("requeued task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	if got := gitOutputForTest(t, worktree, "rev-parse", "HEAD"); got != acceptedHead {
+		t.Fatalf("accepted commit changed across requeue: got %s want %s", got, acceptedHead)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != acceptedHead {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD %s", got, acceptedHead)
+	}
+	if got := gitOutputForTest(t, worktree, "show", "HEAD:daemon-output.txt"); got != "change" {
+		t.Fatalf("accepted implementation change was lost: %q", got)
+	}
+	if got := secondRunBaseSHA(t, root); got != firstBase {
+		t.Fatalf("second run review base got %s, want the retained base %s", got, firstBase)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "gh_pr_create_result.json"), 1)
+}
+
+// The request text carries the actionable tail of the captured command
+// output within the documented budget instead of the whole log.
+func TestFinalizeRevisionRequestBoundsCapturedOutput(t *testing.T) {
+	stderr := strings.Repeat("x", finalizeOutputBudget*2) + "pre-push hook rejected the accepted branch"
+	err := fmt.Errorf("git push failed: %w", &proc.CommandError{
+		Kind:   proc.CommandErrorExitNonZero,
+		Result: proc.RunResult{ExitCode: 1, Stderr: stderr},
+		Err:    errors.New("exit nonzero"),
+	})
+	request := finalizeRevisionRequest("finalize-attempt-2", "/runs/task-1", err)
+	if request.ID != "finalize-attempt-2" || request.Source != finalizeRevisionSource || request.Status != "pending" {
+		t.Fatalf("request got %#v", request)
+	}
+	if !strings.Contains(request.Text, "pre-push hook rejected the accepted branch") {
+		t.Fatalf("request lost the actionable output tail: %q", request.Text)
+	}
+	if !strings.Contains(request.Text, "/runs/task-1") {
+		t.Fatalf("request lost the run-artifact location: %q", request.Text)
+	}
+	if !strings.Contains(request.Text, "[truncated]") || len(request.Text) > finalizeOutputBudget*2 {
+		t.Fatalf("request output was not bounded: len=%d", len(request.Text))
+	}
+}
+
+func mustSingleGlobDir(t *testing.T, pattern string) string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("%s matched %d dirs, want 1: %#v", pattern, len(matches), matches)
+	}
+	return matches[0]
+}
+
+func runBaseSHA(t *testing.T, root string) string {
+	t.Helper()
+	return decodeBaseSHA(t, mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "workspace.json")))
+}
+
+func secondRunBaseSHA(t *testing.T, root string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "runs", "*", "workspace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("want two run workspace evidence files, got %#v", matches)
+	}
+	data, err := os.ReadFile(matches[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decodeBaseSHA(t, data)
+}
+
+func decodeBaseSHA(t *testing.T, data []byte) string {
+	t.Helper()
+	var prepared struct {
+		BaseSHA string `json:"base_sha"`
+	}
+	if err := json.Unmarshal(data, &prepared); err != nil {
+		t.Fatal(err)
+	}
+	return prepared.BaseSHA
+}
+
+// writeHookMessage sets the message the blocking hook reports, so each run's
+// failure output is distinguishable in the persisted revision request.
+func writeHookMessage(t *testing.T, path, message string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(message+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeMessageEchoingGitHook installs a real hook that rejects the operation
+// with the current contents of marker while that file exists.
+func writeMessageEchoingGitHook(t *testing.T, repo, hook, marker string) {
+	t.Helper()
+	path := filepath.Join(repo, ".git", "hooks", hook)
+	body := fmt.Sprintf("#!/bin/sh\nif [ -f %q ]; then\n  cat %q >&2\n  exit 1\nfi\nexit 0\n", marker, marker)
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// finalizeRevisionProjectingClaude is the shared fake claude whose supervisor
+// also passes revision:finalize-attempt-1 once that request reaches it.
+func finalizeRevisionProjectingClaude(t *testing.T, executorBody string) string {
+	t.Helper()
+	return writeFakeCommand(t, "claude", `supervisor=0
+for arg in "$@"; do
+  if [ "$arg" = "--no-session-persistence" ]; then
+    supervisor=1
+  fi
+done
+if [ "$supervisor" = "1" ]; then
+  request="$(cat)"
+  if printf '%s' "$request" | grep -q 'finalize-attempt-1'; then
+    printf '%s\n' '{"status":"accepted","summary":"accepted with the finalization revision","acceptance_passes":["AC1","revision:finalize-attempt-1"],"quality_passes":[],"findings":[],"discussion_items":[]}'
+  else
+    printf '%s\n' '{"status":"accepted","summary":"accepted","acceptance_passes":["AC1"],"quality_passes":[],"findings":[],"discussion_items":[]}'
+  fi
+  exit 0
+fi
+`+executorBody+`
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"fake-claude-session"}'
+`)
+}
+
+// AC1/AC3: a repeated finalization failure must leave the latest failure
+// pending, and a further plain requeue must publish exactly one PR.
+func TestFinalizeFailureRepeatedAfterRequeueKeepsLatestPendingRevision(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	marker := filepath.Join(t.TempDir(), "block-push")
+	writeHookMessage(t, marker, "pre-push hook rejected the accepted branch (run 1)")
+	writeMessageEchoingGitHook(t, repo, "pre-push", marker)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/505
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 1)
+
+	firstClaude := finalizeRevisionProjectingClaude(t, `echo change > daemon-output.txt
+echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+`)
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, firstClaude, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
+	failedTask, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatalf("first run did not publish a failed task: %v", err)
+	}
+	first := findRevisionRequest(t, failedTask, "finalize-attempt-1")
+	if first.Status != "pending" || !strings.Contains(first.Text, "(run 1)") {
+		t.Fatalf("first run pending finalization request got %#v", first)
+	}
+	acceptedHead := gitOutputForTest(t, worktree, "rev-parse", "HEAD")
+	firstBase := runBaseSHA(t, root)
+
+	// A plain requeue whose finalization fails again on its first attempt.
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	writeHookMessage(t, marker, "pre-push hook rejected the accepted branch (run 2)")
+	retainedClaude := finalizeRevisionProjectingClaude(t, `echo '{"status":"completed","summary":"finalization blocker addressed","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["retained commit"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["blocking condition resolved"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+`)
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, retainedClaude, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	secondFailed, err := task.Load(failedPath)
+	if err != nil {
+		t.Fatalf("second run did not publish a failed task: %v", err)
+	}
+	pending := findRevisionRequest(t, secondFailed, "finalize-attempt-1")
+	if pending.Status != "pending" {
+		t.Fatalf("second finalization failure left request status %q, want pending: %#v", pending.Status, pending)
+	}
+	if !strings.Contains(pending.Text, "git push failed") {
+		t.Fatalf("pending request lost the failed operation: %q", pending.Text)
+	}
+	if !strings.Contains(pending.Text, "(run 2)") || strings.Contains(pending.Text, "(run 1)") {
+		t.Fatalf("pending request does not describe the latest failure: %q", pending.Text)
+	}
+	if !strings.Contains(pending.Text, nthRunDir(t, root, 2)) {
+		t.Fatalf("pending request lost the second run's artifact location: %q", pending.Text)
+	}
+	if pending.Evidence != "" {
+		t.Fatalf("pending request kept stale addressed evidence: %q", pending.Evidence)
+	}
+	if secondFailed.ReviewProgress == nil || len(secondFailed.ReviewProgress.Acceptance) == 0 {
+		t.Fatalf("second run lost prior review passes: %#v", secondFailed.ReviewProgress)
+	}
+	if got := secondRunBaseSHA(t, root); got != firstBase {
+		t.Fatalf("second run review base got %s, want the retained base %s", got, firstBase)
+	}
+	if got := gitOutputForTest(t, worktree, "rev-parse", "HEAD"); got != acceptedHead {
+		t.Fatalf("accepted commit changed across the second run: got %s want %s", got, acceptedHead)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+
+	// The final plain requeue finalizes the retained accepted commit.
+	if _, err := task.Requeue(failedPath, task.RequeueOptions{Root: root}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, retainedClaude, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("requeued task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/505" {
+		t.Fatalf("requeued task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	if got := findRevisionRequest(t, doneTask, "finalize-attempt-1"); got.Status != "addressed" {
+		t.Fatalf("successful finalization did not address the request: %#v", got)
+	}
+	if got := gitOutputForTest(t, worktree, "rev-parse", "HEAD"); got != acceptedHead {
+		t.Fatalf("accepted commit changed across requeue: got %s want %s", got, acceptedHead)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != acceptedHead {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD %s", got, acceptedHead)
+	}
+	if got := gitOutputForTest(t, worktree, "show", "HEAD:daemon-output.txt"); got != "change" {
+		t.Fatalf("accepted implementation change was lost: %q", got)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "gh_pr_create_result.json"), 1)
+}
+
+// seedRevisionRequest adds a request from another source to a task file, so
+// Galley's own finalization identity has to avoid the ID it already holds.
+func seedRevisionRequest(t *testing.T, path string, request task.RevisionRequest) {
+	t.Helper()
+	loaded, err := task.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.RevisionRequests = append(loaded.RevisionRequests, request)
+	if err := task.Save(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AC1: a finalization failure must not overwrite a request from another source
+// that already holds the ID Galley would otherwise use for this attempt.
+func TestFinalizeFailurePreservesForeignRequestHoldingItsID(t *testing.T) {
+	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
+	foreign := task.RevisionRequest{
+		ID:        "finalize-attempt-1",
+		Source:    "pr-comment",
+		CommentID: "IC_human_1",
+		Text:      "Reviewer asked for the retry budget to stay documented in the goal.",
+		Status:    "pending",
+		Evidence:  "requested in the PR review thread",
+	}
+	seedRevisionRequest(t, taskPath, foreign)
+	marker := filepath.Join(t.TempDir(), "block-push")
+	writeMarkerFile(t, marker)
+	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	claudeBin := writeFakeClaude(t, `case "$*" in
+  *finalize-attempt-1-2*)
+    rm -f `+marker+`
+    echo '{"status":"completed","summary":"repaired finalization","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["budget documented"],"notes":"reviewer request kept"},{"id":"revision:finalize-attempt-1-2","status":"satisfied","evidence":["removed the blocking condition"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+  *)
+    echo change > daemon-output.txt
+    echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["budget documented"],"notes":"reviewer request kept"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
+    ;;
+esac
+`)
+	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo https://github.com/example/galley/pull/506
+else
+  printf '%s\n' '{"user":{"login":"pr-author"}}'
+fi
+`)
+	setLoopBudget(t, taskPath, 3)
+
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both instructions, identities, and provenance must reach the next
+	// attempt's work order side by side.
+	prompt := attemptPrompt(t, root, "attempt-2")
+	for _, want := range []string{
+		"`finalize-attempt-1` source=`pr-comment` comment=`IC_human_1`: " + foreign.Text,
+		"`finalize-attempt-1-2` source=`finalize`",
+		"pre-push hook rejected the accepted branch",
+		filepath.Join(root, "runs"),
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("attempt-2 work order missing %q:\n%s", want, prompt)
+		}
+	}
+
+	doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
+	if err != nil {
+		t.Fatalf("task did not reach done/: %v", err)
+	}
+	if doneTask.Status != "pr_opened" || doneTask.PR.URL != "https://github.com/example/galley/pull/506" {
+		t.Fatalf("recovered task got status=%q pr=%#v", doneTask.Status, doneTask.PR)
+	}
+	if got := findRevisionRequest(t, doneTask, "finalize-attempt-1"); got != foreign {
+		t.Fatalf("the pr-comment request was not preserved: got %#v want %#v", got, foreign)
+	}
+	own := findRevisionRequest(t, doneTask, "finalize-attempt-1-2")
+	if own.Source != finalizeRevisionSource || own.Status != "addressed" {
+		t.Fatalf("Galley's finalization request got %#v", own)
+	}
+	if !strings.Contains(own.Text, "git push failed") || !strings.Contains(own.Text, "pre-push hook rejected the accepted branch") {
+		t.Fatalf("Galley's finalization request lost the captured failure: %q", own.Text)
+	}
+	if !strings.Contains(own.Text, filepath.Join(root, "runs")) {
+		t.Fatalf("Galley's finalization request lost the run-artifact location: %q", own.Text)
+	}
+	assertCommitsAheadOfBase(t, worktree, 1)
+	if got := gitOutputForTest(t, remote, "rev-parse", "refs/heads/agent/task"); got != gitOutputForTest(t, worktree, "rev-parse", "HEAD") {
+		t.Fatalf("remote branch %s does not point at the accepted HEAD", got)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "gh_pr_create_result.json"), 1)
+}
+
+// A repeated failure on the same attempt must reopen Galley's own request under
+// its derived identity instead of accumulating one request per requeue.
+func TestFinalizeRevisionIdentityIsStableBesideAForeignRequest(t *testing.T) {
+	loaded := task.Task{RevisionRequests: []task.RevisionRequest{{
+		ID: "finalize-attempt-1", Source: "pr-comment", Text: "human instruction", Status: "pending",
+	}}}
+	for run := 1; run <= 3; run++ {
+		id := finalizeRevisionID(loaded.RevisionRequests, 1)
+		if id != "finalize-attempt-1-2" {
+			t.Fatalf("run %d derived id got %q", run, id)
+		}
+		request := finalizeRevisionRequest(id, "/runs/run-"+fmt.Sprint(run), fmt.Errorf("git push failed (run %d)", run))
+		upsertFinalizeRevision(&loaded, request)
+	}
+	if len(loaded.RevisionRequests) != 2 {
+		t.Fatalf("repeated failures did not reuse one identity: %#v", loaded.RevisionRequests)
+	}
+	if loaded.RevisionRequests[0].Source != "pr-comment" || loaded.RevisionRequests[0].Text != "human instruction" {
+		t.Fatalf("the pr-comment request was overwritten: %#v", loaded.RevisionRequests[0])
+	}
+	if got := loaded.RevisionRequests[1]; !strings.Contains(got.Text, "(run 3)") || got.Status != "pending" {
+		t.Fatalf("latest failure was not the pending request: %#v", got)
+	}
+}
+
+// nthRunDir returns the nth (1-based) run directory in chronological order.
+func nthRunDir(t *testing.T, root string, n int) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "runs", "*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) < n {
+		t.Fatalf("want at least %d run dirs, got %#v", n, matches)
+	}
+	return matches[n-1]
+}

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -183,6 +183,9 @@ func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, running
 		if err != nil || done {
 			return err
 		}
+		// A finalization failure re-enters the loop as a pending revision
+		// request on the task; carry it into the next work order.
+		promptTask.RevisionRequests = loaded.RevisionRequests
 	}
 	*loaded = revision.applyToTask(*loaded)
 	loaded.Status = "failed"
@@ -313,7 +316,14 @@ func applySupervisorVerdict(execCtx, daemonCtx context.Context, req verdictAppli
 			fmt.Fprintf(os.Stderr, "galley: task %s accepted verdict rejected by acceptance gate: %s\n", req.Loaded.ID, reason)
 			return true, failVerdictApplication(req, "acceptance-gate", "Accepted verdict rejected by acceptance skeleton gate: "+reason, "Inspect preflight_result.json before re-finalizing.")
 		}
-		return true, acceptSupervisorVerdict(execCtx, req.Opts, req.RunningPath, req.Loaded, req.Prepared, req.Profiles, req.RunDir, req.Verdict)
+		err := acceptSupervisorVerdict(execCtx, req.Opts, req.RunningPath, req.Loaded, req.Prepared, req.Profiles, req.RunDir, req.Verdict)
+		// A finalization failure keeps the accepted work, worktree, and review
+		// progress and spends the next attempt of this loop repairing it.
+		if failure, ok := asFinalizeFailure(err); ok {
+			fmt.Fprintf(os.Stderr, "galley: task %s finalization failed after attempt %d; routing the failure into the revision loop: %v\n", req.Loaded.ID, req.Attempt, failure.Err)
+			return false, recordFinalizeRevision(req, failure)
+		}
+		return true, err
 	case "needs_revision":
 		return false, nil
 	case "hard_stop":
@@ -341,10 +351,16 @@ func acceptSupervisorVerdict(ctx context.Context, opts Options, runningPath stri
 	if opts.CommitOnAccept {
 		fmt.Fprintf(os.Stderr, "galley: task %s accepted; finalizing commit/pr\n", loaded.ID)
 		if err := finalizeAcceptedChange(ctx, opts, loaded, prepared.CWD, prepared.BaseSHA, runDir); err != nil {
+			// A failed commit, push, or PR creation goes back to the verdict
+			// path; every other finalization failure still fails the task.
+			if _, ok := asFinalizeFailure(err); ok {
+				return err
+			}
 			loaded.Status = "failed"
 			appendRisk(loaded, "finalize", "partial_verification", err.Error(), "The executor diff and run evidence were stored; a supervisor should inspect and finish commit or PR creation.", true)
 			return taskstate.FailMoveToStatus(opts.Root, runningPath, loaded, err)
 		}
+		markFinalizeRevisionsAddressed(loaded)
 	} else if err := inputfiles.CleanupNonCommitted(prepared.CWD, loaded.Files); err != nil {
 		loaded.Status = "failed"
 		appendRisk(loaded, "input-file-cleanup", "partial_verification", err.Error(), "Remove non-committed task input files from the execution workspace before archiving or reusing it.", true)
@@ -407,7 +423,9 @@ func mergeDiscussionItems(loaded *task.Task, profiles profile.Bundle, verdict su
 		appendDiscussionItem(loaded, "Supervisor discussion", item, false)
 	}
 	for _, request := range loaded.RevisionRequests {
-		if request.Status == "addressed" {
+		// A pending finalization request is decided by the finalize step that
+		// runs right after this merge, not by a human PR reader.
+		if request.Status == "addressed" || request.Source == finalizeRevisionSource {
 			continue
 		}
 		appendDiscussionItem(
@@ -439,6 +457,13 @@ func mergeDiscussionItems(loaded *task.Task, profiles profile.Bundle, verdict su
 func appendDiscussionItem(loaded *task.Task, topic, summary string, requiresHumanDecision bool) {
 	if strings.TrimSpace(summary) == "" {
 		return
+	}
+	// A second acceptance (for example after a recovered finalization) must not
+	// duplicate the items the first acceptance already recorded.
+	for _, item := range loaded.DiscussionItems {
+		if item.Topic == topic && item.Summary == summary {
+			return
+		}
 	}
 	loaded.DiscussionItems = append(loaded.DiscussionItems, task.DiscussionItem{
 		ID:                    fmt.Sprintf("discussion-%d", len(loaded.DiscussionItems)+1),

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -183,9 +183,10 @@ func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, running
 		if err != nil || done {
 			return err
 		}
-		// A finalization failure re-enters the loop as a pending revision
-		// request on the task; carry it into the next work order.
+		// The task file is the source of truth for the next attempt: it carries
+		// a finalization failure's new request and drops accepted ones.
 		promptTask.RevisionRequests = loaded.RevisionRequests
+		revision = supervisorRevisionFromTask(*loaded)
 	}
 	*loaded = revision.applyToTask(*loaded)
 	loaded.Status = "failed"

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -62,7 +62,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 			}
 		}
 		if err := vcs.Commit(ctx, vcsBinaries(opts), workDir, runDir, commitMessage); err != nil {
-			return err
+			return &finalizeFailure{Err: err}
 		}
 	}
 	if !opts.OpenPR {
@@ -76,7 +76,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	if err := retry.Do(ctx, func(ctx context.Context) error {
 		return vcs.PushCurrentBranch(ctx, vcsBinaries(opts), workDir, runDir)
 	}); err != nil {
-		return err
+		return &finalizeFailure{Err: err}
 	}
 	if loaded.PR.URL != "" {
 		loaded.PR.Status = "open"
@@ -101,7 +101,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	if err != nil {
 		recovered, viewErr := vcs.FetchPRURLForCurrentBranch(ctx, vcsBinaries(opts), workDir, runDir)
 		if viewErr != nil || recovered == "" {
-			return err
+			return &finalizeFailure{Err: err}
 		}
 		prURL = recovered
 	}

--- a/internal/daemon/preflight_reuse.go
+++ b/internal/daemon/preflight_reuse.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +12,10 @@ import (
 
 	setuppreflight "github.com/shinpr/galley/internal/preflight/setup"
 	skeletonpreflight "github.com/shinpr/galley/internal/preflight/skeleton"
+	"github.com/shinpr/galley/internal/runartifact"
 	"github.com/shinpr/galley/internal/task"
+	"github.com/shinpr/galley/internal/vcs"
+	"github.com/shinpr/galley/internal/workspace"
 )
 
 func reuseReadySetup(root, taskID, runDir string, effective task.Executor) (*setuppreflight.Result, bool, error) {
@@ -100,4 +105,56 @@ func priorTaskRunDirs(root, taskID, currentRunDir string) ([]string, error) {
 
 func preflightReuseError(phase string, err error) error {
 	return fmt.Errorf("reuse completed %s evidence: %w", phase, err)
+}
+
+// retainPriorReviewBase keeps a prior run's review base while a finalization
+// failure is still pending, so its accepted commit stays inside the diff.
+func retainPriorReviewBase(ctx context.Context, opts Options, loaded task.Task, runDir string, prepared *workspace.Prepared) {
+	if prepared == nil || !prepared.WorktreeReused || prepared.BaseSHA == "" {
+		return
+	}
+	if !hasPendingFinalizeRevision(loaded) {
+		return
+	}
+	taskID := loaded.ID
+	prior, err := priorRunBaseSHA(opts.Root, taskID, runDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "galley: task %s could not read the prior review base: %v\n", taskID, err)
+		return
+	}
+	if prior == "" || prior == prepared.BaseSHA {
+		return
+	}
+	ancestor, err := vcs.IsAncestor(ctx, vcsBinaries(opts), prepared.CWD, prior, prepared.BaseSHA)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "galley: task %s could not verify the prior review base %s: %v\n", taskID, prior, err)
+		return
+	}
+	if !ancestor {
+		return
+	}
+	prepared.BaseSHA = prior
+}
+
+// priorRunBaseSHA returns the review base recorded by the most recent prior
+// run of this task, or "" when no prior run recorded one.
+func priorRunBaseSHA(root, taskID, currentRunDir string) (string, error) {
+	dirs, err := priorTaskRunDirs(root, taskID, currentRunDir)
+	if err != nil {
+		return "", err
+	}
+	for _, dir := range dirs {
+		data, err := os.ReadFile(runartifact.Path(dir, runartifact.WorkspaceFilename))
+		if err != nil {
+			continue
+		}
+		var prior workspace.Prepared
+		if err := json.Unmarshal(data, &prior); err != nil {
+			continue
+		}
+		if prior.BaseSHA != "" {
+			return prior.BaseSHA, nil
+		}
+	}
+	return "", nil
 }

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -200,6 +200,22 @@ func literalPathspecs(paths []string) []string {
 	return out
 }
 
+// IsAncestor reports whether ancestor is reachable from descendant in workDir.
+// Exit code 0 is yes, 1 is no, and any other exit code is an error.
+func IsAncestor(ctx context.Context, bins Binaries, workDir, ancestor, descendant string) (bool, error) {
+	result, err := proc.RunCommand(ctx, proc.Command{
+		WorkDir: workDir,
+		Argv:    proc.GitArgs(bins.git(), "merge-base", "--is-ancestor", ancestor, descendant),
+	}, proc.RunOptions{})
+	if err == nil {
+		return true, nil
+	}
+	if result.ExitCode == 1 {
+		return false, nil
+	}
+	return false, fmt.Errorf("git merge-base --is-ancestor %s %s failed: %w: %s", ancestor, descendant, err, strings.TrimSpace(result.Stderr))
+}
+
 // Commit creates a git commit and writes command evidence.
 func Commit(ctx context.Context, bins Binaries, workDir, runDir, message string) error {
 	_, err := runCommandWithEvidence(ctx, proc.Command{

--- a/internal/vcs/vcs_isancestor_test.go
+++ b/internal/vcs/vcs_isancestor_test.go
@@ -1,0 +1,41 @@
+package vcs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A reachable base is accepted, an unreachable one is rejected, and an
+// unknown revision is an error rather than a false negative.
+func TestIsAncestorSeparatesReachableUnreachableAndUnknown(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.email", "a@example.test")
+	runGit(t, repo, "config", "user.name", "A")
+	if err := os.WriteFile(filepath.Join(repo, "base.txt"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "base.txt")
+	runGit(t, repo, "commit", "-q", "-m", "base")
+	base := strings.TrimSpace(string(runGitOutput(t, repo, "rev-parse", "HEAD")))
+	if err := os.WriteFile(filepath.Join(repo, "next.txt"), []byte("next\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-q", "-m", "next")
+	head := strings.TrimSpace(string(runGitOutput(t, repo, "rev-parse", "HEAD")))
+
+	ancestor, err := IsAncestor(t.Context(), Binaries{}, repo, base, head)
+	if err != nil || !ancestor {
+		t.Fatalf("base->head got (%v, %v), want (true, nil)", ancestor, err)
+	}
+	ancestor, err = IsAncestor(t.Context(), Binaries{}, repo, head, base)
+	if err != nil || ancestor {
+		t.Fatalf("head->base got (%v, %v), want (false, nil)", ancestor, err)
+	}
+	if _, err := IsAncestor(t.Context(), Binaries{}, repo, strings.Repeat("0", 40), head); err == nil {
+		t.Fatal("unknown revision must return an error, not a false negative")
+	}
+}


### PR DESCRIPTION
## Goal

When finalization of a Supervisor-accepted task fails during commit, push, or PR creation, Galley automatically routes the failure through its existing revision-request executor/Supervisor loop so retained work can still reach PR creation without a user diagnosing or rewriting the failure.

## Acceptance Criteria

- `AC1` When the existing accepted-task finalize operation returns an error from git commit (including pre-commit hooks), git push (including pre-push hooks), or gh pr create, Galley persists one pending finalization revision request containing the failed operation, actionable bounded command output, and the run-artifact location; it preserves the worktree and previously verified review progress and uses the next available attempt in the existing executor-to-Supervisor loop instead of immediately moving the task to failed.
  - Verification: Add focused daemon integration coverage for commit, push, and PR-create failures that each fail once. Assert that the next executor work order contains the corresponding captured failure without a human-authored request, the same worktree and accepted review progress are retained, and execution continues to another Supervisor verdict.
  - Status: satisfied
- `AC2` After the finalization revision is addressed and accepted, Galley invokes the same universal finalize operation again. Already completed effects remain safe and useful: an existing accepted commit is not duplicated, re-pushing the same HEAD is harmless, existing gh-pr-create URL recovery remains effective, and successful recovery produces exactly one open PR with terminal task status pr_opened.
  - Verification: Exercise recovery after commit success/push failure and after push success/PR-create failure. Assert the task branch has no extra empty or duplicate commit, the final remote branch points at the accepted HEAD, only one PR URL is recorded, and the task reaches pr_opened through the ordinary finalize path.
  - Status: satisfied
- `AC3` If shutdown or attempt exhaustion prevents the automatic revision loop from completing, the pending finalization revision, accepted diff, original review base context, and failure artifacts remain recoverable; a plain galley task requeue resumes through the existing revision-request path in the retained worktree and can finalize a branch whose accepted commit already exists without falsely reporting that there is no git diff.
  - Verification: Add a two-run daemon test in which finalization fails after the accepted commit exists, the first run publishes a failed task, task requeue is performed without a new revision request, and the second run reuses the worktree and prior base context to reach pr_opened. Assert no implementation changes or accepted commits are lost.
  - Status: satisfied
- `AC4` Tasks whose finalization succeeds retain the current commit/push/PR behavior, and failures outside accepted-task finalization retain their current lifecycle. Recovery does not bypass Git hooks and introduces no new CLI command or flag, task status, task/profile/schema field, provider route, or stage-specific checkpoint/resume workflow.
  - Verification: Run retained daemon, task lifecycle, VCS, schema, and smoke coverage plus focused negative assertions that hooks are invoked and public CLI/schema/profile surfaces are unchanged.
  - Status: satisfied

## Final Verification

- `<galley:setup:claude>`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml; go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml; go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool on all nine schema/plugin/marketplace JSON files`: passed
- `env -u GALLEY_CLAUDE_GUARD_MODE go test ./internal/daemon/ -run TestFinalize`: passed
- `env -u GALLEY_CLAUDE_GUARD_MODE go test ./internal/daemon -run 'TestFinalize' -count=1 -timeout 900s`: passed
- `python3 -m json.tool on all nine required JSON artifacts`: passed
- `python3 /tmp/check_comments.py (maps git-diff changed lines onto contiguous // blocks in all changed .go files)`: passed
- `go test ./internal/daemon/ -run 'TestFinalizeFailurePreservesForeignRequestHoldingItsID|TestFinalizeRevisionIdentityIsStableBesideAForeignRequest' -count=1 -v`: passed
- `mutation check: temporarily removed the collision-avoidance loop in finalizeRevisionID and the Source condition in upsertFinalizeRevision, then reran the two new tests (fix restored afterwards, verified by re-reading the file and rebuilding)`: passed
- `go test ./internal/daemon/ -run 'TestFinalize' -count=1`: passed
- `env -u GALLEY_CLAUDE_GUARD_MODE go test ./...`: passed
- `test -z "$(find . -name '*.go' -not -path './.git/*' -print | xargs gofmt -l)"`: passed
- `go build -o /tmp/galley ./cmd/galley`: passed
- `GOOS=windows GOARCH=amd64 go build ./...`: passed
- `go run ./cmd/galley schema check`: passed
- `go run ./cmd/galley task validate examples/afk-task.yaml && go run ./cmd/galley profile validate --kind quality examples/quality-default.yaml && go run ./cmd/galley profile validate --kind environment examples/environment-local.yaml`: passed
- `python3 -m json.tool over all nine profile-listed JSON artifacts`: passed
- `./scripts/smoke-local.sh`: passed

## Key Decisions

- `D1` Does recovery split accepted-task finalization into public commit/publish stages? -> No. Finalization remains one universal operation; its failure becomes input to the existing revision-request loop.
  - Rationale: Users need continued AFK progress, not a new stage model, resume command, or decision about which VCS operation failed.
  - Reversibility: The internal finalize implementation can still be refactored later without changing this recovery contract.
- `D2` Which execution path handles a finalization failure? -> The existing executor-to-Supervisor revision-request path handles commit, push, and PR-create failures uniformly.
  - Rationale: This path already preserves prior passes, supplies actionable findings to the executor, reviews any resulting change, and retries finalization without a one-off executor-only route.
  - Reversibility: A future measured performance issue could optimize the internal loop while preserving the same user-visible behavior.
- `D3` Should Galley classify push failures as hook, transport, authentication, or remote-state failures before choosing recovery? -> No. Capture the concrete command failure and let the existing revision loop act on it.
  - Rationale: Reliable classification adds complexity without reducing user action; pre-push hooks make push failures potentially repairable by the executor.
  - Reversibility: A later evidence-backed classifier can be added without changing task or CLI contracts.
- `D4` How should retries behave after some finalize side effects have already succeeded? -> Run the same finalize operation again and rely on its existing clean-worktree skip, idempotent push, and PR URL recovery behavior, while retaining the original review base across requeue.
  - Rationale: This achieves effective resume behavior without persisted per-stage checkpoints or a second finalization workflow.
  - Reversibility: Internal evidence storage can change later as long as requeue continuity remains observable.
- `executor-decision-5` How should the finalization failure be represented without adding a new task/schema field or status? -> Persist an ordinary revision request with a new free-form `source: finalize` value and ID `finalize-attempt-<n>`.
  - Rationale: revision_requests[].source is an unconstrained string in the generated schema, so no schema, profile, or status change is needed, and non-supervisor-source requests already survive the loop's revision reset and a plain requeue.
  - Reversibility: high
- `executor-decision-6` Which finalization errors re-enter the revision loop? -> Only errors from git commit, git push, and gh pr create (after the existing PR URL recovery probe fails).
  - Rationale: AC1 enumerates those three commands, and the retained forbidden-path test requires Galley safety-gate failures to keep failing the run immediately.
  - Reversibility: high
- `executor-decision-7` Where does the retained review base come from across requeue, and when is it applied? -> The most recent prior run's workspace.json base_sha, applied only when the worktree is reused, a finalization request is still pending, and the prior base is an ancestor of the current HEAD.
  - Rationale: Uses existing run evidence instead of a new persisted checkpoint, and the pending-request gate keeps every other requeue (including PR-comment revisions) on today's base resolution.
  - Reversibility: high
- `executor-decision-8` Who closes the finalization revision request? -> Galley marks it addressed after the same finalize operation actually succeeds, with Galley-owned evidence text.
  - Rationale: The request asks for finalization to succeed, so the successful rerun is the authoritative evidence; relying on a supervisor acceptance pass would leave a stale pending request in the PR body.
  - Reversibility: high
- `executor-decision-9` Should a repeated finalization failure upsert the existing finalize-attempt-N request or record a new uniquely-identified request? -> Upsert by ID: replace the same-ID request with the freshly rendered pending request.
  - Rationale: The finding allows either. Upsert keeps exactly one pending finalization request per task, always describing the latest failure, and avoids unbounded revision-request growth across requeues while attempt history remains in task.attempts. It is also the smallest change to the existing helper.
  - Reversibility: high
- `executor-decision-10` How should the new test reproduce the supervisor marking the finalize request addressed before finalization reruns? -> A test-local fake claude whose supervisor branch adds revision:finalize-attempt-1 to acceptance_passes when the request appears in the review input.
  - Rationale: The shared writeFakeClaude supervisor never projects finalize revision passes, so it cannot reach the addressed state that the finding describes; a narrow local variant reproduces the exact production path through projectRevisionPasses.
  - Reversibility: high
- `executor-decision-11` How should Galley pick a collision-free identity for a finalization failure when a non-finalization request already holds `finalize-attempt-N`? -> Deterministically derive the ID: use `finalize-attempt-N`, and while a request from another source holds that ID, try `finalize-attempt-N-2`, `-3`, and so on.
  - Rationale: Because non-finalization requests are now never removed or replaced, the derivation is a pure function of a stable input set, so the same ID is re-derived on every requeue. That lets the existing source-scoped upsert reopen Galley's own request after repeated requeues without accumulating one request per run, and it needs no new persisted field, counter, or schema change. A random or timestamped suffix would have been collision-free but not stable across requeues, breaking the reopen behavior the finding requires.
  - Reversibility: high
- `executor-decision-12` Does the identity fix need its own CHANGELOG entry? -> No; it folds into the existing Unreleased "Fixed" entry for finalization recovery.
  - Rationale: The whole finalization-recovery feature is unreleased, so this is an internal correctness detail of behavior the existing entry already describes. The release-and-documentation dimension asks for one short entry per user-visible change, not one per revision iteration.
  - Reversibility: high
- `executor-decision-13` Where should the identity-stability guarantee be tested, given the implementation-economy dimension's no-redundant-tests rule? -> Daemon-level lifecycle test for the collision plus one focused unit test for repeated-failure identity stability.
  - Rationale: The daemon test is the coverage finding 1 explicitly asks for (work order, provenance, recovery), but it exercises a single failure and cannot show that a third and fourth requeue stop accumulating requests. The unit test covers that distinct regression at the function boundary that owns it, and the two do not overlap in the regression they detect — both were confirmed to fail against the pre-fix logic.
  - Reversibility: high

## Discussion Items

- `discussion-1` Supervisor summary: All active acceptance and quality items pass. Finalization revision identities now preserve same-ID non-finalization requests, repeated failures refresh Galley’s own pending request, and successful recovery addresses only Galley finalization requests. Focused recovery coverage and the full required test suite pass.
- `discussion-2` Supervisor discussion: Accepted scope expansion: docs/supervision.md and docs/troubleshooting.md are outside task.scope.allowed_paths but are minimal, necessary, non-forbidden updates that align existing lifecycle documentation with AC1 and AC3.
- `discussion-3` Scope expansion: Accepted diff includes changes outside task.scope.allowed_paths: docs/supervision.md, docs/troubleshooting.md. Review whether this scope expansion belongs in this PR.
  - Human decision required: true

## Risks

- `R1` external_dependency: A persistent GitHub authentication, network, or remote-rejection failure cannot necessarily be repaired by the executor and may consume the remaining attempt budget.
  - Mitigation: Keep the existing loop budget and exact command evidence visible; on exhaustion preserve the pending revision and retained worktree so the user only resolves the external condition and issues a plain requeue. Do not add failure classifiers or unbounded retries.
- `R2` false-green: A same-run test can pass while requeue after an already-created commit loses the original base SHA and finalize reports no diff.
  - Mitigation: AC3 requires a two-run integration test that fails after commit, requeues, and completes PR creation from the retained branch without adding another implementation commit.
