### PR TITLE
Add golangci-lint and resolve every finding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,14 @@ jobs:
         run: ./scripts/smoke-local.sh
 
   lint:
-    name: Lint
+    name: Lint (${{ matrix.goos }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [darwin, linux, windows]
 
     steps:
       - name: Checkout
@@ -128,9 +133,13 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
+      # Build-tagged files are only analyzed for the target OS, so each
+      # supported platform gets its own lint pass.
       - name: Run golangci-lint
         # golangci/golangci-lint-action@v9.3.0
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
+        env:
+          GOOS: ${{ matrix.goos }}
         with:
           # Keep in sync with the version developers install locally.
           version: v2.13.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,61 @@ jobs:
         if: runner.os != 'Windows'
         run: ./scripts/smoke-local.sh
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        # actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Set up Go
+        # actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Run golangci-lint
+        # golangci/golangci-lint-action@v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
+        with:
+          # Keep in sync with the version developers install locally.
+          version: v2.13.2
+          args: --timeout=10m ./cmd/... ./internal/...
+
+  race:
+    name: Test (race)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        # actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Set up Go
+        # actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      # The race detector needs cgo and a C toolchain, so it runs on one OS
+      # rather than replacing the cross-OS matrix above.
+      - name: Test packages with the race detector
+        run: go test -race ./...
+
   test:
     name: Test
-    needs: test-matrix
+    needs: [test-matrix, lint, race]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Verify OS test matrix succeeded
-        if: needs.test-matrix.result != 'success'
+      - name: Verify OS test matrix, lint, and race succeeded
+        if: needs.test-matrix.result != 'success' || needs.lint.result != 'success' || needs.race.result != 'success'
         run: exit 1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,97 @@
+version: "2"
+
+run:
+  timeout: 10m
+
+linters:
+  default: standard          # errcheck, govet, ineffassign, staticcheck, unused
+  enable:
+    - forcetypeassert
+    - exhaustive
+    - errorlint
+    - wrapcheck
+    - nolintlint
+    - nilerr
+    - gocognit
+    - nestif
+    - contextcheck
+    - noctx
+    - gosec
+    - revive
+  settings:
+    errcheck:
+      # A strings.Builder write cannot fail, and reporting an os.Stderr write
+      # failure would use the same stream. Every other writer stays checked.
+      exclude-functions:
+        - fmt.Fprintf(*strings.Builder)
+        - fmt.Fprintln(*strings.Builder)
+        - fmt.Fprint(*strings.Builder)
+        - fmt.Fprintf(os.Stderr)
+        - fmt.Fprintln(os.Stderr)
+        - fmt.Fprint(os.Stderr)
+    govet:
+      # shadow is not enabled: in `if err := f(); err != nil` the inner binding
+      # dies at the closing brace, so no read is ambiguous and renaming adds none.
+      enable:
+        - nilness
+        - lostcancel
+    gocognit:
+      min-complexity: 25
+    nestif:
+      # nestif sums nesting and else branches rather than measuring depth: a
+      # 3-deep serial nest and three ifs under one guard both score 3.
+      min-complexity: 3
+    exhaustive:
+      default-signifies-exhaustive: false
+    gosec:
+      # SECURITY.md defines task/profile input as trusted, and neither rule
+      # separates a permitted operation from an escape; boundary checks do that.
+      excludes:
+        - G304
+        - G204
+    wrapcheck:
+      ignore-package-globs:
+        - github.com/shinpr/galley/internal/*
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    revive:
+      rules:
+        - name: argument-limit
+          arguments: [4]
+        - name: unused-parameter
+        - name: early-return
+  exclusions:
+    rules:
+      # A cobra command cannot report a write failure on its own output stream.
+      # Only the accessor itself is excluded, and only in the command packages.
+      - linters:
+          - errcheck
+        path: ^internal/(cli|daemoncmd)/
+        source: 'fmt\.Fprint(f|ln)?\(cmd\.(OutOrStdout|ErrOrStderr)\(\)'
+      # Unchecked assertions on values the test itself constructed carry no
+      # information; assertions on code under test use comma-ok + t.Fatalf.
+      - path: _test\.go
+        linters:
+          - forcetypeassert
+      # Test scaffolding writes under paths it built from t.TempDir(), so only
+      # the permission and taint rules are excluded; credential rules still apply.
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "G301|G306|G703"
+      # profile.Constraints holds only policy enums; its secrets_policy name
+      # matches G101's credential pattern while the values are policy names.
+      - linters:
+          - gosec
+        text: "G101"
+        source: "Constraints\\{"
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows semantic versioning.
 
 ## Unreleased
 
+## v0.12.9 - 2026-09-06
+
+### Changed
+
+- Galley now creates its own queue and task-state directories under the workflow root with `0700` instead of `0755`. Directories that already exist keep their current permissions, so tighten them manually to apply this to an existing installation.
+
 ## v0.12.8 - 2026-09-05
 
 ### Fixed

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -12,7 +12,10 @@ func renderOutput(cmd *cobra.Command, output string, payload any, renderText fun
 	case "json":
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(payload)
+		if err := enc.Encode(payload); err != nil {
+			return fmt.Errorf("encode %s output: %w", output, err)
+		}
+		return nil
 	case "text":
 		return renderText()
 	default:

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -31,18 +31,18 @@ func newProfileResolveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "resolve",
 		Short: "Resolve conventional profile paths for a repository",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			repoCWD := cwd
 			if repoCWD == "" {
 				current, err := os.Getwd()
 				if err != nil {
-					return err
+					return fmt.Errorf("resolve working directory: %w", err)
 				}
 				repoCWD = current
 			}
 			repoCWD, err := filepath.Abs(repoCWD)
 			if err != nil {
-				return err
+				return fmt.Errorf("resolve repository path %s: %w", repoCWD, err)
 			}
 			key, qualityPath, environmentPath, err := galleyhome.RepoProfilePaths(root, repoCWD)
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/shinpr/galley/internal/daemoncmd"
 	"github.com/shinpr/galley/internal/updatecheck"
 	"github.com/shinpr/galley/internal/version"
@@ -8,9 +10,12 @@ import (
 )
 
 func Execute() error {
-	updatecheck.Run(updatecheck.Options{})
+	// Execute is the process entry point, so it owns the root context.
+	ctx := context.Background()
+	updatecheck.Run(ctx, updatecheck.Options{})
 	root := NewRootCommand()
 	if err := root.Execute(); err != nil {
+		//nolint:wrapcheck // the command's own error is the user-facing message
 		return err
 	}
 	return nil
@@ -42,7 +47,7 @@ func newVersionCommand() *cobra.Command {
 		Short:         "Print Galley version information",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.Println(version.String())
 			return nil
 		},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -143,7 +143,7 @@ func TestSchemaGenerateAndCheck(t *testing.T) {
 
 func TestTaskRequeueText(t *testing.T) {
 	root := t.TempDir()
-	failedPath := setupTaskInState(t, root, "failed", "needs_supervisor_review", nil)
+	failedPath := setupTaskInState(t, taskInState{Root: root, State: "failed", Status: "needs_supervisor_review"}, nil)
 	stdout, stderr, err := executeCommand(
 		"task", "requeue",
 		"--root", root,
@@ -179,7 +179,7 @@ func TestTaskRequeueText(t *testing.T) {
 
 func TestTaskRequeueRejectsEmptyRevisionRequest(t *testing.T) {
 	root := t.TempDir()
-	failedPath := setupTaskInState(t, root, "failed", "needs_supervisor_review", nil)
+	failedPath := setupTaskInState(t, taskInState{Root: root, State: "failed", Status: "needs_supervisor_review"}, nil)
 	_, _, err := executeCommand("task", "requeue", "--root", root, "--revision-request", "   ", failedPath)
 	if err == nil || !strings.Contains(err.Error(), "revision-request must not be empty") {
 		t.Fatalf("error got %v", err)
@@ -191,7 +191,7 @@ func TestTaskRequeueRejectsEmptyRevisionRequest(t *testing.T) {
 
 func TestTaskQueueText(t *testing.T) {
 	root := t.TempDir()
-	draftPath := setupTaskInState(t, root, "draft", "draft", nil)
+	draftPath := setupTaskInState(t, taskInState{Root: root, State: "draft", Status: "draft"}, nil)
 	stdout, stderr, err := executeCommand("task", "queue", "--root", root, "--reason", "draft approved for daemon", draftPath)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func TestTaskQueueText(t *testing.T) {
 
 func TestTaskListText(t *testing.T) {
 	root := t.TempDir()
-	setupTaskInState(t, root, "failed", "needs_supervisor_review", func(loaded *taskpkg.Task) {
+	setupTaskInState(t, taskInState{Root: root, State: "failed", Status: "needs_supervisor_review"}, func(loaded *taskpkg.Task) {
 		loaded.Attempts = []taskpkg.Attempt{{
 			Number:            1,
 			ClaudeStatus:      "completed",
@@ -235,7 +235,7 @@ func TestTaskListText(t *testing.T) {
 
 func TestTaskShowByIDText(t *testing.T) {
 	root := t.TempDir()
-	setupTaskInState(t, root, "failed", "failed", func(loaded *taskpkg.Task) {
+	setupTaskInState(t, taskInState{Root: root, State: "failed", Status: "failed"}, func(loaded *taskpkg.Task) {
 		loaded.Attempts = []taskpkg.Attempt{{
 			Number:            2,
 			ClaudeStatus:      "hard_stop",
@@ -276,7 +276,7 @@ func TestTaskShowByIDText(t *testing.T) {
 
 func TestTaskShowByIDWithDots(t *testing.T) {
 	root := t.TempDir()
-	setupTaskInState(t, root, "done", "accepted", func(loaded *taskpkg.Task) {
+	setupTaskInState(t, taskInState{Root: root, State: "done", Status: "accepted"}, func(loaded *taskpkg.Task) {
 		loaded.ID = "task.release.1"
 	})
 
@@ -294,7 +294,7 @@ func TestTaskShowByIDWithDots(t *testing.T) {
 
 func TestTaskShowAcceptedTerminalSuppressesPriorFailure(t *testing.T) {
 	root := t.TempDir()
-	setupTaskInState(t, root, "done", "pr_opened", func(loaded *taskpkg.Task) {
+	setupTaskInState(t, taskInState{Root: root, State: "done", Status: "pr_opened"}, func(loaded *taskpkg.Task) {
 		loaded.PR.URL = "https://example.test/pr/1"
 		loaded.PR.Status = "open"
 		loaded.Attempts = []taskpkg.Attempt{{
@@ -361,13 +361,12 @@ func TestTaskShowAcceptedTerminalSuppressesPriorFailure(t *testing.T) {
 // or merged: prior failed attempts must remain under the prior_attempt_* prefix
 // instead of regressing to the active "failed" framing.
 func TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses(t *testing.T) {
-	for _, terminalStatus := range []string{"closed", "merged"} {
-		terminalStatus := terminalStatus
-		t.Run(terminalStatus, func(t *testing.T) {
+	for _, terminalStatus := range []taskpkg.Status{"closed", "merged"} {
+		t.Run(string(terminalStatus), func(t *testing.T) {
 			root := t.TempDir()
-			setupTaskInState(t, root, "done", terminalStatus, func(loaded *taskpkg.Task) {
+			setupTaskInState(t, taskInState{Root: root, State: "done", Status: terminalStatus}, func(loaded *taskpkg.Task) {
 				loaded.PR.URL = "https://example.test/pr/2"
-				loaded.PR.Status = terminalStatus
+				loaded.PR.Status = string(terminalStatus)
 				loaded.Attempts = []taskpkg.Attempt{{
 					Number:            2,
 					ClaudeStatus:      "failed",
@@ -397,7 +396,7 @@ func TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses(t *testing.T) {
 				}
 			}
 			for _, want := range []string{
-				"status: " + terminalStatus,
+				"status: " + string(terminalStatus),
 				"prior_attempt_claude_status: failed",
 				"prior_attempt_error_phase: executor",
 			} {
@@ -411,7 +410,7 @@ func TestTaskShowAcceptedTerminalCoversPRLifecycleStatuses(t *testing.T) {
 
 func TestTaskArchiveText(t *testing.T) {
 	root := t.TempDir()
-	donePath := setupTaskInState(t, root, "done", "accepted", nil)
+	donePath := setupTaskInState(t, taskInState{Root: root, State: "done", Status: "accepted"}, nil)
 
 	stdout, stderr, err := executeCommand("task", "archive", "--reason", "done", donePath)
 	if err != nil {
@@ -443,7 +442,7 @@ func TestTaskArchiveRemovesManagedWorktree(t *testing.T) {
 	if !prepared.WorktreeCreated {
 		t.Fatalf("expected worktree to be created: %+v", prepared)
 	}
-	donePath := setupTaskInState(t, root, "done", "accepted", func(loaded *taskpkg.Task) {
+	donePath := setupTaskInState(t, taskInState{Root: root, State: "done", Status: "accepted"}, func(loaded *taskpkg.Task) {
 		loaded.Scope.CWD = repo
 		loaded.Worktree.Enabled = true
 		loaded.Worktree.Branch = "agent/task-cli-test"
@@ -482,7 +481,14 @@ func TestTaskArchiveRemovesManagedWorktree(t *testing.T) {
 	}
 }
 
-func setupTaskInState(t *testing.T, root, state, status string, modify func(*taskpkg.Task)) string {
+type taskInState struct {
+	Root   string
+	State  string
+	Status taskpkg.Status
+}
+
+func setupTaskInState(t *testing.T, spec taskInState, modify func(*taskpkg.Task)) string {
+	root, state, status := spec.Root, spec.State, spec.Status
 	t.Helper()
 	path := filepath.Join(root, "tasks", state, "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -793,7 +799,7 @@ func initCLIGitRepo(t *testing.T) string {
 
 func runCLIGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/cli/schema.go
+++ b/internal/cli/schema.go
@@ -29,7 +29,7 @@ func newSchemaGenerateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate plugin schema references",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			targets, err := schemaTargets(output)
 			if err != nil {
 				return err
@@ -39,9 +39,11 @@ func newSchemaGenerateCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				//nolint:gosec // G301: generated schemas are committed repository artifacts
 				if err := os.MkdirAll(filepath.Dir(target.Path), 0o755); err != nil {
 					return fmt.Errorf("create schema directory: %w", err)
 				}
+				//nolint:gosec // G306: generated schemas are committed repository artifacts
 				if err := os.WriteFile(target.Path, data, 0o644); err != nil {
 					return fmt.Errorf("write schema: %w", err)
 				}
@@ -59,7 +61,7 @@ func newSchemaCheckCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check that plugin schema references match the Go contracts",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			targets, err := schemaTargets(path)
 			if err != nil {
 				return err
@@ -131,7 +133,7 @@ func schemaTargets(dir string) ([]schemaTarget, error) {
 func findGalleyRepoRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve working directory: %w", err)
 	}
 	for {
 		goMod := filepath.Join(dir, "go.mod")

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -95,13 +96,13 @@ func newTaskArchiveCommand() *cobra.Command {
 }
 
 type taskListItem struct {
-	ID            string `json:"id"`
-	Status        string `json:"status"`
-	State         string `json:"state"`
-	File          string `json:"file"`
-	PRURL         string `json:"pr_url,omitempty"`
-	LatestVerdict string `json:"latest_verdict,omitempty"`
-	LatestSummary string `json:"latest_summary,omitempty"`
+	ID            string      `json:"id"`
+	Status        task.Status `json:"status"`
+	State         string      `json:"state"`
+	File          string      `json:"file"`
+	PRURL         string      `json:"pr_url,omitempty"`
+	LatestVerdict string      `json:"latest_verdict,omitempty"`
+	LatestSummary string      `json:"latest_summary,omitempty"`
 	// DecodeError is set on entries whose known fields could not be decoded.
 	// Unknown fields are ignored by task.Load; malformed known fields or
 	// invalid top-level YAML still surface as non-fatal entries in scans.
@@ -116,7 +117,7 @@ func newTaskListCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List tasks under a Galley workflow root",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			resolvedRoot, err := resolveTaskRoot(root, cmd.Flags().Changed("root"))
 			if err != nil {
 				return err
@@ -198,63 +199,13 @@ func newTaskShowCommand() *cobra.Command {
 				if loaded.PR.URL != "" {
 					fmt.Fprintf(cmd.OutOrStdout(), "pr: %s (%s)\n", loaded.PR.URL, loaded.PR.Status)
 				}
-				if len(loaded.Attempts) > 0 {
-					last := loaded.Attempts[len(loaded.Attempts)-1]
-					// Once the supervisor has accepted the task, the last attempt's
-					// raw claude status and error fields are auditable history rather
-					// than the active runtime state. Relabel them under a
-					// prior_attempt_* prefix so accepted/pr_opened tasks no longer
-					// surface "failed" framing as if it were the current state.
-					prefix := "latest"
-					if isAcceptedTerminalStatus(loaded.Status) {
-						prefix = "prior_attempt"
-					}
-					fmt.Fprintf(cmd.OutOrStdout(), "%s_attempt: %d\n", prefix, last.Number)
-					fmt.Fprintf(cmd.OutOrStdout(), "%s_claude_status: %s\n", prefix, last.ClaudeStatus)
-					fmt.Fprintf(cmd.OutOrStdout(), "%s_supervisor_verdict: %s\n", prefix, last.SupervisorVerdict)
-					fmt.Fprintf(cmd.OutOrStdout(), "%s_summary: %s\n", prefix, last.Summary)
-					if last.Error != nil {
-						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_phase: %s\n", prefix, last.Error.Phase)
-						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_kind: %s\n", prefix, last.Error.Kind)
-						fmt.Fprintf(cmd.OutOrStdout(), "%s_error_message: %s\n", prefix, last.Error.Message)
-						if last.Error.ArtifactDir != "" {
-							fmt.Fprintf(cmd.OutOrStdout(), "%s_error_artifact_dir: %s\n", prefix, last.Error.ArtifactDir)
-						}
-						// An executor interruption stops before Supervisor and
-						// keeps the worktree, so surface the resume path instead
-						// of implying a review verdict is pending.
-						if isExecutorInterruption(last) {
-							fmt.Fprintf(cmd.OutOrStdout(), "%s_executor_interruption: true\n", prefix)
-							fmt.Fprintf(cmd.OutOrStdout(), "%s_recovery: resolve the interruption cause, then run: galley task requeue %s\n", prefix, loaded.ID)
-						}
-					}
-				}
+				printLatestAttempt(cmd.OutOrStdout(), loaded)
 				if len(loaded.Risks) > 0 {
 					last := loaded.Risks[len(loaded.Risks)-1]
 					fmt.Fprintf(cmd.OutOrStdout(), "latest_risk: %s %s: %s\n", last.ID, last.Type, last.Detail)
 				}
-				for _, command := range loaded.Verification.Commands {
-					if command.Status == "failed" {
-						fmt.Fprintf(cmd.OutOrStdout(), "failed_verification: %s\n", command.Cmd)
-						if command.OutputExcerpt != "" {
-							fmt.Fprintf(cmd.OutOrStdout(), "failed_output: %s\n", command.OutputExcerpt)
-						}
-					}
-				}
-				if preflight != nil {
-					fmt.Fprintf(cmd.OutOrStdout(), "preflight_enabled: %t\n", preflight.Enabled)
-					fmt.Fprintf(cmd.OutOrStdout(), "preflight_required: %t\n", preflight.Required)
-					fmt.Fprintf(cmd.OutOrStdout(), "preflight_declared_outputs: %d\n", preflight.DeclaredOutputs)
-					if preflight.RuntimeStatus != "" {
-						fmt.Fprintf(cmd.OutOrStdout(), "preflight_runtime_status: %s\n", preflight.RuntimeStatus)
-					}
-					for _, o := range preflight.RuntimeOutputs {
-						fmt.Fprintf(cmd.OutOrStdout(), "preflight_output: ac=%s path=%s kind=%s implementation_required=%t\n", o.ACID, o.Path, o.Kind, o.ImplementationRequired)
-					}
-					if preflight.FailureSummary != "" {
-						fmt.Fprintf(cmd.OutOrStdout(), "preflight_failure: %s\n", preflight.FailureSummary)
-					}
-				}
+				printFailedVerifications(cmd.OutOrStdout(), loaded)
+				printPreflightSummary(cmd.OutOrStdout(), preflight)
 				return nil
 			})
 		},
@@ -356,7 +307,7 @@ func resolveTaskRoot(root string, explicit bool) (string, error) {
 	paths := daemonctl.ResolvePaths(defaultRoot, "", "")
 	exe, err := os.Executable()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve galley executable: %w", err)
 	}
 	status, err := daemonctl.Inspect(paths.PIDFile, "", exe)
 	if errors.Is(err, daemonctl.ErrNotRunning) {
@@ -390,7 +341,7 @@ func taskFiles(dir string) ([]string, error) {
 // PR is closed or merged. Without those tail states a previously accepted
 // task would regress to "active failure" framing once cleanup ran, even
 // though the supervisor already approved the work.
-func isAcceptedTerminalStatus(status string) bool {
+func isAcceptedTerminalStatus(status task.Status) bool {
 	return task.IsAcceptedTerminal(status)
 }
 
@@ -590,19 +541,24 @@ func applyRuntimePreflight(view *preflightSummaryView, root, taskID string) {
 	if runDir == "" {
 		return
 	}
-	if pf, err := runartifact.Read[skeletonpreflight.Result](runDir, runartifact.PreflightResultFilename); err == nil && pf != nil {
-		view.RuntimeStatus = pf.Status
-		for _, o := range pf.Outputs {
-			view.RuntimeOutputs = append(view.RuntimeOutputs, preflightOutputView{ACID: o.ACID, Path: o.Path, Kind: o.Kind, ImplementationRequired: o.ImplementationRequired})
-		}
-		if pf.Error != nil {
-			if pf.Error.Phase != "" {
-				view.FailureSummary = pf.Error.Phase + ": " + pf.Error.Message
-			} else {
-				view.FailureSummary = pf.Error.Message
-			}
-		}
+	pf, err := runartifact.Read[skeletonpreflight.Result](runDir, runartifact.PreflightResultFilename)
+	if err != nil || pf == nil {
+		return
 	}
+	view.RuntimeStatus = pf.Status
+	for _, o := range pf.Outputs {
+		view.RuntimeOutputs = append(view.RuntimeOutputs, preflightOutputView{ACID: o.ACID, Path: o.Path, Kind: o.Kind, ImplementationRequired: o.ImplementationRequired})
+	}
+	if pf.Error != nil {
+		view.FailureSummary = preflightFailureSummary(*pf.Error)
+	}
+}
+
+func preflightFailureSummary(e skeletonpreflight.PreflightError) string {
+	if e.Phase != "" {
+		return e.Phase + ": " + e.Message
+	}
+	return e.Message
 }
 
 func newTaskWorkOrderCommand() *cobra.Command {
@@ -624,4 +580,70 @@ func newTaskWorkOrderCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+// printLatestAttempt renders the last attempt. After acceptance those fields
+// are history, so a prior_attempt_* prefix replaces the active "failed" framing.
+//
+//nolint:errcheck // every caller passes cmd.OutOrStdout(); that stream cannot report its own write failure
+func printLatestAttempt(stdout io.Writer, loaded task.Task) {
+	if len(loaded.Attempts) == 0 {
+		return
+	}
+	last := loaded.Attempts[len(loaded.Attempts)-1]
+	prefix := "latest"
+	if isAcceptedTerminalStatus(loaded.Status) {
+		prefix = "prior_attempt"
+	}
+	fmt.Fprintf(stdout, "%s_attempt: %d\n", prefix, last.Number)
+	fmt.Fprintf(stdout, "%s_claude_status: %s\n", prefix, last.ClaudeStatus)
+	fmt.Fprintf(stdout, "%s_supervisor_verdict: %s\n", prefix, last.SupervisorVerdict)
+	fmt.Fprintf(stdout, "%s_summary: %s\n", prefix, last.Summary)
+	if last.Error == nil {
+		return
+	}
+	fmt.Fprintf(stdout, "%s_error_phase: %s\n", prefix, last.Error.Phase)
+	fmt.Fprintf(stdout, "%s_error_kind: %s\n", prefix, last.Error.Kind)
+	fmt.Fprintf(stdout, "%s_error_message: %s\n", prefix, last.Error.Message)
+	if last.Error.ArtifactDir != "" {
+		fmt.Fprintf(stdout, "%s_error_artifact_dir: %s\n", prefix, last.Error.ArtifactDir)
+	}
+	// An executor interruption stops before Supervisor and keeps the worktree,
+	// so surface the resume path instead of implying a review verdict is pending.
+	if isExecutorInterruption(last) {
+		fmt.Fprintf(stdout, "%s_executor_interruption: true\n", prefix)
+		fmt.Fprintf(stdout, "%s_recovery: resolve the interruption cause, then run: galley task requeue %s\n", prefix, loaded.ID)
+	}
+}
+
+//nolint:errcheck // every caller passes cmd.OutOrStdout(); that stream cannot report its own write failure
+func printFailedVerifications(stdout io.Writer, loaded task.Task) {
+	for _, command := range loaded.Verification.Commands {
+		if command.Status != "failed" {
+			continue
+		}
+		fmt.Fprintf(stdout, "failed_verification: %s\n", command.Cmd)
+		if command.OutputExcerpt != "" {
+			fmt.Fprintf(stdout, "failed_output: %s\n", command.OutputExcerpt)
+		}
+	}
+}
+
+//nolint:errcheck // every caller passes cmd.OutOrStdout(); that stream cannot report its own write failure
+func printPreflightSummary(stdout io.Writer, preflight *preflightSummaryView) {
+	if preflight == nil {
+		return
+	}
+	fmt.Fprintf(stdout, "preflight_enabled: %t\n", preflight.Enabled)
+	fmt.Fprintf(stdout, "preflight_required: %t\n", preflight.Required)
+	fmt.Fprintf(stdout, "preflight_declared_outputs: %d\n", preflight.DeclaredOutputs)
+	if preflight.RuntimeStatus != "" {
+		fmt.Fprintf(stdout, "preflight_runtime_status: %s\n", preflight.RuntimeStatus)
+	}
+	for _, o := range preflight.RuntimeOutputs {
+		fmt.Fprintf(stdout, "preflight_output: ac=%s path=%s kind=%s implementation_required=%t\n", o.ACID, o.Path, o.Kind, o.ImplementationRequired)
+	}
+	if preflight.FailureSummary != "" {
+		fmt.Fprintf(stdout, "preflight_failure: %s\n", preflight.FailureSummary)
+	}
 }

--- a/internal/cli/task_omitted_status_test.go
+++ b/internal/cli/task_omitted_status_test.go
@@ -100,17 +100,7 @@ func TestTaskQueuePersistsQueuedStatusFromOmittedStatusDraft(t *testing.T) {
 	}
 
 	// Queue may rename by source basename; also accept the standard task.yaml path.
-	queuedPath := filepath.Join(root, "tasks", "queued", filepath.Base(src))
-	if _, err := os.Stat(queuedPath); err != nil {
-		entries, readErr := os.ReadDir(filepath.Join(root, "tasks", "queued"))
-		if readErr != nil {
-			t.Fatalf("queued dir: %v (stat %s: %v)", readErr, queuedPath, err)
-		}
-		if len(entries) != 1 {
-			t.Fatalf("expected one queued file, got %#v (stat %s: %v)", entries, queuedPath, err)
-		}
-		queuedPath = filepath.Join(root, "tasks", "queued", entries[0].Name())
-	}
+	queuedPath := resolveQueuedTaskPath(t, root, src)
 
 	loaded, err := taskpkg.Load(queuedPath)
 	if err != nil {
@@ -126,4 +116,24 @@ func TestTaskQueuePersistsQueuedStatusFromOmittedStatusDraft(t *testing.T) {
 	if !strings.Contains(string(raw), "status: queued") && !strings.Contains(string(raw), `status: "queued"`) {
 		t.Fatalf("queued YAML must persist status queued:\n%s", raw)
 	}
+}
+
+// resolveQueuedTaskPath finds the queued file. Queue may rename by source
+// basename, so the standard task.yaml path is accepted as well.
+func resolveQueuedTaskPath(t *testing.T, root, src string) string {
+	t.Helper()
+	queuedDir := filepath.Join(root, "tasks", "queued")
+	byBasename := filepath.Join(queuedDir, filepath.Base(src))
+	statErr := error(nil)
+	if _, statErr = os.Stat(byBasename); statErr == nil {
+		return byBasename
+	}
+	entries, readErr := os.ReadDir(queuedDir)
+	if readErr != nil {
+		t.Fatalf("queued dir: %v (stat %s: %v)", readErr, byBasename, statErr)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one queued file, got %#v (stat %s: %v)", entries, byBasename, statErr)
+	}
+	return filepath.Join(queuedDir, entries[0].Name())
 }

--- a/internal/cli/task_show_interruption_test.go
+++ b/internal/cli/task_show_interruption_test.go
@@ -56,48 +56,69 @@ func TestTaskShowExecutorInterruptionRendering(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			taskPath := writeCLITaskYAML(t)
-			loaded, err := taskpkg.Load(taskPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			loaded.Status = "failed"
-			loaded.Attempts = []taskpkg.Attempt{tc.attempt}
-			dst := filepath.Join(root, "tasks", "failed", "task.yaml")
-			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := taskpkg.Save(dst, loaded); err != nil {
-				t.Fatal(err)
-			}
-
+			writeFailedTaskWithAttempt(t, root, tc.attempt)
 			stdout, _, err := executeCommand("task", "show", "--root", root, "task-cli-test", "-o", "text")
 			if err != nil {
 				t.Fatalf("task show: %v", err)
 			}
-			interruptionMarkers := []string{
-				"latest_executor_interruption: true",
-				"latest_recovery: resolve the interruption cause, then run: galley task requeue task-cli-test",
-			}
-			if tc.wantInterruption {
-				want := append([]string{
-					"latest_error_phase: executor",
-					"latest_error_kind: executor_interrupted",
-					artifactDir,
-				}, interruptionMarkers...)
-				want = append(want, tc.wantDetail...)
-				for _, w := range want {
-					if !strings.Contains(stdout, w) {
-						t.Fatalf("task show output missing %q\n%s", w, stdout)
-					}
-				}
-			} else {
-				for _, marker := range interruptionMarkers {
-					if strings.Contains(stdout, marker) {
-						t.Fatalf("ordinary failure must not render %q\n%s", marker, stdout)
-					}
-				}
-			}
+			assertInterruptionRendering(t, stdout, interruptionRendering{
+				WantInterruption: tc.wantInterruption,
+				ArtifactDir:      artifactDir,
+				WantDetail:       tc.wantDetail,
+			})
 		})
+	}
+}
+
+func writeFailedTaskWithAttempt(t *testing.T, root string, attempt taskpkg.Attempt) {
+	t.Helper()
+	taskPath := writeCLITaskYAML(t)
+	loaded, err := taskpkg.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Status = "failed"
+	loaded.Attempts = []taskpkg.Attempt{attempt}
+	dst := filepath.Join(root, "tasks", "failed", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := taskpkg.Save(dst, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// interruptionRendering is what `task show` must (or must not) render for one
+// failed attempt.
+type interruptionRendering struct {
+	WantInterruption bool
+	ArtifactDir      string
+	WantDetail       []string
+}
+
+func assertInterruptionRendering(t *testing.T, stdout string, want interruptionRendering) {
+	t.Helper()
+	markers := []string{
+		"latest_executor_interruption: true",
+		"latest_recovery: resolve the interruption cause, then run: galley task requeue task-cli-test",
+	}
+	if !want.WantInterruption {
+		for _, marker := range markers {
+			if strings.Contains(stdout, marker) {
+				t.Fatalf("ordinary failure must not render %q\n%s", marker, stdout)
+			}
+		}
+		return
+	}
+	expected := append([]string{
+		"latest_error_phase: executor",
+		"latest_error_kind: executor_interrupted",
+		want.ArtifactDir,
+	}, markers...)
+	expected = append(expected, want.WantDetail...)
+	for _, w := range expected {
+		if !strings.Contains(stdout, w) {
+			t.Fatalf("task show output missing %q\n%s", w, stdout)
+		}
 	}
 }

--- a/internal/daemon/acceptance_skeleton_creator_codex_test.go
+++ b/internal/daemon/acceptance_skeleton_creator_codex_test.go
@@ -77,7 +77,8 @@ func readCreatorCommandPlan(t *testing.T, runDir string) (struct {
 	Argv  []string `json:"argv"`
 	Env   []string `json:"env"`
 	Stdin string   `json:"stdin"`
-}, []byte) {
+}, []byte,
+) {
 	t.Helper()
 	var plan struct {
 		Argv  []string `json:"argv"`
@@ -104,7 +105,7 @@ func TestAcceptanceSkeletonPreflightCodexProviderHappyPath(t *testing.T) {
 	codexBin := fakeCodexCreator(t, manifest, `mkdir -p internal/foo
 printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 assertion.\n' > internal/foo/foo_test.go`)
 
-	res, err, runDir := runPreflightWithOptions(t, codexPreflightTask("AC1"), skeletonpreflight.Options{CodexBin: codexBin})
+	res, runDir, err := runPreflightWithOptions(t, codexPreflightTask("AC1"), skeletonpreflight.Options{CodexBin: codexBin})
 	if err != nil {
 		t.Fatalf("preflight error: %v", err)
 	}
@@ -184,7 +185,7 @@ printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 assertion.\n
 printf '%s\n' '{"event":"assistant_message","message":'`+strconv.Quote(manifest)+`'}'
 `)
 
-	res, err, runDir := runPreflightWithOptions(t, codexPreflightTask("AC1"), skeletonpreflight.Options{CodexBin: codexBin})
+	res, runDir, err := runPreflightWithOptions(t, codexPreflightTask("AC1"), skeletonpreflight.Options{CodexBin: codexBin})
 	if err != nil {
 		t.Fatalf("preflight error: %v", err)
 	}
@@ -236,7 +237,7 @@ printf 'package foo_test\n' > internal/foo/foo_test.go`
 		t.Run(tc.name, func(t *testing.T) {
 			tk := preflightTestTask("AC1")
 			tk.Executor.CLI = tc.cli
-			res, err, runDir := runPreflightWithOptions(t, tk, tc.opts)
+			res, runDir, err := runPreflightWithOptions(t, tk, tc.opts)
 			if err != nil {
 				t.Fatalf("preflight error: %v", err)
 			}
@@ -308,7 +309,7 @@ printf 'package foo_test\n' > internal/foo/foo_test.go`
 			tk.Executor.CLI = tc.cli
 			tk.Executor.Model = tc.model
 			tk.Executor.Effort = tc.effort
-			res, err, runDir := runPreflightWithOptions(t, tk, tc.opts)
+			res, runDir, err := runPreflightWithOptions(t, tk, tc.opts)
 			if err != nil {
 				t.Fatalf("preflight error: %v", err)
 			}

--- a/internal/daemon/acceptance_skeleton_preflight_test.go
+++ b/internal/daemon/acceptance_skeleton_preflight_test.go
@@ -32,18 +32,24 @@ func preflightTestTask(acIDs ...string) task.Task {
 	}
 }
 
-func runPreflightWithOptions(t *testing.T, tk task.Task, opts skeletonpreflight.Options) (*skeletonpreflight.Result, error, string) {
+func runPreflightWithOptions(t *testing.T, tk task.Task, opts skeletonpreflight.Options) (*skeletonpreflight.Result, string, error) {
 	t.Helper()
 	work := t.TempDir()
 	runDir := t.TempDir()
-	res, err := runPreflightInWorkdir(t, tk, opts, work, runDir)
-	return res, err, runDir
+	res, err := runPreflightInWorkdir(t, tk, opts, preflightDirs{Work: work, RunDir: runDir})
+	return res, runDir, err
 }
 
-func runPreflightInWorkdir(t *testing.T, tk task.Task, opts skeletonpreflight.Options, work, runDir string) (*skeletonpreflight.Result, error) {
+type preflightDirs struct {
+	Work   string
+	RunDir string
+}
+
+func runPreflightInWorkdir(t *testing.T, tk task.Task, opts skeletonpreflight.Options, dirs preflightDirs) (*skeletonpreflight.Result, error) {
+	work, runDir := dirs.Work, dirs.RunDir
 	t.Helper()
-	if err := exec.Command("git", "-C", work, "rev-parse", "--git-dir").Run(); err != nil {
-		if err := exec.Command("git", "init", work).Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), "git", "-C", work, "rev-parse", "--git-dir").Run(); err != nil {
+		if err := exec.CommandContext(t.Context(), "git", "init", work).Run(); err != nil {
 			t.Fatalf("initialize test repository: %v", err)
 		}
 	}
@@ -68,7 +74,7 @@ func TestAcceptanceSkeletonPreflightBuiltInCreatorHappyPath(t *testing.T) {
 	claudeBin := fakeCreator(t, manifest, `mkdir -p internal/foo
 printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 assertion.\n' > internal/foo/foo_test.go`)
 
-	res, err, runDir := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+	res, runDir, err := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 	if err != nil {
 		t.Fatalf("preflight error: %v", err)
 	}
@@ -115,7 +121,7 @@ func TestAcceptanceSkeletonPreflightMissingDeclaredFileFails(t *testing.T) {
 	t.Parallel()
 	manifest := resultManifest(`[{\"ac_id\":\"AC1\",\"path\":\"internal/foo/foo_test.go\",\"kind\":\"go-test\",\"purpose\":\"p\",\"satisfies\":\"s\",\"integration_point\":\"i\",\"implementation_required\":true}]`)
 	claudeBin := fakeCreator(t, manifest, "")
-	res, err, _ := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+	res, _, err := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 	if err == nil {
 		t.Fatal("expected error for missing creator-declared file")
 	}
@@ -131,7 +137,7 @@ func TestAcceptanceSkeletonPreflightRejectsUndeclaredCreatorChanges(t *testing.T
 printf 'package foo_test\n' > internal/foo/foo_test.go
 printf 'package foo_test\n' > internal/foo/extra_test.go`)
 
-	res, err, _ := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+	res, _, err := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 	if err == nil {
 		t.Fatal("expected error for undeclared creator file")
 	}
@@ -153,7 +159,7 @@ func TestAcceptanceSkeletonPreflightRequiresDeclaredOutputChangedByCreator(t *te
 	manifest := resultManifest(`[{\"ac_id\":\"AC1\",\"path\":\"internal/foo/foo_test.go\",\"kind\":\"go-test\",\"purpose\":\"verify AC1\",\"satisfies\":\"AC1 behavior\",\"integration_point\":\"executor completes this test\",\"implementation_required\":true}]`)
 	claudeBin := fakeCreator(t, manifest, "")
 
-	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, work, runDir)
+	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, preflightDirs{Work: work, RunDir: runDir})
 	if err == nil {
 		t.Fatal("expected error for unchanged declared output")
 	}
@@ -170,7 +176,7 @@ func TestAcceptanceSkeletonPreflightRejectsRunDirOutput(t *testing.T) {
 	manifest := resultManifest(`[{\"ac_id\":\"AC1\",\"path\":\"` + outputPath + `\",\"kind\":\"go-test\",\"purpose\":\"verify AC1\",\"satisfies\":\"AC1 behavior\",\"integration_point\":\"executor completes this test\",\"implementation_required\":true}]`)
 	claudeBin := fakeCreator(t, manifest, "")
 
-	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, work, runDir)
+	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, preflightDirs{Work: work, RunDir: runDir})
 	if err == nil {
 		t.Fatal("expected error for run evidence output")
 	}
@@ -190,7 +196,7 @@ func TestAcceptanceSkeletonPreflightRejectsSymlinkDirectoryEscape(t *testing.T) 
 	manifest := resultManifest(`[{\"ac_id\":\"AC1\",\"path\":\"tests/foo_test.go\",\"kind\":\"go-test\",\"purpose\":\"verify AC1\",\"satisfies\":\"AC1 behavior\",\"integration_point\":\"executor completes this test\",\"implementation_required\":true}]`)
 	claudeBin := fakeCreator(t, manifest, `printf 'package foo_test\n' > tests/foo_test.go`)
 
-	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, work, runDir)
+	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, preflightDirs{Work: work, RunDir: runDir})
 	if err == nil {
 		t.Fatal("expected error for symlink directory escape")
 	}
@@ -210,7 +216,7 @@ func TestAcceptanceSkeletonPreflightIgnoresRunDirInsideWorktreeSnapshot(t *testi
 	claudeBin := fakeCreator(t, manifest, `mkdir -p internal/foo
 printf 'package foo_test\n' > internal/foo/foo_test.go`)
 
-	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, work, runDir)
+	res, err := runPreflightInWorkdir(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin}, preflightDirs{Work: work, RunDir: runDir})
 	if err != nil {
 		t.Fatalf("preflight error: %v", err)
 	}
@@ -236,7 +242,7 @@ func TestAcceptanceSkeletonPreflightRejectsUnsafePath(t *testing.T) {
 			manifest := resultManifest(`[{\"ac_id\":\"AC1\",\"path\":\"` + tc.path + `\",\"kind\":\"go-test\",\"purpose\":\"p\",\"satisfies\":\"s\",\"integration_point\":\"i\",\"implementation_required\":true}]`)
 			claudeBin := fakeCreator(t, manifest, `mkdir -p secret
 printf 'package foo\n' > secret/foo_test.go`)
-			res, err, _ := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+			res, _, err := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 			if err == nil {
 				t.Fatalf("expected error for %s", tc.name)
 			}
@@ -256,7 +262,7 @@ func TestAcceptanceSkeletonPreflightAcceptsDuplicateOutputPaths(t *testing.T) {
 	claudeBin := fakeCreator(t, manifest, `mkdir -p internal/foo
 printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 and AC2 assertions.\n' > internal/foo/foo_test.go`)
 
-	res, err, runDir := runPreflightWithOptions(t, preflightTestTask("AC1", "AC2"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+	res, runDir, err := runPreflightWithOptions(t, preflightTestTask("AC1", "AC2"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 	if err != nil {
 		t.Fatalf("preflight error: %v", err)
 	}
@@ -266,25 +272,7 @@ printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 and AC2 asse
 	if len(res.Outputs) != 2 {
 		t.Fatalf("expected 2 outputs for duplicate-path case, got %+v", res.Outputs)
 	}
-	byAC := map[string]skeletonpreflight.Output{}
-	for _, out := range res.Outputs {
-		byAC[out.ACID] = out
-	}
-	for _, ac := range []string{"AC1", "AC2"} {
-		out, ok := byAC[ac]
-		if !ok {
-			t.Fatalf("missing output for %s in %+v", ac, res.Outputs)
-		}
-		if out.Path != "internal/foo/foo_test.go" {
-			t.Fatalf("%s path = %q, want shared skeleton path", ac, out.Path)
-		}
-		if out.Purpose == "" || out.Satisfies == "" || out.IntegrationPoint == "" {
-			t.Fatalf("%s metadata not preserved: %+v", ac, out)
-		}
-		if !strings.Contains(out.Purpose, ac) || !strings.Contains(out.Satisfies, ac) || !strings.Contains(out.IntegrationPoint, ac) {
-			t.Fatalf("%s metadata mixed up: %+v", ac, out)
-		}
-	}
+	assertPerACMetadataPreserved(t, res.Outputs, "internal/foo/foo_test.go")
 	if len(res.Baseline.SkeletonHashes) != 1 {
 		t.Fatalf("baseline should dedupe the shared path, got %+v", res.Baseline.SkeletonHashes)
 	}
@@ -295,16 +283,30 @@ printf 'package foo_test\n\n// TODO(galley-skeleton): implement AC1 and AC2 asse
 	if persisted == nil || len(persisted.Outputs) != 2 {
 		t.Fatalf("persisted preflight_result.json did not preserve duplicate outputs: %+v", persisted)
 	}
+	assertPerACMetadataPreserved(t, persisted.Outputs, "internal/foo/foo_test.go")
+}
+
+// assertPerACMetadataPreserved pins that two ACs sharing one skeleton path each
+// keep their own metadata rather than collapsing into a single entry.
+func assertPerACMetadataPreserved(t *testing.T, outputs []skeletonpreflight.Output, wantPath string) {
+	t.Helper()
+	byAC := map[string]skeletonpreflight.Output{}
+	for _, out := range outputs {
+		byAC[out.ACID] = out
+	}
 	for _, ac := range []string{"AC1", "AC2"} {
-		found := false
-		for _, out := range persisted.Outputs {
-			if out.ACID == ac && out.Path == "internal/foo/foo_test.go" && out.Purpose != "" && out.Satisfies != "" && out.IntegrationPoint != "" {
-				found = true
-				break
-			}
+		out, ok := byAC[ac]
+		if !ok {
+			t.Fatalf("missing output for %s in %+v", ac, outputs)
 		}
-		if !found {
-			t.Fatalf("persisted preflight_result.json missing %s entry: %+v", ac, persisted.Outputs)
+		if out.Path != wantPath {
+			t.Fatalf("%s path = %q, want %q", ac, out.Path, wantPath)
+		}
+		if out.Purpose == "" || out.Satisfies == "" || out.IntegrationPoint == "" {
+			t.Fatalf("%s metadata not preserved: %+v", ac, out)
+		}
+		if !strings.Contains(out.Purpose, ac) || !strings.Contains(out.Satisfies, ac) || !strings.Contains(out.IntegrationPoint, ac) {
+			t.Fatalf("%s metadata mixed up: %+v", ac, out)
 		}
 	}
 }
@@ -327,7 +329,7 @@ func TestAcceptanceSkeletonPreflightRejectsInvalidManifestFields(t *testing.T) {
 			t.Parallel()
 			manifest := resultManifest(`[` + tc.output + `]`)
 			claudeBin := fakeCreator(t, manifest, `printf 'package foo\n' > foo_test.go`)
-			res, err, runDir := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
+			res, runDir, err := runPreflightWithOptions(t, preflightTestTask("AC1"), skeletonpreflight.Options{ClaudeBin: claudeBin})
 			if err == nil {
 				t.Fatalf("expected error for %s", tc.name)
 			}

--- a/internal/daemon/attempt_error.go
+++ b/internal/daemon/attempt_error.go
@@ -10,23 +10,31 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-func appendFailureAttempt(loaded *task.Task, phase, kind string, err error, artifactDir string) {
+// attemptFailure is one failed attempt Galley records on the task.
+type attemptFailure struct {
+	Phase       string
+	Kind        string
+	Err         error
+	ArtifactDir string
+}
+
+func appendFailureAttempt(loaded *task.Task, failure attemptFailure) {
 	if loaded == nil {
 		return
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	message := ""
-	if err != nil {
-		message = err.Error()
+	if failure.Err != nil {
+		message = failure.Err.Error()
 	}
 	loaded.Attempts = append(loaded.Attempts, task.Attempt{
 		Number:            len(loaded.Attempts) + 1,
 		StartedAt:         now,
 		CompletedAt:       now,
 		ClaudeStatus:      "not_run",
-		SupervisorVerdict: kind,
+		SupervisorVerdict: failure.Kind,
 		Summary:           message,
-		Error:             attemptError(phase, kind, err, artifactDir),
+		Error:             attemptError(failure),
 	})
 }
 
@@ -37,16 +45,16 @@ func supervisorFailureKind(err error) string {
 	return classifyFailureKind("supervisor_failed", err)
 }
 
-func attemptError(phase, kind string, err error, artifactDir string) *task.AttemptError {
+func attemptError(failure attemptFailure) *task.AttemptError {
 	message := ""
-	if err != nil {
-		message = err.Error()
+	if failure.Err != nil {
+		message = failure.Err.Error()
 	}
 	return &task.AttemptError{
-		Phase:       phase,
-		Kind:        kind,
+		Phase:       failure.Phase,
+		Kind:        failure.Kind,
 		Message:     message,
-		ArtifactDir: artifactDir,
+		ArtifactDir: failure.ArtifactDir,
 	}
 }
 

--- a/internal/daemon/cleanup.go
+++ b/internal/daemon/cleanup.go
@@ -57,49 +57,28 @@ func cleanupTaskWorktree(ctx context.Context, opts Options, path string) error {
 	// Querying GitHub for these tasks is a recurring maintenance failure, so
 	// the no-GitHub path is gated strictly on the persisted final status (R1).
 	persistedFinal := loaded.PR.Status == "merged" || loaded.PR.Status == "closed"
-	finalStatus := loaded.PR.Status
-	if !persistedFinal {
-		// The task still records a non-final PR (e.g. open), so the live PR
-		// state may have changed after Galley last persisted the task. Refresh
-		// it from GitHub. `gh pr view` is a GET-equivalent and idempotent, so a
-		// brief GitHub read flake should not abort worktree cleanup.
-		var state vcs.PullRequestState
-		err = retry.Do(ctx, func(ctx context.Context) error {
-			s, fetchErr := vcs.FetchPRState(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL)
-			if fetchErr != nil {
-				return fetchErr
-			}
-			state = s
-			return nil
-		})
-		if err != nil {
-			return cleanupTaskError(path, loaded, err)
-		}
-		if strings.EqualFold(state.State, "open") {
-			return nil
-		}
-		if !strings.EqualFold(state.State, "closed") {
-			return cleanupTaskError(path, loaded, fmt.Errorf("unsupported PR state %q", state.State))
-		}
-		finalStatus = closedPRTaskStatus(state)
+	finalStatus, stillOpen, err := resolveFinalStatus(ctx, effectiveOpts, loaded, persistedFinal)
+	if err != nil {
+		return cleanupTaskError(path, loaded, err)
+	}
+	if stillOpen {
+		return nil
 	}
 
 	cleanupResult, err := workspace.Remove(ctx, loaded.Scope.CWD, loaded.Worktree, workspaceOptions(effectiveOpts))
 	if err != nil {
 		return cleanupTaskError(path, loaded, err)
 	}
+	// Nothing is left to record: only the status is reconciled, and an
+	// unchanged status leaves the task file untouched.
 	if cleanupResult.AlreadyMissing && persistedFinal {
-		if loaded.Status == finalStatus {
-			return nil
-		}
-		loaded.Status = finalStatus
-		if err := task.Save(path, loaded); err != nil {
-			return cleanupTaskError(path, loaded, err)
-		}
-		return nil
+		return reconcileFinalStatus(path, loaded, finalStatus)
 	}
+
 	loaded.Status = finalStatus
-	loaded.PR.Status = finalStatus
+	// PR.Status carries the PR lifecycle vocabulary; a final task status maps
+	// onto its merged/closed values.
+	loaded.PR.Status = string(finalStatus)
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	loaded.Attempts = append(loaded.Attempts, task.Attempt{
 		Number:            len(loaded.Attempts) + 1,
@@ -128,9 +107,54 @@ func cleanupTaskError(path string, loaded task.Task, err error) error {
 	)
 }
 
-func closedPRTaskStatus(state vcs.PullRequestState) string {
+func closedPRTaskStatus(state vcs.PullRequestState) task.Status {
 	if state.Merged {
-		return "merged"
+		return task.StatusMerged
 	}
-	return "closed"
+	return task.StatusClosed
+}
+
+// refreshFinalPRStatus resolves a non-final PR's task status, reporting
+// stillOpen while the PR is open. The idempotent GET is retried on a flake.
+func refreshFinalPRStatus(ctx context.Context, opts Options, prURL string) (status task.Status, stillOpen bool, err error) {
+	var state vcs.PullRequestState
+	if err := retry.Do(ctx, func(ctx context.Context) error {
+		s, fetchErr := vcs.FetchPRState(ctx, vcsRepo(opts, opts.Root, ""), prURL)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		state = s
+		return nil
+	}); err != nil {
+		return "", false, err
+	}
+	if strings.EqualFold(state.State, "open") {
+		return "", true, nil
+	}
+	if !strings.EqualFold(state.State, "closed") {
+		return "", false, fmt.Errorf("unsupported PR state %q", state.State)
+	}
+	return closedPRTaskStatus(state), false, nil
+}
+
+// resolveFinalStatus returns a completed PR's task status. An already-final
+// persisted status needs no GitHub call, so cleanup survives an API outage.
+func resolveFinalStatus(ctx context.Context, opts Options, loaded task.Task, persistedFinal bool) (status task.Status, stillOpen bool, err error) {
+	if persistedFinal {
+		return task.Status(loaded.PR.Status), false, nil
+	}
+	return refreshFinalPRStatus(ctx, opts, loaded.PR.URL)
+}
+
+// reconcileFinalStatus records a resolved final status on a task whose worktree
+// is already gone. An unchanged status must not rewrite the task file.
+func reconcileFinalStatus(path string, loaded task.Task, finalStatus task.Status) error {
+	if loaded.Status == finalStatus {
+		return nil
+	}
+	loaded.Status = finalStatus
+	if err := task.Save(path, loaded); err != nil {
+		return cleanupTaskError(path, loaded, err)
+	}
+	return nil
 }

--- a/internal/daemon/cleanup_test.go
+++ b/internal/daemon/cleanup_test.go
@@ -122,8 +122,8 @@ func assertGHNotInvoked(t *testing.T, marker string) {
 }
 
 func TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI(t *testing.T) {
-	for _, prStatus := range []string{"merged", "closed"} {
-		t.Run(prStatus, func(t *testing.T) {
+	for _, prStatus := range []task.Status{"merged", "closed"} {
+		t.Run(string(prStatus), func(t *testing.T) {
 			root := filepath.Join(t.TempDir(), ".agent-workflow")
 			repo := initDaemonGitRepo(t)
 			if err := queue.EnsureLayout(root); err != nil {
@@ -131,7 +131,7 @@ func TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI(t *tes
 			}
 			taskPath := filepath.Join(root, "tasks", "done", "task.yaml")
 			writeDaemonTask(t, taskPath, repo)
-			_, worktreePath := prepareDonePRTask(t, taskPath, repo, prStatus)
+			_, worktreePath := prepareDonePRTask(t, taskPath, repo, string(prStatus))
 			if err := os.RemoveAll(worktreePath); err != nil {
 				t.Fatal(err)
 			}
@@ -141,39 +141,50 @@ func TestCleanupWorktreesSkipsAlreadyFinalMissingWorktreeWithoutGitHubAPI(t *tes
 				t.Fatal(err)
 			}
 			assertGHNotInvoked(t, marker)
-
-			reloaded, err := task.Load(taskPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if reloaded.Status != prStatus {
-				t.Fatalf("task status got %q want %q", reloaded.Status, prStatus)
-			}
-			if reloaded.PR.Status != prStatus {
-				t.Fatalf("pr status got %q want %q", reloaded.PR.Status, prStatus)
-			}
-			old := time.Now().Add(-time.Hour)
-			if err := os.Chtimes(taskPath, old, old); err != nil {
-				t.Fatal(err)
-			}
-			before, err := os.Stat(taskPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := cleanupWorktrees(t.Context(), Options{Root: root, GHBin: ghBin}.withDefaults()); err != nil {
-				t.Fatal(err)
-			}
-			after, err := os.Stat(taskPath)
-			if err != nil || !before.ModTime().Equal(after.ModTime()) {
-				t.Fatalf("unchanged cleanup rewrote task: %v", err)
-			}
+			assertTaskAndPRStatus(t, taskPath, prStatus)
+			assertSecondCleanupDoesNotRewrite(t, taskPath, Options{Root: root, GHBin: ghBin}.withDefaults())
 		})
 	}
 }
 
+func assertTaskAndPRStatus(t *testing.T, taskPath string, want task.Status) {
+	t.Helper()
+	reloaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Status != want {
+		t.Fatalf("task status got %q want %q", reloaded.Status, want)
+	}
+	if reloaded.PR.Status != string(want) {
+		t.Fatalf("pr status got %q want %q", reloaded.PR.Status, want)
+	}
+}
+
+// assertSecondCleanupDoesNotRewrite pins, via mtime, that a second cleanup
+// leaves an already reconciled task file untouched.
+func assertSecondCleanupDoesNotRewrite(t *testing.T, taskPath string, opts Options) {
+	t.Helper()
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(taskPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupWorktrees(t.Context(), opts); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(taskPath)
+	if err != nil || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("unchanged cleanup rewrote task: %v", err)
+	}
+}
+
 func TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI(t *testing.T) {
-	for _, prStatus := range []string{"merged", "closed"} {
-		t.Run(prStatus, func(t *testing.T) {
+	for _, prStatus := range []task.Status{"merged", "closed"} {
+		t.Run(string(prStatus), func(t *testing.T) {
 			root := filepath.Join(t.TempDir(), ".agent-workflow")
 			repo := initDaemonGitRepo(t)
 			if err := queue.EnsureLayout(root); err != nil {
@@ -181,7 +192,7 @@ func TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI(t *testin
 			}
 			taskPath := filepath.Join(root, "tasks", "done", "task.yaml")
 			writeDaemonTask(t, taskPath, repo)
-			_, worktreePath := prepareDonePRTask(t, taskPath, repo, prStatus)
+			_, worktreePath := prepareDonePRTask(t, taskPath, repo, string(prStatus))
 			ghBin, marker := writeFailIfInvokedGH(t)
 
 			if err := cleanupWorktrees(context.Background(), Options{Root: root, GHBin: ghBin}.withDefaults()); err != nil {
@@ -196,7 +207,7 @@ func TestCleanupWorktreesRemovesPersistedFinalWorktreeWithoutGitHubAPI(t *testin
 			if err != nil {
 				t.Fatal(err)
 			}
-			if reloaded.PR.Status != prStatus {
+			if reloaded.PR.Status != string(prStatus) {
 				t.Fatalf("pr status got %q want %q", reloaded.PR.Status, prStatus)
 			}
 			if reloaded.Status != prStatus {

--- a/internal/daemon/codex_executor_dispatch_test.go
+++ b/internal/daemon/codex_executor_dispatch_test.go
@@ -64,103 +64,131 @@ func TestDaemonDispatchesSelectedExecutorBinary(t *testing.T) {
 		{"codex", "codex"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			root := filepath.Join(t.TempDir(), ".agent-workflow")
-			repo := initDaemonGitRepo(t)
-			promptPath, schemaPath := writeDaemonPromptFiles(t)
-
-			markerDir := t.TempDir()
-			claudeExecMarker := filepath.Join(markerDir, "claude-exec.marker")
-			codexExecMarker := filepath.Join(markerDir, "codex-exec.marker")
-
-			executorResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
-
-			// The supervisor branch in writeFakeClaude exits before running
-			// body, so the executor marker only fires when claude is invoked
-			// as the executor (not as the supervisor on a codex task).
-			claudeBin := writeFakeClaude(t, "echo executor >> "+claudeExecMarker+"\necho change > daemon-output.txt\necho '"+executorResult+"'\n")
-			codexBin := writeFakeCodexExecutor(t, "echo executor >> "+codexExecMarker+"\necho change > daemon-output.txt\necho '"+executorResult+"'\n")
-
-			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
-			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			writeDaemonTask(t, taskPath, repo)
-			loaded, err := task.Load(taskPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			loaded.Executor.CLI = tc.cli
-			if err := task.Save(taskPath, loaded); err != nil {
-				t.Fatal(err)
-			}
-
-			err = runTestDaemon(context.Background(), Options{
-				Root:               root,
-				SystemPromptFile:   promptPath,
-				JSONSchemaFile:     schemaPath,
-				Once:               true,
-				MaxConcurrentTasks: 1,
-				Supervisor:         "claude",
-				ClaudeBin:          claudeBin,
-				CodexBin:           codexBin,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			doneTask, err := task.Load(filepath.Join(root, "tasks", "done", "task.yaml"))
-			if err != nil {
-				t.Fatalf("done task missing: %v", err)
-			}
-			if doneTask.Status != "accepted" {
-				t.Fatalf("status got %q", doneTask.Status)
-			}
-			if len(doneTask.Attempts) != 1 || doneTask.Attempts[0].ClaudeStatus != "completed" {
-				t.Fatalf("attempts got %#v", doneTask.Attempts)
-			}
-
-			if tc.cli == "claude" {
-				if _, err := os.Stat(claudeExecMarker); err != nil {
-					t.Fatalf("claude executor marker missing: %v", err)
-				}
-				if _, err := os.Stat(codexExecMarker); !os.IsNotExist(err) {
-					t.Fatalf("codex executor marker should not exist for cli=claude: %v", err)
-				}
-			} else {
-				if _, err := os.Stat(codexExecMarker); err != nil {
-					t.Fatalf("codex executor marker missing: %v", err)
-				}
-				if _, err := os.Stat(claudeExecMarker); !os.IsNotExist(err) {
-					// claudeBin was invoked as supervisor only, which exits
-					// before running the body that writes the marker.
-					t.Fatalf("claude executor marker should not exist for cli=codex (supervisor path only): %v", err)
-				}
-			}
-
-			planData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", "command_plan.json"))
-			var plan struct {
-				Argv []string `json:"argv"`
-				Env  []string `json:"env,omitempty"`
-			}
-			if err := json.Unmarshal(planData, &plan); err != nil {
-				t.Fatalf("decode command_plan.json: %v", err)
-			}
-			if len(plan.Argv) == 0 {
-				t.Fatal("command_plan.json argv is empty")
-			}
-			if len(plan.Env) != 0 {
-				t.Fatalf("command_plan.json must not persist environment entries: %v", plan.Env)
-			}
-			wantBin := claudeBin
-			if tc.cli == "codex" {
-				wantBin = codexBin
-			}
-			if filepath.Base(plan.Argv[0]) != filepath.Base(wantBin) {
-				t.Fatalf("command_plan.json argv[0] basename got %q, want %q (selected cli=%s)", filepath.Base(plan.Argv[0]), filepath.Base(wantBin), tc.cli)
-			}
+			assertExecutorBinaryDispatched(t, tc.cli)
 		})
+	}
+}
+
+// assertExecutorBinaryDispatched pins that only the selected binary ran as the
+// executor and that the persisted command plan names it.
+func assertExecutorBinaryDispatched(t *testing.T, cli string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+
+	markerDir := t.TempDir()
+	claudeExecMarker := filepath.Join(markerDir, "claude-exec.marker")
+	codexExecMarker := filepath.Join(markerDir, "codex-exec.marker")
+
+	executorResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
+
+	// writeFakeClaude's supervisor branch exits before body, so the marker
+	// fires only when claude runs as the executor.
+	claudeBin := writeFakeClaude(t, "echo executor >> "+claudeExecMarker+"\necho change > daemon-output.txt\necho '"+executorResult+"'\n")
+	codexBin := writeFakeCodexExecutor(t, "echo executor >> "+codexExecMarker+"\necho change > daemon-output.txt\necho '"+executorResult+"'\n")
+
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.CLI = cli
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runTestDaemon(context.Background(), Options{
+		Root:               root,
+		SystemPromptFile:   promptPath,
+		JSONSchemaFile:     schemaPath,
+		Once:               true,
+		MaxConcurrentTasks: 1,
+		Supervisor:         "claude",
+		ClaudeBin:          claudeBin,
+		CodexBin:           codexBin,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertTaskAccepted(t, filepath.Join(root, "tasks", "done", "task.yaml"))
+	assertOnlySelectedExecutorRan(t, executorMarkers{CLI: cli, Claude: claudeExecMarker, Codex: codexExecMarker})
+	assertCommandPlanBinary(t, root, dispatchBinaries{CLI: cli, Claude: claudeBin, Codex: codexBin})
+}
+
+func assertTaskAccepted(t *testing.T, donePath string) {
+	t.Helper()
+	doneTask, err := task.Load(donePath)
+	if err != nil {
+		t.Fatalf("done task missing: %v", err)
+	}
+	if doneTask.Status != "accepted" {
+		t.Fatalf("status got %q", doneTask.Status)
+	}
+	if len(doneTask.Attempts) != 1 || doneTask.Attempts[0].ClaudeStatus != "completed" {
+		t.Fatalf("attempts got %#v", doneTask.Attempts)
+	}
+}
+
+// executorMarkers are the per-binary execution markers for one dispatch case.
+type executorMarkers struct {
+	CLI    string
+	Claude string
+	Codex  string
+}
+
+// assertOnlySelectedExecutorRan pins that the unselected binary never ran as
+// the executor; claude's supervisor path exits before writing its marker.
+func assertOnlySelectedExecutorRan(t *testing.T, m executorMarkers) {
+	t.Helper()
+	ran, absent := m.Claude, m.Codex
+	if m.CLI != "claude" {
+		ran, absent = m.Codex, m.Claude
+	}
+	if _, err := os.Stat(ran); err != nil {
+		t.Fatalf("%s executor marker missing: %v", m.CLI, err)
+	}
+	if _, err := os.Stat(absent); !os.IsNotExist(err) {
+		t.Fatalf("unselected executor marker should not exist for cli=%s: %v", m.CLI, err)
+	}
+}
+
+// dispatchBinaries are the executor binaries one dispatch case can select.
+type dispatchBinaries struct {
+	CLI    string
+	Claude string
+	Codex  string
+}
+
+func assertCommandPlanBinary(t *testing.T, root string, bins dispatchBinaries) {
+	t.Helper()
+	cli := bins.CLI
+	planData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", "command_plan.json"))
+	var plan struct {
+		Argv []string `json:"argv"`
+		Env  []string `json:"env,omitempty"`
+	}
+	if err := json.Unmarshal(planData, &plan); err != nil {
+		t.Fatalf("decode command_plan.json: %v", err)
+	}
+	if len(plan.Argv) == 0 {
+		t.Fatal("command_plan.json argv is empty")
+	}
+	if len(plan.Env) != 0 {
+		t.Fatalf("command_plan.json must not persist environment entries: %v", plan.Env)
+	}
+	wantBin := bins.Claude
+	if cli == "codex" {
+		wantBin = bins.Codex
+	}
+	if filepath.Base(plan.Argv[0]) != filepath.Base(wantBin) {
+		t.Fatalf("command_plan.json argv[0] basename got %q, want %q (selected cli=%s)", filepath.Base(plan.Argv[0]), filepath.Base(wantBin), cli)
 	}
 }
 

--- a/internal/daemon/comments.go
+++ b/internal/daemon/comments.go
@@ -78,7 +78,7 @@ func processTaskPRComments(ctx context.Context, opts Options, path string) error
 	// idempotency key, so retrying could create duplicate PR comments.
 	var comments []vcs.PRComment
 	err = retry.Do(ctx, func(ctx context.Context) error {
-		fetched, fetchErr := vcs.FetchPRComments(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL)
+		fetched, fetchErr := vcs.FetchPRComments(ctx, vcsRepo(effectiveOpts, effectiveOpts.Root, ""), loaded.PR.URL)
 		if fetchErr != nil {
 			return fetchErr
 		}
@@ -88,10 +88,23 @@ func processTaskPRComments(ctx context.Context, opts Options, path string) error
 	if err != nil {
 		return err
 	}
+	return applyPRCommands(ctx, prCommandRun{Opts: effectiveOpts, Path: path, Loaded: loaded}, comments)
+}
+
+// prCommandRun is one task's PR comment scan.
+type prCommandRun struct {
+	Opts   Options
+	Path   string
+	Loaded task.Task
+}
+
+// applyPRCommands acts on the first unprocessed /galley comment. Reply failures
+// are collected; a task-file write failure stops the scan.
+func applyPRCommands(ctx context.Context, run prCommandRun, comments []vcs.PRComment) error {
 	var errs []error
 	for _, comment := range comments {
 		commentID := strconv.FormatInt(comment.ID, 10)
-		if slices.Contains(loaded.PR.ProcessedCommentIDs, commentID) {
+		if slices.Contains(run.Loaded.PR.ProcessedCommentIDs, commentID) {
 			continue
 		}
 		command, ok := parsePRCommand(comment)
@@ -102,61 +115,71 @@ func processTaskPRComments(ctx context.Context, opts Options, path string) error
 		// them to the PR author recorded for this task. When the recorded PR
 		// author is empty (unknown), fail closed and reject the command.
 		// Replies are concise and do not echo the user-supplied request body.
-		if !prCommentMatchesPRAuthor(comment, loaded.PR.AuthorLogin) {
-			loaded.PR.ProcessedCommentIDs = append(loaded.PR.ProcessedCommentIDs, command.CommentID)
-			if err := task.Save(path, loaded); err != nil {
+		if !prCommentMatchesPRAuthor(comment, run.Loaded.PR.AuthorLogin) {
+			run.Loaded.PR.ProcessedCommentIDs = append(run.Loaded.PR.ProcessedCommentIDs, command.CommentID)
+			if err := task.Save(run.Path, run.Loaded); err != nil {
 				return err
 			}
-			if effectiveOpts.ReplyPRComments {
-				if err := vcs.PostPRComment(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL, "Galley ignored this comment because only the pull request author can run Galley from PR comments."); err != nil {
-					errs = append(errs, err)
-				}
-			}
+			errs = append(errs, run.reply(ctx, "Galley ignored this comment because only the pull request author can run Galley from PR comments."))
 			continue
 		}
-		if loaded.Status == "queued" || loaded.Status == "running" {
-			applyPRCommandToLoadedTask(&loaded, command)
-			if err := task.Save(path, loaded); err != nil {
+		if run.Loaded.Status == "queued" || run.Loaded.Status == "running" {
+			applyPRCommandToLoadedTask(&run.Loaded, command)
+			if err := task.Save(run.Path, run.Loaded); err != nil {
 				return err
 			}
-			if effectiveOpts.ReplyPRComments {
-				if err := vcs.PostPRComment(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL, fmt.Sprintf("Galley noted this comment; task is already %s.", loaded.Status)); err != nil {
-					errs = append(errs, err)
-				}
-			}
+			errs = append(errs, run.reply(ctx, fmt.Sprintf("Galley noted this comment; task is already %s.", run.Loaded.Status)))
 			continue
 		}
-		result, err := task.Requeue(path, task.RequeueOptions{
-			Reason:              command.Reason,
-			ProcessedCommentIDs: []string{command.CommentID},
-			RevisionRequests: []task.RevisionRequest{{
-				ID:        "pr-comment-" + command.CommentID,
-				Source:    "pr_comment",
-				CommentID: command.CommentID,
-				Text:      command.Reason,
-				Status:    "pending",
-			}},
-		})
+		result, err := requeueFromPRComment(run.Path, command)
 		if err != nil {
-			applyPRCommandToLoadedTask(&loaded, command)
-			appendRiskWithID(&loaded, "pr-requeue-"+command.CommentID, "external_dependency", fmt.Sprintf("PR comment %s requested a rerun, but Galley could not requeue the task: %v", command.CommentID, err), "Resolve the queued/running task conflict or filesystem error, then run galley task requeue manually.", true)
-			if saveErr := task.Save(path, loaded); saveErr != nil {
-				errs = append(errs, errors.Join(err, saveErr))
-				continue
-			}
-			errs = append(errs, err)
+			errs = append(errs, run.recordRequeueFailure(command, err))
 			continue
 		}
-		path = result.To
-		loaded = result.Task
-		if effectiveOpts.ReplyPRComments {
-			if err := vcs.PostPRComment(ctx, vcsBinaries(effectiveOpts), effectiveOpts.Root, loaded.PR.URL, fmt.Sprintf("Galley requeued task `%s` from this comment.", loaded.ID)); err != nil {
-				errs = append(errs, err)
-			}
-		}
+		run.Loaded = result.Task
+		errs = append(errs, run.reply(ctx, fmt.Sprintf("Galley requeued task `%s` from this comment.", run.Loaded.ID)))
 		break
 	}
 	return errors.Join(errs...)
+}
+
+// reply posts a PR comment when replies are enabled; PostPRComment is never
+// retried because posting a comment is non-idempotent.
+func (run prCommandRun) reply(ctx context.Context, body string) error {
+	if !run.Opts.ReplyPRComments {
+		return nil
+	}
+	return vcs.PostPRComment(ctx, vcsRepo(run.Opts, run.Opts.Root, ""), run.Loaded.PR.URL, body)
+}
+
+func requeueFromPRComment(path string, command prCommand) (task.RequeueResult, error) {
+	return task.Requeue(path, task.RequeueOptions{
+		Reason:              command.Reason,
+		ProcessedCommentIDs: []string{command.CommentID},
+		RevisionRequests: []task.RevisionRequest{{
+			ID:        "pr-comment-" + command.CommentID,
+			Source:    "pr_comment",
+			CommentID: command.CommentID,
+			Text:      command.Reason,
+			Status:    "pending",
+		}},
+	})
+}
+
+// recordRequeueFailure keeps the comment processed and records the failure as a
+// task risk so the PR comment cannot be retried in a loop.
+func (run *prCommandRun) recordRequeueFailure(command prCommand, err error) error {
+	applyPRCommandToLoadedTask(&run.Loaded, command)
+	appendRiskWithID(&run.Loaded, "pr-requeue-"+command.CommentID, riskSpec{
+		Type:        "external_dependency",
+		Detail:      fmt.Sprintf("PR comment %s requested a rerun, but Galley could not requeue the task: %v", command.CommentID, err),
+		Mitigation:  "Resolve the queued/running task conflict or filesystem error, then run galley task requeue manually.",
+		HumanReview: true,
+	})
+	if saveErr := task.Save(run.Path, run.Loaded); saveErr != nil {
+		return errors.Join(err, saveErr)
+	}
+	return err
 }
 
 func applyPRCommandToLoadedTask(loaded *task.Task, command prCommand) {
@@ -204,9 +227,13 @@ func isActionableForPRCommentPoll(loaded task.Task) bool {
 	if !strings.EqualFold(loaded.PR.Status, "open") {
 		return false
 	}
+	// A closed, merged, archived, accepted, draft, or failed task cannot drive a
+	// follow-up run from a /galley comment.
 	switch loaded.Status {
-	case "pr_opened", "needs_supervisor_review", "queued", "running":
+	case task.StatusPROpened, task.StatusNeedsSupervisorReview, task.StatusQueued, task.StatusRunning:
 		return true
+	case task.StatusDraft, task.StatusFailed, task.StatusAccepted, task.StatusMerged, task.StatusClosed, task.StatusArchived:
+		return false
 	default:
 		return false
 	}

--- a/internal/daemon/comments_test.go
+++ b/internal/daemon/comments_test.go
@@ -87,7 +87,7 @@ func TestPollPRCommentsRequeuesTaskOnce(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -142,7 +142,7 @@ func TestPollPRCommentsRequeuesNeedsSupervisorReviewOpenPR(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 	failedPath := filepath.Join(root, "tasks", "failed", "task.yaml")
 	writeDaemonTask(t, failedPath, repo)
 	loaded, err := task.Load(failedPath)
@@ -192,7 +192,7 @@ func TestPollPRCommentsReplyOmitsReasonAndCommentID(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -263,7 +263,7 @@ func TestPollPRCommentsReplyForQueuedOrRunningTask(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	queuedPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	writeDaemonTask(t, queuedPath, repo)
 	loaded, err := task.Load(queuedPath)
@@ -315,7 +315,7 @@ func TestPollPRCommentsContinuesAfterReplyFailure(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -368,7 +368,7 @@ func TestPollPRCommentsRecordsFailedRequeueForManualRecovery(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	queuedPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
@@ -425,7 +425,7 @@ func TestPollPRCommentsIgnoresNonPRAuthor(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -469,7 +469,7 @@ func TestPollPRCommentsRejectsNonAuthor(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -537,7 +537,7 @@ func TestPollPRCommentsRejectsWhenPRAuthorLoginEmpty(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, true)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: true})
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	writeDaemonTask(t, donePath, repo)
 	loaded, err := task.Load(donePath)
@@ -734,7 +734,7 @@ func TestPollPRCommentsSkipsHistoricalNonActionableTasks(t *testing.T) {
 	// these tasks first.
 	cases := []struct {
 		name     string
-		status   string
+		status   task.Status
 		prStatus string
 		prURL    string
 	}{
@@ -790,7 +790,7 @@ func TestPollPRCommentsActionableOnlyFetchesOpenPRTasks(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 
 	closedPath := filepath.Join(root, "tasks", "done", "task-closed.yaml")
 	writeDaemonTask(t, closedPath, repo)
@@ -854,7 +854,16 @@ fi
 	}
 }
 
-func writeDaemonEnvironmentProfile(t *testing.T, root, repo string, pollComments, replyComments bool) {
+type commentProfileSpec struct {
+	Root          string
+	Repo          string
+	PollComments  bool
+	ReplyComments bool
+}
+
+func writeDaemonEnvironmentProfile(t *testing.T, spec commentProfileSpec) {
+	root, repo := spec.Root, spec.Repo
+	pollComments, replyComments := spec.PollComments, spec.ReplyComments
 	t.Helper()
 	_, _, environmentPath, err := galleyhome.RepoProfilePaths(root, repo)
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -222,7 +222,7 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	// Preserve outstanding children for force-stop recovery; never clear another daemon's registry.
-	//nolint:contextcheck // ProcessInfo probes liveness on its own 2s budget; a cancelled daemon context must not corrupt owner metadata
+	//nolint:contextcheck,nolintlint // ProcessInfo probes liveness on its own 2s budget (unix only), so a cancelled daemon context cannot corrupt owner metadata
 	owner := currentRunningOwner()
 	registry := proc.NewChildRegistry(proc.OwnedChildRegistryPath(opts.Root, owner.PID, owner.ProcessStartedAt))
 	ctx = proc.WithChildRegistry(ctx, registry)
@@ -512,7 +512,7 @@ func claimAvailableTasks(daemonCtx, execCtx context.Context, batch claimBatch) (
 			return claimedCount, firstNonNil(firstClaimErr, daemonCtx.Err())
 		default:
 		}
-		//nolint:contextcheck // ProcessInfo probes liveness on its own 2s budget; a cancelled daemon context must not corrupt owner metadata
+		//nolint:contextcheck,nolintlint // ProcessInfo probes liveness on its own 2s budget (unix only), so a cancelled daemon context cannot corrupt owner metadata
 		claimed, err := batch.claimOne(queuedPath)
 		if err != nil {
 			firstClaimErr = firstNonNil(firstClaimErr, err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -133,9 +133,9 @@ type Options struct {
 }
 
 type daemonDependencies struct {
-	stageExecutorOutput  func(context.Context, Options, string, string, []string) error
-	captureDiffArtifacts func(context.Context, string, string, string, workspace.Options) (executorflow.DiffArtifacts, error)
-	supervisorRunner     func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)
+	stageExecutorOutput  func(context.Context, stageOutputRequest) error
+	captureDiffArtifacts func(context.Context, executorflow.DiffCapture) (executorflow.DiffArtifacts, error)
+	supervisorRunner     func(context.Context, supervisorRunRequest) (supervisor.Verdict, error)
 	setupExecutorRunner  func(context.Context, setuppreflight.Options) (*setuppreflight.Result, error)
 }
 
@@ -222,6 +222,7 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	// Preserve outstanding children for force-stop recovery; never clear another daemon's registry.
+	//nolint:contextcheck // ProcessInfo probes liveness on its own 2s budget; a cancelled daemon context must not corrupt owner metadata
 	owner := currentRunningOwner()
 	registry := proc.NewChildRegistry(proc.OwnedChildRegistryPath(opts.Root, owner.PID, owner.ProcessStartedAt))
 	ctx = proc.WithChildRegistry(ctx, registry)
@@ -277,7 +278,7 @@ func runNormalDaemon(ctx context.Context, opts Options) error {
 	// context.Canceled as an error makes `galley daemon run` exit non-zero on a
 	// clean shutdown and read as a failed unit under systemd.
 	if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
-		return err
+		return fmt.Errorf("daemon stopped: %w", err)
 	}
 	return nil
 }
@@ -418,7 +419,7 @@ func (opts Options) withDefaults() Options {
 func processAvailable(ctx context.Context, opts Options) (int, error) {
 	select {
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return 0, fmt.Errorf("daemon poll interrupted: %w", ctx.Err())
 	default:
 	}
 	if err := queue.EnsureLayout(opts.Root); err != nil {
@@ -436,20 +437,8 @@ func processAvailable(ctx context.Context, opts Options) (int, error) {
 	stopped := ctx.Done()
 	for {
 		if ctx.Err() == nil {
-			err := queue.RecoverStaleClaimsExcept(opts.Root, opts.ClaimTTL, time.Now(), active)
-			var queued []string
-			if err == nil && len(active) < limit {
-				queued, err = queue.QueuedTasks(opts.Root)
-			}
-			if err == nil && len(queued) > 0 {
-				var repoCounts map[string]int
-				repoCounts, err = queue.RunningRepoCounts(opts.Root)
-				if err == nil {
-					var count int
-					count, err = claimAvailableTasks(ctx, execCtx, opts, queued, limit-len(active), repoCounts, active, completed)
-					claimedCount += count
-				}
-			}
+			count, err := pollOnce(ctx, execCtx, claimBatch{Opts: opts, Limit: limit, Active: active, Completed: completed})
+			claimedCount += count
 			firstErr = firstNonNil(firstErr, err)
 		}
 		if len(active) == 0 {
@@ -466,19 +455,56 @@ func processAvailable(ctx context.Context, opts Options) (int, error) {
 	}
 }
 
+// pollOnce recovers stale claims and claims what the limits allow.
+// batch.Limit is daemon-wide; this cycle takes what the active tasks leave.
+func pollOnce(ctx, execCtx context.Context, batch claimBatch) (int, error) {
+	opts, active := batch.Opts, batch.Active
+	if err := queue.RecoverStaleClaimsExcept(opts.Root, opts.ClaimTTL, time.Now(), active); err != nil {
+		return 0, err
+	}
+	if len(active) >= batch.Limit {
+		return 0, nil
+	}
+	queued, err := queue.QueuedTasks(opts.Root)
+	if err != nil {
+		return 0, err
+	}
+	if len(queued) == 0 {
+		return 0, nil
+	}
+	repoCounts, err := queue.RunningRepoCounts(opts.Root)
+	if err != nil {
+		return 0, err
+	}
+	batch.Queued = queued
+	batch.Limit -= len(active)
+	batch.RepoCounts = repoCounts
+	return claimAvailableTasks(ctx, execCtx, batch)
+}
+
 type taskCompletion struct {
 	path string
 	err  error
 }
 
-func claimAvailableTasks(daemonCtx, execCtx context.Context, opts Options, queued []string, limit int, repoCounts map[string]int, active map[string]bool, completed chan<- taskCompletion) (int, error) {
+// claimBatch is one poll cycle's claim capacity and shared bookkeeping.
+type claimBatch struct {
+	Opts       Options
+	Queued     []string
+	Limit      int
+	RepoCounts map[string]int
+	Active     map[string]bool
+	Completed  chan<- taskCompletion
+}
+
+func claimAvailableTasks(daemonCtx, execCtx context.Context, batch claimBatch) (int, error) {
 	claimedCount := 0
 	var firstClaimErr error
-	for _, queuedPath := range queued {
-		if claimedCount >= limit {
+	for _, queuedPath := range batch.Queued {
+		if claimedCount >= batch.Limit {
 			break
 		}
-		if active[task.TaskStatePath(opts.Root, task.WorkflowStateRunning, filepath.Base(queuedPath))] {
+		if batch.Active[task.TaskStatePath(batch.Opts.Root, task.WorkflowStateRunning, filepath.Base(queuedPath))] {
 			continue
 		}
 		select {
@@ -486,43 +512,52 @@ func claimAvailableTasks(daemonCtx, execCtx context.Context, opts Options, queue
 			return claimedCount, firstNonNil(firstClaimErr, daemonCtx.Err())
 		default:
 		}
-		repoKey, skip, err := repoKeyForClaim(opts, queuedPath, repoCounts)
+		//nolint:contextcheck // ProcessInfo probes liveness on its own 2s budget; a cancelled daemon context must not corrupt owner metadata
+		claimed, err := batch.claimOne(queuedPath)
 		if err != nil {
-			if firstClaimErr == nil {
-				firstClaimErr = err
-			}
+			firstClaimErr = firstNonNil(firstClaimErr, err)
 			continue
 		}
-		if skip {
-			continue
-		}
-		claimed, err := queue.ClaimTask(opts.Root, queuedPath)
-		if err != nil {
-			if errors.Is(err, queue.ErrClaimConflict) {
-				continue
-			}
-			if firstClaimErr == nil {
-				firstClaimErr = err
-			}
+		if claimed == "" {
 			continue
 		}
 		claimedCount++
-		if err := queue.WriteOwner(claimed, currentRunningOwner()); err != nil {
-			// Owner metadata is a best-effort recovery aid; if it cannot be written
-			// the task still proceeds and falls back to TTL-based recovery.
-			fmt.Fprintf(os.Stderr, "galley: record task owner failed for %s: %v\n", claimed, err)
-		}
-		if repoKey != "" {
-			repoCounts[repoKey]++
-		}
-		active[claimed] = true
+		batch.Active[claimed] = true
 		go func(path string) {
-			err := processClaimedTask(execCtx, daemonCtx, opts, path)
+			err := processClaimedTask(execCtx, daemonCtx, batch.Opts, path)
 			_ = queue.RemoveOwner(path)
-			completed <- taskCompletion{path: path, err: err}
+			batch.Completed <- taskCompletion{path: path, err: err}
 		}(claimed)
 	}
 	return claimedCount, firstClaimErr
+}
+
+// claimOne claims queuedPath and records its owner. An empty path means
+// skipped (repo limit reached or another daemon won), which is not an error.
+func (batch claimBatch) claimOne(queuedPath string) (string, error) {
+	repoKey, skip, err := repoKeyForClaim(batch.Opts, queuedPath, batch.RepoCounts)
+	if err != nil {
+		return "", err
+	}
+	if skip {
+		return "", nil
+	}
+	claimed, err := queue.ClaimTask(batch.Opts.Root, queuedPath)
+	if err != nil {
+		if errors.Is(err, queue.ErrClaimConflict) {
+			return "", nil
+		}
+		return "", err
+	}
+	if err := queue.WriteOwner(claimed, currentRunningOwner()); err != nil {
+		// Owner metadata is a best-effort recovery aid; if it cannot be written
+		// the task still proceeds and falls back to TTL-based recovery.
+		fmt.Fprintf(os.Stderr, "galley: record task owner failed for %s: %v\n", claimed, err)
+	}
+	if repoKey != "" {
+		batch.RepoCounts[repoKey]++
+	}
+	return claimed, nil
 }
 
 func repoKeyForClaim(opts Options, queuedPath string, repoCounts map[string]int) (string, bool, error) {
@@ -576,13 +611,14 @@ func queuedHasClaimConflict(root, queuedPath string) (bool, error) {
 }
 
 func pathExistsForClaim(path string) (bool, error) {
-	if _, err := os.Stat(path); err == nil {
+	_, err := os.Stat(path)
+	if err == nil {
 		return true, nil
-	} else if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
-	} else {
-		return false, fmt.Errorf("inspect claim conflict path %s: %w", path, err)
 	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect claim conflict path %s: %w", path, err)
 }
 
 func gracefulTaskContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
@@ -627,7 +663,7 @@ func processClaimedTask(execCtx, daemonCtx context.Context, opts Options, runnin
 	}
 	runID, runDir, err := initializeRunEvidence(opts.Root, runningPath, loaded, validation)
 	if err != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, "run_evidence", "run_evidence_failed", err, "")
+		return failClaimedStage(opts.Root, runningPath, &loaded, attemptFailure{Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: ""})
 	}
 
 	// Profile resolution must happen before workspace.Prepare so that the
@@ -637,7 +673,7 @@ func processClaimedTask(execCtx, daemonCtx context.Context, opts Options, runnin
 	// into runSupervisorLoop so the supervisor loop never re-loads it.
 	profiles, resolvedProfiles, err := loadAndPersistTaskProfiles(opts, &loaded, runDir)
 	if err != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, "run_evidence", "run_evidence_failed", err, runDir)
+		return failClaimedStage(opts.Root, runningPath, &loaded, attemptFailure{Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: runDir})
 	}
 	effectiveOpts := resolveEffectiveTaskOptions(opts, profiles).apply(opts)
 
@@ -648,121 +684,214 @@ func processClaimedTask(execCtx, daemonCtx context.Context, opts Options, runnin
 	}
 	effectiveExecutor := task.ResolveEffectiveExecutor(loaded.Executor, envExecutor)
 	if err := task.ValidateEffectiveExecutor(effectiveExecutor); err != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, "executor_preflight", "executor_config_failed", err, runDir)
+		return failClaimedStage(opts.Root, runningPath, &loaded, attemptFailure{Phase: "executor_preflight", Kind: "executor_config_failed", Err: err, ArtifactDir: runDir})
 	}
 
 	// Per-task provider overrides bypass startup Preflight, so validate before setup and execution.
 	if credentialErr := validateProviderCredential(effectiveOpts.Supervisor, opts); credentialErr != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, "supervisor_preflight", "supervisor_config_failed", fmt.Errorf("supervisor is %q: %w", effectiveOpts.Supervisor, credentialErr), runDir)
+		return failClaimedStage(opts.Root, runningPath, &loaded, attemptFailure{Phase: "supervisor_preflight", Kind: "supervisor_config_failed", Err: fmt.Errorf("supervisor is %q: %w", effectiveOpts.Supervisor, credentialErr), ArtifactDir: runDir})
 	}
 	if credentialErr := validateProviderCredential(effectiveExecutor.CLI, opts); credentialErr != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, "executor_preflight", "executor_config_failed", fmt.Errorf("executor is %q: %w", effectiveExecutor.CLI, credentialErr), runDir)
+		return failClaimedStage(opts.Root, runningPath, &loaded, attemptFailure{Phase: "executor_preflight", Kind: "executor_config_failed", Err: fmt.Errorf("executor is %q: %w", effectiveExecutor.CLI, credentialErr), ArtifactDir: runDir})
 	}
 
-	prepared, err := prepareClaimedWorkspace(execCtx, opts, profiles, runningPath, runDir, &loaded, effectiveExecutor)
+	prepared, err := prepareClaimedWorkspace(execCtx, opts, claimedWorkspaceRequest{Profiles: profiles, RunningPath: runningPath, RunDir: runDir, Loaded: &loaded, EffectiveExecutor: effectiveExecutor})
 	if err != nil {
 		return taskstate.FailMoveToStatus(opts.Root, runningPath, &loaded, err)
 	}
-	// Setup runs after workspace preparation and before skeleton or implementation roles.
-	var setupRes *setuppreflight.Result
-	var setupUpdate *setuppreflight.EnvironmentUpdate
-	setupReused := false
-	if prepared.WorktreeReused {
-		setupRes, setupReused, err = reuseReadySetup(opts.Root, loaded.ID, runDir, effectiveExecutor, preflightInputKey("setup", loaded, profiles, prepared, effectiveExecutor))
-		if err != nil {
-			return failClaimedStage(opts.Root, runningPath, &loaded, setuppreflight.Phase, setuppreflight.FailedKind, preflightReuseError(setuppreflight.Phase, err), runDir)
-		}
+	if err := runSetupStage(execCtx, setupStage{
+		Opts:              opts,
+		RunningPath:       runningPath,
+		RunDir:            runDir,
+		Loaded:            &loaded,
+		Prepared:          prepared,
+		Profiles:          profiles,
+		Resolved:          resolvedProfiles,
+		EffectiveExecutor: effectiveExecutor,
+	}); err != nil {
+		return err
 	}
-	var setupErr error
-	if !setupReused {
-		setupRes, setupUpdate, setupErr = setuppreflight.Run(execCtx, setuppreflight.Options{
-			Task:                   task.WithExecutor(loaded, effectiveExecutor),
-			WorkDir:                prepared.CWD,
-			RunDir:                 runDir,
-			Profiles:               profiles,
-			ClaudeBin:              opts.ClaudeBin,
-			CodexBin:               opts.CodexBin,
-			GrokBin:                opts.GrokBin,
-			GLMAuthToken:           opts.GLMAuthToken,
-			KimiAPIKey:             opts.KimiAPIKey,
-			EnvironmentProfilePath: resolvedProfiles.EnvironmentProfileFile,
-			ExecutorRunner:         opts.daemonDependencies().setupExecutorRunner,
-		})
+	if err := runAcceptanceSkeletonStage(execCtx, skeletonPreflightStage{
+		Opts:              opts,
+		RunningPath:       runningPath,
+		RunDir:            runDir,
+		Loaded:            &loaded,
+		Prepared:          prepared,
+		Profiles:          profiles,
+		EffectiveExecutor: effectiveExecutor,
+	}); err != nil {
+		return err
 	}
-	if setupErr != nil {
-		return failClaimedStage(opts.Root, runningPath, &loaded, setuppreflight.Phase, setuppreflight.FailedKind, setupErr, runDir)
-	}
-	if setupUpdate != nil && setupUpdate.Changed && profiles.Environment != nil {
-		profiles.Environment.Setup = &setupUpdate.After
-	}
-	if setupRes != nil && !setupReused {
-		if err := recordPreflightInputs(runDir, "setup", preflightInputKey("setup", loaded, profiles, prepared, effectiveExecutor), runDir); err != nil {
-			return failClaimedStage(opts.Root, runningPath, &loaded, setuppreflight.Phase, setuppreflight.FailedKind, err, runDir)
-		}
-	}
-	// Apply setup readiness evidence (and any persisted profile change) to the
-	// running task before the implementation work order is built so the
-	// supervisor and executor share the same readiness facts.
-	if !setupReused {
-		applySetupResultToTask(&loaded, setupRes, setupUpdate)
-	}
-	if setupRes != nil && !setupReused {
-		if err := task.Save(runningPath, loaded); err != nil {
-			return failClaimedStage(opts.Root, runningPath, &loaded, setuppreflight.Phase, setuppreflight.FailedKind, err, runDir)
-		}
-	}
-	// Optional acceptance skeleton preflight runs after inputfiles.Prepare and
-	// before the first executor attempt. The stage is a no-op when the task
-	// omits preflight.acceptance_skeleton.enabled or sets it to false. When the stage fails the daemon does not run the executor and
-	// surfaces the failure through task status and run evidence.
-	if cfg := loaded.Preflight; cfg != nil && cfg.AcceptanceSkeleton.IsEnabled() {
-		var res *skeletonpreflight.Result
-		preflightReused := false
-		if prepared.WorktreeReused {
-			res, preflightReused, err = reuseCompletedAcceptanceSkeleton(opts.Root, loaded.ID, runDir, effectiveExecutor, preflightInputKey("skeleton", loaded, profiles, prepared, effectiveExecutor), prepared.CWD)
-			if err != nil {
-				return failClaimedStage(opts.Root, runningPath, &loaded, "acceptance_skeleton_preflight", "acceptance_skeleton_preflight_failed", preflightReuseError("acceptance skeleton", err), runDir)
-			}
-		}
-		var perr error
-		if !preflightReused {
-			res, perr = skeletonpreflight.Run(execCtx, skeletonpreflight.Options{
-				Task:         task.WithExecutor(loaded, effectiveExecutor),
-				WorkDir:      prepared.CWD,
-				RunDir:       runDir,
-				Profiles:     profiles,
-				GitBin:       opts.GitBin,
-				ClaudeBin:    opts.ClaudeBin,
-				CodexBin:     opts.CodexBin,
-				GrokBin:      opts.GrokBin,
-				GLMAuthToken: opts.GLMAuthToken,
-				KimiAPIKey:   opts.KimiAPIKey,
-			})
-		}
-		if perr != nil {
-			return failClaimedStage(opts.Root, runningPath, &loaded, "acceptance_skeleton_preflight", "acceptance_skeleton_preflight_failed", perr, runDir)
-		}
-		if res != nil && !preflightReused {
-			if err := recordPreflightInputs(runDir, "skeleton", preflightInputKey("skeleton", loaded, profiles, prepared, effectiveExecutor), runDir); err != nil {
-				return failClaimedStage(opts.Root, runningPath, &loaded, "acceptance_skeleton_preflight", "acceptance_skeleton_preflight_failed", err, runDir)
-			}
-		}
-		if res != nil && !preflightReused {
-			skeletonpreflight.ApplyToTask(&loaded, res)
-			if err := task.Save(runningPath, loaded); err != nil {
-				return failClaimedStage(opts.Root, runningPath, &loaded, "acceptance_skeleton_preflight", "acceptance_skeleton_preflight_failed", err, runDir)
-			}
-			if err := task.Save(runartifact.Path(runDir, runartifact.EffectiveTaskSnapshotFilename), executionTask(loaded, prepared.CWD, effectiveExecutor)); err != nil {
-				return failClaimedStage(opts.Root, runningPath, &loaded, "run_evidence", "run_evidence_failed", err, runDir)
-			}
-		}
-	}
-	return runSupervisorLoop(execCtx, daemonCtx, effectiveOpts, runningPath, &loaded, prepared, profiles, runDir, runID, effectiveExecutor)
+	return runSupervisorLoop(execCtx, daemonCtx, supervisorLoopRequest{Opts: effectiveOpts, RunningPath: runningPath, Loaded: &loaded, Prepared: prepared, Profiles: profiles, RunDir: runDir, RunID: runID, EffectiveExecutor: effectiveExecutor})
 }
 
-func failClaimedStage(root, runningPath string, loaded *task.Task, phase, kind string, err error, runDir string) error {
-	appendFailureAttempt(loaded, phase, kind, err, runDir)
-	return taskstate.FailMoveToStatus(root, runningPath, loaded, err)
+// skeletonPreflightStage is one task's optional acceptance-skeleton preflight,
+// run after inputfiles.Prepare and before the first executor attempt.
+type skeletonPreflightStage struct {
+	Opts              Options
+	RunningPath       string
+	RunDir            string
+	Loaded            *task.Task
+	Prepared          claimedWorkspace
+	Profiles          profile.Bundle
+	EffectiveExecutor task.Executor
+}
+
+// runAcceptanceSkeletonStage is a no-op unless preflight.acceptance_skeleton
+// is enabled. A failure skips the executor and lands in status and run evidence.
+func runAcceptanceSkeletonStage(ctx context.Context, st skeletonPreflightStage) error {
+	cfg := st.Loaded.Preflight
+	if cfg == nil || !cfg.AcceptanceSkeleton.IsEnabled() {
+		return nil
+	}
+	res, reused, err := st.resolveSkeletonResult(ctx)
+	if err != nil {
+		return err
+	}
+	if res == nil || reused {
+		return nil
+	}
+	return st.applySkeletonResult(res)
+}
+
+func (st skeletonPreflightStage) inputKey() string {
+	return preflightInputKey("skeleton", preflightInputSources{
+		Loaded:   *st.Loaded,
+		Profiles: st.Profiles,
+		Prepared: st.Prepared,
+		Executor: st.EffectiveExecutor,
+	})
+}
+
+func (st skeletonPreflightStage) fail(err error) error {
+	return failClaimedStage(st.Opts.Root, st.RunningPath, st.Loaded, attemptFailure{
+		Phase:       "acceptance_skeleton_preflight",
+		Kind:        "acceptance_skeleton_preflight_failed",
+		Err:         err,
+		ArtifactDir: st.RunDir,
+	})
+}
+
+// resolveSkeletonResult reuses a prior run's completed skeleton when the
+// worktree was reused and its inputs still match; otherwise it runs the stage.
+func (st skeletonPreflightStage) resolveSkeletonResult(ctx context.Context) (*skeletonpreflight.Result, bool, error) {
+	res, reused, err := st.reusePriorSkeleton()
+	if err != nil {
+		return nil, false, err
+	}
+	if reused {
+		return res, true, nil
+	}
+	res, err = skeletonpreflight.Run(ctx, skeletonpreflight.Options{
+		Task:         task.WithExecutor(*st.Loaded, st.EffectiveExecutor),
+		WorkDir:      st.Prepared.CWD,
+		RunDir:       st.RunDir,
+		Profiles:     st.Profiles,
+		GitBin:       st.Opts.GitBin,
+		ClaudeBin:    st.Opts.ClaudeBin,
+		CodexBin:     st.Opts.CodexBin,
+		GrokBin:      st.Opts.GrokBin,
+		GLMAuthToken: st.Opts.GLMAuthToken,
+		KimiAPIKey:   st.Opts.KimiAPIKey,
+	})
+	if err != nil {
+		return nil, false, st.fail(err)
+	}
+	return res, false, nil
+}
+
+func (st skeletonPreflightStage) applySkeletonResult(res *skeletonpreflight.Result) error {
+	if err := recordPreflightInputs(st.RunDir, "skeleton", st.inputKey(), st.RunDir); err != nil {
+		return st.fail(err)
+	}
+	skeletonpreflight.ApplyToTask(st.Loaded, res)
+	if err := task.Save(st.RunningPath, *st.Loaded); err != nil {
+		return st.fail(err)
+	}
+	snapshot := executionTask(*st.Loaded, st.Prepared.CWD, st.EffectiveExecutor)
+	if err := task.Save(runartifact.Path(st.RunDir, runartifact.EffectiveTaskSnapshotFilename), snapshot); err != nil {
+		return failClaimedStage(st.Opts.Root, st.RunningPath, st.Loaded, attemptFailure{
+			Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: st.RunDir,
+		})
+	}
+	return nil
+}
+
+// setupStage is one claimed task's setup preflight, which runs after workspace
+// preparation and before the skeleton or implementation roles.
+type setupStage struct {
+	Opts              Options
+	RunningPath       string
+	RunDir            string
+	Loaded            *task.Task
+	Prepared          claimedWorkspace
+	Profiles          profile.Bundle
+	Resolved          resolvedProfileFiles
+	EffectiveExecutor task.Executor
+}
+
+func (st setupStage) inputKey() string {
+	return preflightInputKey("setup", preflightInputSources{
+		Loaded:   *st.Loaded,
+		Profiles: st.Profiles,
+		Prepared: st.Prepared,
+		Executor: st.EffectiveExecutor,
+	})
+}
+
+func (st setupStage) fail(err error) error {
+	return failClaimedStage(st.Opts.Root, st.RunningPath, st.Loaded, attemptFailure{
+		Phase: setuppreflight.Phase, Kind: setuppreflight.FailedKind, Err: err, ArtifactDir: st.RunDir,
+	})
+}
+
+// runSetupStage reuses a prior ready setup when the worktree and inputs match;
+// otherwise it discovers one and applies it for supervisor and executor alike.
+func runSetupStage(ctx context.Context, st setupStage) error {
+	reused, err := st.reusePriorSetup()
+	if err != nil {
+		return err
+	}
+	if reused {
+		return nil
+	}
+	res, update, err := setuppreflight.Run(ctx, setuppreflight.Options{
+		Task:                   task.WithExecutor(*st.Loaded, st.EffectiveExecutor),
+		WorkDir:                st.Prepared.CWD,
+		RunDir:                 st.RunDir,
+		Profiles:               st.Profiles,
+		ClaudeBin:              st.Opts.ClaudeBin,
+		CodexBin:               st.Opts.CodexBin,
+		GrokBin:                st.Opts.GrokBin,
+		GLMAuthToken:           st.Opts.GLMAuthToken,
+		KimiAPIKey:             st.Opts.KimiAPIKey,
+		EnvironmentProfilePath: st.Resolved.EnvironmentProfileFile,
+		ExecutorRunner:         st.Opts.daemonDependencies().setupExecutorRunner,
+	})
+	if err != nil {
+		return st.fail(err)
+	}
+	if update != nil && update.Changed && st.Profiles.Environment != nil {
+		st.Profiles.Environment.Setup = &update.After
+	}
+	if res != nil {
+		if err := recordPreflightInputs(st.RunDir, "setup", st.inputKey(), st.RunDir); err != nil {
+			return st.fail(err)
+		}
+	}
+	applySetupResultToTask(st.Loaded, res, update)
+	if res == nil {
+		return nil
+	}
+	if err := task.Save(st.RunningPath, *st.Loaded); err != nil {
+		return st.fail(err)
+	}
+	return nil
+}
+
+func failClaimedStage(root, runningPath string, loaded *task.Task, failure attemptFailure) error {
+	appendFailureAttempt(loaded, failure)
+	return taskstate.FailMoveToStatus(root, runningPath, loaded, failure.Err)
 }
 
 // loadAndPersistTaskProfiles resolves the quality and environment profiles for
@@ -822,7 +951,7 @@ func applySetupResultToTask(loaded *task.Task, res *setuppreflight.Result, updat
 	if update != nil && update.Changed {
 		// Surface profile changes as a Risk-style entry so task/PR output
 		// records that environment.yaml setup was rewritten.
-		appendRisk(loaded, "setup-profile-updated", "technical_debt", fmt.Sprintf("Setup executor persisted a learned plan to %s (%s). %s", update.ProfilePath, update.Reason, note), "", false)
+		appendRisk(loaded, "setup-profile-updated", riskSpec{Type: "technical_debt", Detail: fmt.Sprintf("Setup executor persisted a learned plan to %s (%s). %s", update.ProfilePath, update.Reason, note), Mitigation: "", HumanReview: false})
 	}
 }
 
@@ -859,7 +988,7 @@ func validateClaimedTask(loaded *task.Task) (task.ValidationResult, error) {
 		return validation, nil
 	}
 	err := fmt.Errorf("task validation failed: %v", validation.Errors)
-	appendFailureAttempt(loaded, "validation", "validation_failed", err, "")
+	appendFailureAttempt(loaded, attemptFailure{Phase: "validation", Kind: "validation_failed", Err: err, ArtifactDir: ""})
 	return validation, err
 }
 
@@ -884,7 +1013,18 @@ type claimedWorkspace struct {
 	ReviewContractContext supervisor.ReviewContractContext
 }
 
-func prepareClaimedWorkspace(ctx context.Context, opts Options, profiles profile.Bundle, runningPath, runDir string, loaded *task.Task, effectiveExecutor task.Executor) (claimedWorkspace, error) {
+// claimedWorkspaceRequest is the claimed task a workspace is prepared for.
+type claimedWorkspaceRequest struct {
+	Profiles          profile.Bundle
+	RunningPath       string
+	RunDir            string
+	Loaded            *task.Task
+	EffectiveExecutor task.Executor
+}
+
+func prepareClaimedWorkspace(ctx context.Context, opts Options, req claimedWorkspaceRequest) (claimedWorkspace, error) {
+	profiles, runningPath, runDir := req.Profiles, req.RunningPath, req.RunDir
+	loaded, effectiveExecutor := req.Loaded, req.EffectiveExecutor
 	wsOpts := workspaceOptions(opts)
 	// Resolve the environment profile pr.base into a concrete git ref name and
 	// pass it through workspace.Options.StartPoint so the new task branch is
@@ -897,31 +1037,31 @@ func prepareClaimedWorkspace(ctx context.Context, opts Options, profiles profile
 	}
 	startPoint, err := resolveWorktreeStartPoint(ctx, opts, loaded.Scope.CWD, prBase)
 	if err != nil {
-		appendFailureAttempt(loaded, "workspace", "workspace_failed", err, runDir)
+		appendFailureAttempt(loaded, attemptFailure{Phase: "workspace", Kind: "workspace_failed", Err: err, ArtifactDir: runDir})
 		return claimedWorkspace{}, err
 	}
 	wsOpts.StartPoint = startPoint
 	prepared, err := workspace.Prepare(ctx, loaded.Scope.CWD, loaded.Worktree, wsOpts)
 	if err != nil {
-		appendFailureAttempt(loaded, "workspace", "workspace_failed", err, runDir)
+		appendFailureAttempt(loaded, attemptFailure{Phase: "workspace", Kind: "workspace_failed", Err: err, ArtifactDir: runDir})
 		return claimedWorkspace{}, err
 	}
-	retainPriorReviewBase(ctx, opts, *loaded, runDir, &prepared)
+	retainPriorReviewBase(ctx, opts, reviewBaseRetention{Loaded: *loaded, RunDir: runDir, Prepared: &prepared})
 	if err := writeJSON(runartifact.Path(runDir, runartifact.WorkspaceFilename), prepared); err != nil {
-		appendFailureAttempt(loaded, "run_evidence", "run_evidence_failed", err, runDir)
+		appendFailureAttempt(loaded, attemptFailure{Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: runDir})
 		return claimedWorkspace{}, err
 	}
 	var priorInputs []inputfiles.Prepared
 	if prepared.WorktreeReused {
 		priorInputs, err = priorPreparedInputs(opts.Root, loaded.ID, runDir, prepared.CWD)
 		if err != nil {
-			appendFailureAttempt(loaded, "input_files", "input_files_failed", err, runDir)
+			appendFailureAttempt(loaded, attemptFailure{Phase: "input_files", Kind: "input_files_failed", Err: err, ArtifactDir: runDir})
 			return claimedWorkspace{}, err
 		}
 	}
 	preparedFiles, err := inputfiles.PrepareReusing(prepared.CWD, loaded.Files, priorInputs)
 	if err != nil {
-		appendFailureAttempt(loaded, "input_files", "input_files_failed", err, runDir)
+		appendFailureAttempt(loaded, attemptFailure{Phase: "input_files", Kind: "input_files_failed", Err: err, ArtifactDir: runDir})
 		return claimedWorkspace{}, err
 	}
 	cleanupPrepared := true
@@ -931,11 +1071,11 @@ func prepareClaimedWorkspace(ctx context.Context, opts Options, profiles profile
 		}
 	}()
 	if err := writeJSON(runartifact.Path(runDir, runartifact.InputFilesFilename), preparedFiles); err != nil {
-		appendFailureAttempt(loaded, "run_evidence", "run_evidence_failed", err, runDir)
+		appendFailureAttempt(loaded, attemptFailure{Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: runDir})
 		return claimedWorkspace{}, err
 	}
 	if prepared.WorktreeReused && prepared.Dirty {
-		appendRisk(loaded, "workspace-dirty", "technical_debt", "Reused worktree had uncommitted changes before executor run.", "Preserved existing worktree state and recorded git status porcelain in workspace.json.", true)
+		appendRisk(loaded, "workspace-dirty", riskSpec{Type: "technical_debt", Detail: "Reused worktree had uncommitted changes before executor run.", Mitigation: "Preserved existing worktree state and recorded git status porcelain in workspace.json.", HumanReview: true})
 		if err := task.Save(runningPath, *loaded); err != nil {
 			return claimedWorkspace{}, err
 		}
@@ -1011,8 +1151,44 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", src, err)
 	}
+	//nolint:gosec // G703: the only caller passes runDir plus a constant filename
 	if err := os.WriteFile(dst, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", dst, err)
 	}
 	return nil
+}
+
+// reusePriorSkeleton reports a prior run's completed skeleton when the worktree
+// was reused and its inputs still match.
+func (st skeletonPreflightStage) reusePriorSkeleton() (*skeletonpreflight.Result, bool, error) {
+	if !st.Prepared.WorktreeReused {
+		return nil, false, nil
+	}
+	res, reused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{
+		Root:      st.Opts.Root,
+		TaskID:    st.Loaded.ID,
+		RunDir:    st.RunDir,
+		Effective: st.EffectiveExecutor,
+		InputKey:  st.inputKey(),
+		WorkDir:   st.Prepared.CWD,
+	})
+	if err != nil {
+		return nil, false, st.fail(preflightReuseError("acceptance skeleton", err))
+	}
+	return res, reused, nil
+}
+
+// reusePriorSetup reports whether a prior run's ready setup still applies.
+func (st setupStage) reusePriorSetup() (bool, error) {
+	if !st.Prepared.WorktreeReused {
+		return false, nil
+	}
+	_, reused, err := reuseReadySetup(preflightReuseQuery{
+		Root: st.Opts.Root, TaskID: st.Loaded.ID, RunDir: st.RunDir,
+		Effective: st.EffectiveExecutor, InputKey: st.inputKey(),
+	})
+	if err != nil {
+		return false, st.fail(preflightReuseError(setuppreflight.Phase, err))
+	}
+	return reused, nil
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -686,7 +686,7 @@ func TestRunOnceCopiesInputFileAndRemovesBeforeCommit(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(worktreePath, "docs", "plan.md")); !os.IsNotExist(err) {
 		t.Fatalf("expected non-committed input file removed before commit, stat err=%v", err)
 	}
-	commitOutput, err := exec.Command("git", "-C", worktreePath, "show", "--name-only", "--format=", "HEAD").Output()
+	commitOutput, err := exec.CommandContext(t.Context(), "git", "-C", worktreePath, "show", "--name-only", "--format=", "HEAD").Output()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1020,7 +1020,7 @@ func initDaemonGitRepo(t *testing.T) string {
 
 func runDaemonGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1030,7 +1030,7 @@ func runDaemonGit(t *testing.T, dir string, args ...string) {
 
 func mustCommandOutput(t *testing.T, name string, args ...string) []byte {
 	t.Helper()
-	output, err := exec.Command(name, args...).CombinedOutput()
+	output, err := exec.CommandContext(t.Context(), name, args...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %v failed: %v\n%s", name, args, err, output)
 	}

--- a/internal/daemon/decode_tolerance_test.go
+++ b/internal/daemon/decode_tolerance_test.go
@@ -114,7 +114,7 @@ func TestPollPRCommentsProcessesUnknownFieldTask(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 
 	// Readable task that should still be requeued.
 	donePath := filepath.Join(root, "tasks", "done", "readable.yaml")
@@ -180,7 +180,7 @@ func TestCleanupWorktreesProcessesUnknownFieldTask(t *testing.T) {
 	if err := queue.EnsureLayout(root); err != nil {
 		t.Fatal(err)
 	}
-	writeDaemonEnvironmentProfile(t, root, repo, false, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: false, ReplyComments: false})
 
 	// Readable task with an open PR worktree.
 	taskPath := filepath.Join(root, "tasks", "done", "readable.yaml")

--- a/internal/daemon/executor_attempt.go
+++ b/internal/daemon/executor_attempt.go
@@ -45,17 +45,38 @@ type attemptOutcome struct {
 // process from blocking shutdown.
 const evidenceCaptureTimeout = 2 * time.Minute
 
-func defaultStageExecutorOutput(ctx context.Context, opts Options, workDir, attemptDir string, excludePaths []string) error {
-	bins := vcsBinaries(opts)
-	statusZ, err := vcs.StatusPorcelainZ(ctx, bins, workDir)
+// stageOutputRequest is one attempt's executor output staging.
+type stageOutputRequest struct {
+	Opts         Options
+	WorkDir      string
+	AttemptDir   string
+	ExcludePaths []string
+}
+
+func defaultStageExecutorOutput(ctx context.Context, req stageOutputRequest) error {
+	excludePaths := req.ExcludePaths
+	repo := vcsRepo(req.Opts, req.WorkDir, req.AttemptDir)
+	statusZ, err := vcs.StatusPorcelainZ(ctx, repo)
 	if err != nil {
 		return err
 	}
 	reviewable := reviewablePathsFromStatus(statusZ, excludePaths)
-	return vcs.StagePathsForReview(ctx, bins, workDir, attemptDir, reviewable)
+	return vcs.StagePathsForReview(ctx, repo, reviewable)
 }
 
-func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, workDir, baseSHA, attemptDir, prompt string) (attemptOutcome, error) {
+// executorAttemptRequest is one executor attempt in a prepared workspace.
+type executorAttemptRequest struct {
+	Opts       Options
+	Loaded     task.Task
+	WorkDir    string
+	BaseSHA    string
+	AttemptDir string
+	Prompt     string
+}
+
+func runExecutorAttempt(ctx context.Context, req executorAttemptRequest) (attemptOutcome, error) {
+	opts, loaded := req.Opts, req.Loaded
+	workDir, baseSHA, attemptDir, prompt := req.WorkDir, req.BaseSHA, req.AttemptDir, req.Prompt
 	attemptCtx := ctx
 	var cancel context.CancelFunc
 	attemptTimeout := time.Duration(loaded.ExecutionPolicy.TimeoutMS) * time.Millisecond
@@ -81,14 +102,14 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, wor
 	}
 	switch transport {
 	case provider.TransportClaude:
-		commandPlan, stdoutPath, stderrPath, err = prepareClaudeExecutorPlan(opts, loaded, workDir, prompt, attemptDir)
+		commandPlan, stdoutPath, stderrPath, err = prepareClaudeExecutorPlan(executorPlanRequest{Opts: opts, Loaded: loaded, WorkDir: workDir, Prompt: prompt, AttemptDir: attemptDir})
 		if err == nil {
 			err = runner.ConfigureClaudeProvider(&commandPlan, claudeProviderOptions(cli, opts))
 		}
 	case provider.TransportCodex:
-		commandPlan, stdoutPath, stderrPath, err = prepareCodexExecutorPlan(opts, loaded, workDir, prompt, attemptDir)
+		commandPlan, stdoutPath, stderrPath, err = prepareCodexExecutorPlan(executorPlanRequest{Opts: opts, Loaded: loaded, WorkDir: workDir, Prompt: prompt, AttemptDir: attemptDir})
 	case provider.TransportGrok:
-		commandPlan, stdoutPath, stderrPath, err = prepareGrokExecutorPlan(opts, loaded, workDir, prompt, attemptDir)
+		commandPlan, stdoutPath, stderrPath, err = prepareGrokExecutorPlan(executorPlanRequest{Opts: opts, Loaded: loaded, WorkDir: workDir, Prompt: prompt, AttemptDir: attemptDir})
 	}
 	if err != nil {
 		return attemptOutcome{}, err
@@ -105,12 +126,8 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, wor
 		return attemptOutcome{}, err
 	}
 	if transport == provider.TransportGrok {
-		data, readErr := os.ReadFile(stdoutPath)
-		if readErr != nil {
-			data = []byte(run.RunResult.Stdout)
-		}
-		if metaErr := runner.WriteGrokCompletionMetadata(runartifact.Path(attemptDir, runartifact.GrokCompletionMetadataFilename), data); metaErr != nil {
-			return attemptOutcome{}, metaErr
+		if err := writeGrokCompletionEvidence(attemptDir, stdoutPath, run.RunResult.Stdout); err != nil {
+			return attemptOutcome{}, err
 		}
 	}
 
@@ -146,7 +163,7 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, wor
 	defer evidenceCancel()
 
 	excludePaths := nonCommittedInputDestinations(loaded.Files)
-	stageErr := opts.daemonDependencies().stageExecutorOutput(evidenceCtx, opts, workDir, attemptDir, excludePaths)
+	stageErr := opts.daemonDependencies().stageExecutorOutput(evidenceCtx, stageOutputRequest{Opts: opts, WorkDir: workDir, AttemptDir: attemptDir, ExcludePaths: excludePaths})
 	if stageErr != nil && !terminal.Interrupted() {
 		// For a normally completed attempt a staging failure is terminal: the
 		// supervisor would otherwise review a stale or empty diff.
@@ -158,7 +175,7 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, wor
 		outcome.EvidenceErr = stageErr
 	}
 
-	diffArtifacts, err := opts.daemonDependencies().captureDiffArtifacts(evidenceCtx, workDir, baseSHA, attemptDir, workspaceOptions(opts))
+	diffArtifacts, err := opts.daemonDependencies().captureDiffArtifacts(evidenceCtx, executorflow.DiffCapture{WorkDir: workDir, BaseSHA: baseSHA, AttemptDir: attemptDir, Opts: workspaceOptions(opts)})
 	if err != nil {
 		if !terminal.Interrupted() {
 			return attemptOutcome{}, err
@@ -173,7 +190,15 @@ func runExecutorAttempt(ctx context.Context, opts Options, loaded task.Task, wor
 	return outcome, nil
 }
 
-func mergeAttemptEvidence(loaded *task.Task, outcome attemptOutcome, runID, workDir, attemptDir string) {
+// attemptEvidencePaths locate one attempt's evidence.
+type attemptEvidencePaths struct {
+	RunID      string
+	WorkDir    string
+	AttemptDir string
+}
+
+func mergeAttemptEvidence(loaded *task.Task, outcome attemptOutcome, paths attemptEvidencePaths) {
+	runID, workDir, attemptDir := paths.RunID, paths.WorkDir, paths.AttemptDir
 	loaded.Attempts = append(loaded.Attempts, task.Attempt{
 		Number:            len(loaded.Attempts) + 1,
 		StartedAt:         outcome.Started.Format(time.RFC3339Nano),
@@ -189,14 +214,14 @@ func mergeAttemptEvidence(loaded *task.Task, outcome attemptOutcome, runID, work
 		OutputExcerpt: fmt.Sprintf("executor stdout/stderr captured under %s; run_result.json contains bounded tails", attemptDir),
 	})
 	if outcome.DiffErr != nil {
-		appendRisk(loaded, "git-diff", "partial_verification", outcome.DiffErr.Error(), "Stored other run evidence; git diff evidence is unavailable.", true)
+		appendRisk(loaded, "git-diff", riskSpec{Type: "partial_verification", Detail: outcome.DiffErr.Error(), Mitigation: "Stored other run evidence; git diff evidence is unavailable.", HumanReview: true})
 	}
 	if outcome.ParseErr != nil {
-		appendRisk(loaded, "executor-result-parse", "partial_verification", outcome.ParseErr.Error(), fmt.Sprintf("Stored raw %s stdout and stderr for supervisor review.", executorArtifactLabel(loaded.Executor.CLI)), true)
+		appendRisk(loaded, "executor-result-parse", riskSpec{Type: "partial_verification", Detail: outcome.ParseErr.Error(), Mitigation: fmt.Sprintf("Stored raw %s stdout and stderr for supervisor review.", executorArtifactLabel(loaded.Executor.CLI)), HumanReview: true})
 		return
 	}
 	if outcome.ExecutorResult.Status == "completed" && outcome.DiffErr == nil && !outcome.DiffDirty {
-		appendRisk(loaded, "git-diff-empty", "partial_verification", "Executor completed but produced no git diff in the execution workspace.", fmt.Sprintf("Stored %s result and raw logs for supervisor review.", executorArtifactLabel(loaded.Executor.CLI)), true)
+		appendRisk(loaded, "git-diff-empty", riskSpec{Type: "partial_verification", Detail: "Executor completed but produced no git diff in the execution workspace.", Mitigation: fmt.Sprintf("Stored %s result and raw logs for supervisor review.", executorArtifactLabel(loaded.Executor.CLI)), HumanReview: true})
 	}
 	for _, verification := range outcome.ExecutorResult.Verification {
 		loaded.Verification.Commands = append(loaded.Verification.Commands, task.VerificationCommand{
@@ -216,10 +241,10 @@ func mergeAttemptEvidence(loaded *task.Task, outcome attemptOutcome, runID, work
 		})
 	}
 	for _, executorRisk := range outcome.ExecutorResult.Risks {
-		appendRisk(loaded, "executor-risk", executorRisk.Type, executorRisk.Detail, executorRisk.Mitigation, executorRisk.NeedsHumanReview)
+		appendRisk(loaded, "executor-risk", riskSpec{Type: executorRisk.Type, Detail: executorRisk.Detail, Mitigation: executorRisk.Mitigation, HumanReview: executorRisk.NeedsHumanReview})
 	}
 	if outcome.ExecutorResult.Status == "hard_stop" && outcome.ExecutorResult.HardStop != nil {
-		appendRisk(loaded, "executor-hard-stop", "other", outcome.ExecutorResult.HardStop.Reason, strings.Join(outcome.ExecutorResult.HardStop.NeededToContinue, "; "), true)
+		appendRisk(loaded, "executor-hard-stop", riskSpec{Type: "other", Detail: outcome.ExecutorResult.HardStop.Reason, Mitigation: strings.Join(outcome.ExecutorResult.HardStop.NeededToContinue, "; "), HumanReview: true})
 	}
 }
 
@@ -253,7 +278,7 @@ func executorAttemptError(outcome attemptOutcome, attemptDir string) *task.Attem
 	if outcome.RunErr == nil {
 		return nil
 	}
-	return attemptError("executor", classifyFailureKind("executor_failed", outcome.RunErr), outcome.RunErr, attemptDir)
+	return attemptError(attemptFailure{Phase: "executor", Kind: classifyFailureKind("executor_failed", outcome.RunErr), Err: outcome.RunErr, ArtifactDir: attemptDir})
 }
 
 // executorInterruptionError signals that an executor attempt did not reach a
@@ -315,15 +340,13 @@ func appendExecutorInterruptionAttempt(loaded *task.Task, outcome attemptOutcome
 		Status:        "failed",
 		OutputExcerpt: fmt.Sprintf("executor interrupted (%s); terminal decision and raw logs captured under %s", outcome.Terminal.Reason, attemptDir),
 	})
-	appendRisk(loaded, "executor-interruption", "external_dependency", message,
-		"Resolve the interruption cause, then run `galley task requeue` to resume from the preserved worktree.", true)
+	appendRisk(loaded, "executor-interruption", riskSpec{Type: "external_dependency", Detail: message, Mitigation: "Resolve the interruption cause, then run `galley task requeue` to resume from the preserved worktree.", HumanReview: true})
 	// CaptureDiffArtifacts reports a snapshot/diff failure in-band as DiffErr (nil
 	// function error), so it is joined with any staging failure. Both surface as
 	// secondary evidence; the interruption stays primary and the worktree keeps
 	// partial changes for requeue.
 	if evidenceErr := errors.Join(outcome.EvidenceErr, outcome.DiffErr); evidenceErr != nil {
-		appendRisk(loaded, "executor-interruption-evidence", "partial_verification", evidenceErr.Error(),
-			"Evidence capture failed after the interruption; the preserved worktree still holds the partial changes for requeue.", true)
+		appendRisk(loaded, "executor-interruption-evidence", riskSpec{Type: "partial_verification", Detail: evidenceErr.Error(), Mitigation: "Evidence capture failed after the interruption; the preserved worktree still holds the partial changes for requeue.", HumanReview: true})
 	}
 }
 
@@ -366,16 +389,16 @@ func appendSupervisorFailureAttempt(loaded *task.Task, outcome attemptOutcome, e
 		ClaudeStatus:      executorStatus(outcome.RunResult, outcome.RunErr),
 		SupervisorVerdict: kind,
 		Summary:           err.Error(),
-		Error:             attemptError("supervisor", kind, err, attemptDir),
+		Error:             attemptError(attemptFailure{Phase: "supervisor", Kind: kind, Err: err, ArtifactDir: attemptDir}),
 	})
 	// A supervisor failure is not a human review decision. Preserve the
 	// evidence as an operational failure so the task can be requeued.
 	loaded.Status = "failed"
 	if supervisor.IsVerdictContractError(err) {
-		appendRisk(loaded, "supervisor-invalid-verdict", "partial_verification", fmt.Sprintf("Supervisor evaluation failed (%s): %s", kind, err.Error()), "Inspect the supervisor-try-1 validation evidence and requeue with the same or another supervisor after correcting the output-contract issue.", true)
+		appendRisk(loaded, "supervisor-invalid-verdict", riskSpec{Type: "partial_verification", Detail: fmt.Sprintf("Supervisor evaluation failed (%s): %s", kind, err.Error()), Mitigation: "Inspect the supervisor-try-1 validation evidence and requeue with the same or another supervisor after correcting the output-contract issue.", HumanReview: true})
 		return
 	}
-	appendRisk(loaded, "supervisor-stall", "partial_verification", fmt.Sprintf("Supervisor evaluation failed (%s): %s", kind, err.Error()), "Inspect the supervisor-try-1 evidence under the attempt directory and requeue the task once the supervisor backend is healthy.", true)
+	appendRisk(loaded, "supervisor-stall", riskSpec{Type: "partial_verification", Detail: fmt.Sprintf("Supervisor evaluation failed (%s): %s", kind, err.Error()), Mitigation: "Inspect the supervisor-try-1 evidence under the attempt directory and requeue the task once the supervisor backend is healthy.", HumanReview: true})
 }
 
 func appendSupervisorIdleTimeoutAttempt(loaded *task.Task, outcome attemptOutcome, idle *supervisorIdleTimeoutError, attemptDir string) {
@@ -395,10 +418,21 @@ func appendSupervisorIdleTimeoutAttempt(loaded *task.Task, outcome attemptOutcom
 		},
 	})
 	loaded.Status = "failed"
-	appendRisk(loaded, "supervisor-idle-timeout", "partial_verification", message, "Inspect the supervisor-try-1 evidence under the attempt directory, then requeue the task or adjust the daemon --idle-timeout or --supervisor settings.", true)
+	appendRisk(loaded, "supervisor-idle-timeout", riskSpec{Type: "partial_verification", Detail: message, Mitigation: "Inspect the supervisor-try-1 evidence under the attempt directory, then requeue the task or adjust the daemon --idle-timeout or --supervisor settings.", HumanReview: true})
 }
 
-func prepareClaudeExecutorPlan(opts Options, loaded task.Task, workDir, prompt, attemptDir string) (proc.Command, string, string, error) {
+// executorPlanRequest is the input to one executor's command plan.
+type executorPlanRequest struct {
+	Opts       Options
+	Loaded     task.Task
+	WorkDir    string
+	Prompt     string
+	AttemptDir string
+}
+
+func prepareClaudeExecutorPlan(req executorPlanRequest) (proc.Command, string, string, error) {
+	opts, loaded := req.Opts, req.Loaded
+	workDir, prompt, attemptDir := req.WorkDir, req.Prompt, req.AttemptDir
 	claudeOpts := runner.FromTask(loaded)
 	claudeOpts.Bin = opts.ClaudeBin
 	claudeOpts.WorkDir = workDir
@@ -407,17 +441,9 @@ func prepareClaudeExecutorPlan(opts Options, loaded task.Task, workDir, prompt, 
 	claudeOpts.AttemptDir = attemptDir
 	claudeOpts.Prompt = prompt
 	if !opts.DisableClaudeGuard {
-		guardDir := opts.ClaudeGuardPluginDir
-		if guardDir == "" {
-			guardDir = filepath.Join(opts.Root, "runtime", "claude-guard-plugin")
-		}
-		guardDir, err := claudeguard.Ensure(guardDir)
+		guardDir, err := resolveClaudeGuardDir(opts)
 		if err != nil {
 			return proc.Command{}, "", "", err
-		}
-		guardDir, err = filepath.Abs(guardDir)
-		if err != nil {
-			return proc.Command{}, "", "", fmt.Errorf("resolve Claude guard plugin dir: %w", err)
 		}
 		claudeOpts.PluginDirs = append(claudeOpts.PluginDirs, guardDir)
 	}
@@ -428,7 +454,9 @@ func prepareClaudeExecutorPlan(opts Options, loaded task.Task, workDir, prompt, 
 	return plan, filepath.Join(attemptDir, "claude.stdout.jsonl"), filepath.Join(attemptDir, "claude.stderr.log"), nil
 }
 
-func prepareCodexExecutorPlan(opts Options, loaded task.Task, workDir, prompt, attemptDir string) (proc.Command, string, string, error) {
+func prepareCodexExecutorPlan(req executorPlanRequest) (proc.Command, string, string, error) {
+	opts, loaded := req.Opts, req.Loaded
+	workDir, prompt, attemptDir := req.WorkDir, req.Prompt, req.AttemptDir
 	codexOpts := runner.CodexFromTask(loaded)
 	codexOpts.Bin = opts.CodexBin
 	codexOpts.WorkDir = workDir
@@ -443,7 +471,9 @@ func prepareCodexExecutorPlan(opts Options, loaded task.Task, workDir, prompt, a
 	return plan, filepath.Join(attemptDir, "codex.stdout.jsonl"), filepath.Join(attemptDir, "codex.stderr.log"), nil
 }
 
-func prepareGrokExecutorPlan(opts Options, loaded task.Task, workDir, prompt, attemptDir string) (proc.Command, string, string, error) {
+func prepareGrokExecutorPlan(req executorPlanRequest) (proc.Command, string, string, error) {
+	opts, loaded := req.Opts, req.Loaded
+	workDir, prompt, attemptDir := req.WorkDir, req.Prompt, req.AttemptDir
 	grokOpts := runner.GrokFromTask(loaded)
 	grokOpts.Bin = opts.GrokBin
 	grokOpts.WorkDir = workDir
@@ -456,4 +486,32 @@ func prepareGrokExecutorPlan(opts Options, loaded task.Task, workDir, prompt, at
 		return proc.Command{}, "", "", err
 	}
 	return plan, filepath.Join(attemptDir, "grok.stdout.json"), filepath.Join(attemptDir, "grok.stderr.log"), nil
+}
+
+// writeGrokCompletionEvidence records Grok's completion metadata, falling back
+// to the captured stdout tail when the stdout file cannot be read.
+func writeGrokCompletionEvidence(attemptDir, stdoutPath, stdoutTail string) error {
+	data, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		data = []byte(stdoutTail)
+	}
+	return runner.WriteGrokCompletionMetadata(runartifact.Path(attemptDir, runartifact.GrokCompletionMetadataFilename), data)
+}
+
+// resolveClaudeGuardDir materializes the Claude guard plugin and returns its
+// absolute path.
+func resolveClaudeGuardDir(opts Options) (string, error) {
+	guardDir := opts.ClaudeGuardPluginDir
+	if guardDir == "" {
+		guardDir = filepath.Join(opts.Root, "runtime", "claude-guard-plugin")
+	}
+	guardDir, err := claudeguard.Ensure(guardDir)
+	if err != nil {
+		return "", err
+	}
+	guardDir, err = filepath.Abs(guardDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve Claude guard plugin dir: %w", err)
+	}
+	return guardDir, nil
 }

--- a/internal/daemon/executor_defaults_preflight_test.go
+++ b/internal/daemon/executor_defaults_preflight_test.go
@@ -133,23 +133,11 @@ esac
   model: "env-model"
   effort: "minimal"
 `,
-			authored:  task.Executor{Model: "task-model"},
-			want:      task.Executor{CLI: "codex", Model: "task-model", Effort: "minimal"},
-			claudeBin: writeFakeClaude(t, "exit 1\n"),
-			codexBin:  codexBin,
-			checkPlans: func(t *testing.T, root string) {
-				argv := readSingleCommandPlan(t, root, "preflight_creator_command_plan.json")
-				joined := strings.Join(argv, " ")
-				if filepath.Base(argv[0]) != "codex" {
-					t.Fatalf("skeleton creator cli = %v, want codex", argv)
-				}
-				if !strings.Contains(joined, "task-model") {
-					t.Fatalf("skeleton creator missing effective model: %v", argv)
-				}
-				if !strings.Contains(joined, `model_reasoning_effort="minimal"`) && !strings.Contains(joined, "model_reasoning_effort=minimal") {
-					t.Fatalf("skeleton creator missing effective effort: %v", argv)
-				}
-			},
+			authored:   task.Executor{Model: "task-model"},
+			want:       task.Executor{CLI: "codex", Model: "task-model", Effort: "minimal"},
+			claudeBin:  writeFakeClaude(t, "exit 1\n"),
+			codexBin:   codexBin,
+			checkPlans: assertCodexCreatorUsesEffectiveExecutor,
 		})
 	})
 
@@ -174,28 +162,11 @@ printf '%s\n' '`+executorResult+`'
   model: "grok-model"
   effort: "none"
 `,
-			authored:  task.Executor{CLI: "claude"},
-			want:      task.Executor{CLI: "claude"},
-			claudeBin: claudeBin,
-			codexBin:  writeFakeCommand(t, "codex", "exit 1\n"),
-			checkPlans: func(t *testing.T, root string) {
-				matches, err := filepath.Glob(filepath.Join(root, "runs", "*", "*_command_plan.json"))
-				if err != nil || len(matches) == 0 {
-					t.Fatalf("command plan glob = %v (err %v)", matches, err)
-				}
-				for _, planPath := range matches {
-					argv := readCommandPlanArgv(t, planPath)
-					for _, arg := range argv {
-						if arg == "--model" || arg == "--effort" || arg == "grok-model" || arg == "none" {
-							t.Fatalf("plan %s carries environment model or effort override %q: %v", planPath, arg, argv)
-						}
-					}
-				}
-				creator := readSingleCommandPlan(t, root, "preflight_creator_command_plan.json")
-				if filepath.Base(creator[0]) != "claude" {
-					t.Fatalf("skeleton creator cli = %v, want claude", creator)
-				}
-			},
+			authored:   task.Executor{CLI: "claude"},
+			want:       task.Executor{CLI: "claude"},
+			claudeBin:  claudeBin,
+			codexBin:   writeFakeCommand(t, "codex", "exit 1\n"),
+			checkPlans: assertNoEnvironmentOverridesLeakIntoPlans,
 		})
 	})
 }
@@ -255,7 +226,8 @@ setup:
 		}, nil
 	})
 
-	supervisorRunner := func(_ context.Context, _ Options, evidence supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+	supervisorRunner := func(_ context.Context, req supervisorRunRequest) (supervisor.Verdict, error) {
+		evidence := req.Evidence
 		supervisorExecutor = evidence.Task.Executor
 		return supervisor.Verdict{Status: "accepted", Summary: "effective executor observed"}, nil
 	}
@@ -437,7 +409,8 @@ case "$input" in
 esac
 `)
 	claudeBin := writeFakeClaude(t, "exit 1\n")
-	supervisorRunner := func(_ context.Context, _ Options, evidence supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+	supervisorRunner := func(_ context.Context, req supervisorRunRequest) (supervisor.Verdict, error) {
+		evidence := req.Evidence
 		supervisorExecutor = evidence.Task.Executor
 		return supervisor.Verdict{Status: "accepted", Summary: "empty effort observed"}, nil
 	}
@@ -541,28 +514,7 @@ func TestDaemonRequeuePicksUpChangedEnvironmentExecutorDefaults(t *testing.T) {
 	var setupCalls []observed
 
 	envDir := t.TempDir()
-	envBody := func(cli, model, effort string) string {
-		return `id: "requeue-env"
-cwd: ` + workdirQuote(repo) + `
-commands:
-  test_unit: "true"
-executor:
-  default_cli: "` + cli + `"
-  model: "` + model + `"
-  effort: "` + effort + `"
-constraints:
-  network: "approval_required"
-  secrets_policy: "never_read_env_files"
-  destructive_commands: "deny"
-setup:
-  commands:
-    - run: "true"
-      why: "no-op setup"
-worktree:
-  cleanup: false
-`
-	}
-	envPath := writeSetupEnvironmentProfile(t, envDir, envBody("codex", "env-model-v1", "minimal"))
+	envPath := writeSetupEnvironmentProfile(t, envDir, requeueEnvBody(repo, "codex", "env-model-v1", "minimal"))
 
 	withSetupExecutorRunner(t, func(_ context.Context, opts setuppreflight.Options) (*setuppreflight.Result, error) {
 		setupCalls = append(setupCalls, observed{
@@ -591,48 +543,8 @@ worktree:
 	creatorManifest := `{"outputs":[{"ac_id":"AC1","path":"internal/foo/foo_test.go","kind":"go-test","purpose":"verify AC1","satisfies":"AC1 observable behavior","integration_point":"executor completes this skeleton before acceptance","implementation_required":true}],"no_skeletons":[]}`
 	executorResult := `{"status":"completed","summary":"done","files_modified":["daemon-output.txt","internal/foo/foo_test.go"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}`
 	// Both fake backends distinguish skeleton and implementation prompts.
-	codexBin := writeFakeCommand(t, "codex", `out=""
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --output-last-message)
-      out="$2"
-      shift 2
-      ;;
-    *)
-      shift
-      ;;
-  esac
-done
-input="$(cat)"
-case "$input" in
-  *"acceptance skeleton creator"*)
-    mkdir -p internal/foo
-    printf 'package foo_test\n' > internal/foo/foo_test.go
-    printf '%s\n' '`+creatorManifest+`' > "$out"
-    ;;
-  *)
-    echo change > daemon-output.txt
-    printf '%s\n' '`+executorResult+`' > "$out"
-    printf '%s\n' '{"type":"turn.completed","usage":{}}'
-    ;;
-esac
-`)
-	claudeBin := writeFakeClaude(t, `creator=0
-for arg in "$@"; do
-  case "$arg" in
-    *"Galley Acceptance Skeleton Manifest"*) creator=1 ;;
-  esac
-done
-if [ "$creator" = "1" ]; then
-  mkdir -p internal/foo
-  # Always rewrite so reused worktrees still record a creator workspace change.
-  printf 'package foo_test\n// requeue-creator-%s\n' "$(date +%s%N)" > internal/foo/foo_test.go
-  printf '%s\n' '{"type":"result","result":"{\"outputs\":[{\"ac_id\":\"AC1\",\"path\":\"internal/foo/foo_test.go\",\"kind\":\"go-test\",\"purpose\":\"verify AC1\",\"satisfies\":\"AC1 observable behavior\",\"integration_point\":\"executor completes this skeleton before acceptance\",\"implementation_required\":true}],\"no_skeletons\":[]}"}'
-  exit 0
-fi
-echo change > daemon-output.txt
-printf '%s\n' '`+executorResult+`'
-`)
+	codexBin := writeRequeueCodexBackend(t, creatorManifest, executorResult)
+	claudeBin := writeRequeueClaudeBackend(t, executorResult)
 
 	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
 	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
@@ -671,30 +583,14 @@ printf '%s\n' '`+executorResult+`'
 		t.Fatalf("first setup effective = %#v, want %#v", setupCalls[0], wantFirst)
 	}
 
-	firstSetupMatches, err := filepath.Glob(filepath.Join(root, "runs", "*", "setup_result.json"))
-	if err != nil || len(firstSetupMatches) != 1 {
-		t.Fatalf("first setup_result.json glob = %v err %v", firstSetupMatches, err)
-	}
-	firstSetupData, err := os.ReadFile(firstSetupMatches[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	var firstSetup setuppreflight.Result
-	if err := json.Unmarshal(firstSetupData, &firstSetup); err != nil {
-		t.Fatal(err)
-	}
-	if firstSetup.ExecutorCLI != "codex" || firstSetup.ExecutorModel != "task-model" || firstSetup.ExecutorEffort != "minimal" {
-		t.Fatalf("first setup identity = cli=%q model=%q effort=%q", firstSetup.ExecutorCLI, firstSetup.ExecutorModel, firstSetup.ExecutorEffort)
-	}
+	assertSetupIdentity(t, loadSingleSetupResult(t, root), executorIdentity{CLI: "codex", Model: "task-model", Effort: "minimal"})
 
 	donePath := filepath.Join(root, "tasks", "done", "task.yaml")
 	done, err := task.Load(donePath)
 	if err != nil {
 		t.Fatalf("first done task: %v", err)
 	}
-	if done.Executor.CLI != "" || done.Executor.Effort != "" || done.Executor.Model != "task-model" {
-		t.Fatalf("authored executor must stay partial after first run, got %#v", done.Executor)
-	}
+	assertAuthoredExecutorStaysPartial(t, done.Executor, "first run")
 	retainedSkeleton := filepath.Join(taskWorktreePath(repo, done.Worktree.Path), "internal/foo/foo_test.go")
 	if err := os.WriteFile(retainedSkeleton, []byte("package foo_test\n// retained executor work\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -713,16 +609,14 @@ printf '%s\n' '`+executorResult+`'
 		t.Fatalf("lost existing skeleton implementation: %q %v", data, err)
 	}
 
-	if err := os.WriteFile(envPath, []byte(envBody("claude", "env-model-v2", "xhigh")), 0o600); err != nil {
+	if err := os.WriteFile(envPath, []byte(requeueEnvBody(repo, "claude", "env-model-v2", "xhigh")), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	requeued, err := task.Requeue(donePath, task.RequeueOptions{Root: root, Reason: "env defaults changed"})
 	if err != nil {
 		t.Fatalf("requeue: %v", err)
 	}
-	if requeued.Task.Executor.CLI != "" || requeued.Task.Executor.Effort != "" || requeued.Task.Executor.Model != "task-model" {
-		t.Fatalf("requeued authored executor must stay partial, got %#v", requeued.Task.Executor)
-	}
+	assertAuthoredExecutorStaysPartial(t, requeued.Task.Executor, "requeue")
 
 	if err := runTestDaemon(context.Background(), opts); err != nil {
 		t.Fatalf("second run: %v", err)
@@ -735,32 +629,7 @@ printf '%s\n' '`+executorResult+`'
 		t.Fatalf("second setup effective = %#v, want %#v", setupCalls[1], wantSecond)
 	}
 
-	plans, err := filepath.Glob(filepath.Join(root, "runs", "*", "preflight_creator_command_plan.json"))
-	if err != nil || len(plans) == 0 {
-		t.Fatalf("preflight_creator_command_plan.json glob = %v err %v", plans, err)
-	}
-	newestPlan := plans[0]
-	newestMod := int64(0)
-	for _, p := range plans {
-		st, err := os.Stat(p)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if st.ModTime().UnixNano() >= newestMod {
-			newestMod = st.ModTime().UnixNano()
-			newestPlan = p
-		}
-	}
-	planData, err := os.ReadFile(newestPlan)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var plan struct {
-		Argv []string `json:"argv"`
-	}
-	if err := json.Unmarshal(planData, &plan); err != nil {
-		t.Fatal(err)
-	}
+	plan := readNewestCreatorPlan(t, root)
 	joined := strings.Join(plan.Argv, " ")
 	if filepath.Base(plan.Argv[0]) != "claude" {
 		t.Fatalf("second skeleton creator cli = %v, want claude", plan.Argv)
@@ -772,28 +641,225 @@ printf '%s\n' '`+executorResult+`'
 		t.Fatalf("second skeleton creator missing new effort: %v", plan.Argv)
 	}
 
-	done2, err := task.Load(filepath.Join(root, "tasks", "done", filepath.Base(requeued.To)))
+	done2 := loadDoneTaskByNameOrScan(t, filepath.Join(root, "tasks", "done"), filepath.Base(requeued.To))
+	assertAuthoredExecutorStaysPartial(t, done2.Executor, "second run")
+	assertVerificationContainsCommand(t, done2.Verification.Commands, "claude")
+}
+
+// loadDoneTaskByNameOrScan loads the requeued task from tasks/done. Requeue may
+// rename the file, so the directory is scanned when the expected name is gone.
+func loadDoneTaskByNameOrScan(t *testing.T, doneDir, name string) task.Task {
+	t.Helper()
+	loaded, err := task.Load(filepath.Join(doneDir, name))
+	if err == nil {
+		return loaded
+	}
+	entries, readErr := os.ReadDir(doneDir)
+	if readErr != nil || len(entries) == 0 {
+		t.Fatalf("second done task: %v (scan err %v)", err, readErr)
+	}
+	loaded, err = task.Load(filepath.Join(doneDir, entries[0].Name()))
 	if err != nil {
-		entries, readErr := os.ReadDir(filepath.Join(root, "tasks", "done"))
-		if readErr != nil || len(entries) == 0 {
-			t.Fatalf("second done task: %v (scan err %v)", err, readErr)
+		t.Fatalf("second done task load: %v", err)
+	}
+	return loaded
+}
+
+func assertVerificationContainsCommand(t *testing.T, commands []task.VerificationCommand, want string) {
+	t.Helper()
+	for _, vc := range commands {
+		if strings.Contains(vc.Cmd, want) {
+			return
 		}
-		done2, err = task.Load(filepath.Join(root, "tasks", "done", entries[0].Name()))
+	}
+	t.Fatalf("verification history missing %q command: %#v", want, commands)
+}
+
+func assertCodexCreatorUsesEffectiveExecutor(t *testing.T, root string) {
+	t.Helper()
+	argv := readSingleCommandPlan(t, root, "preflight_creator_command_plan.json")
+	joined := strings.Join(argv, " ")
+	if filepath.Base(argv[0]) != "codex" {
+		t.Fatalf("skeleton creator cli = %v, want codex", argv)
+	}
+	if !strings.Contains(joined, "task-model") {
+		t.Fatalf("skeleton creator missing effective model: %v", argv)
+	}
+	if !strings.Contains(joined, `model_reasoning_effort="minimal"`) && !strings.Contains(joined, "model_reasoning_effort=minimal") {
+		t.Fatalf("skeleton creator missing effective effort: %v", argv)
+	}
+}
+
+// assertNoEnvironmentOverridesLeakIntoPlans pins that a task-selected cli keeps
+// the environment profile's model and effort out of every command plan.
+func assertNoEnvironmentOverridesLeakIntoPlans(t *testing.T, root string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "runs", "*", "*_command_plan.json"))
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("command plan glob = %v (err %v)", matches, err)
+	}
+	for _, planPath := range matches {
+		argv := readCommandPlanArgv(t, planPath)
+		for _, arg := range argv {
+			if arg == "--model" || arg == "--effort" || arg == "grok-model" || arg == "none" {
+				t.Fatalf("plan %s carries environment model or effort override %q: %v", planPath, arg, argv)
+			}
+		}
+	}
+	creator := readSingleCommandPlan(t, root, "preflight_creator_command_plan.json")
+	if filepath.Base(creator[0]) != "claude" {
+		t.Fatalf("skeleton creator cli = %v, want claude", creator)
+	}
+}
+
+// creatorPlan is the persisted skeleton-creator command plan.
+type creatorPlan struct {
+	Argv []string `json:"argv"`
+}
+
+// readNewestCreatorPlan returns the most recently written skeleton-creator
+// plan, which belongs to the latest run.
+func readNewestCreatorPlan(t *testing.T, root string) creatorPlan {
+	t.Helper()
+	plans, err := filepath.Glob(filepath.Join(root, "runs", "*", "preflight_creator_command_plan.json"))
+	if err != nil || len(plans) == 0 {
+		t.Fatalf("preflight_creator_command_plan.json glob = %v err %v", plans, err)
+	}
+	newestPath := plans[0]
+	newestMod := int64(0)
+	for _, path := range plans {
+		st, err := os.Stat(path)
 		if err != nil {
-			t.Fatalf("second done task load: %v", err)
+			t.Fatal(err)
+		}
+		if st.ModTime().UnixNano() >= newestMod {
+			newestMod = st.ModTime().UnixNano()
+			newestPath = path
 		}
 	}
-	if done2.Executor.CLI != "" || done2.Executor.Effort != "" || done2.Executor.Model != "task-model" {
-		t.Fatalf("authored executor must stay partial after second run, got %#v", done2.Executor)
+	data, err := os.ReadFile(newestPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	foundClaude := false
-	for _, vc := range done2.Verification.Commands {
-		if strings.Contains(vc.Cmd, "claude") {
-			foundClaude = true
-			break
-		}
+	var plan creatorPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		t.Fatal(err)
 	}
-	if !foundClaude {
-		t.Fatalf("second implementation verification missing claude command: %#v", done2.Verification.Commands)
+	return plan
+}
+
+// loadSingleSetupResult reads the one setup_result.json the run produced.
+func loadSingleSetupResult(t *testing.T, root string) setuppreflight.Result {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "runs", "*", "setup_result.json"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("setup_result.json glob = %v (err %v)", matches, err)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result setuppreflight.Result
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+// requeueEnvBody renders an environment profile whose executor defaults the
+// requeue test changes between runs.
+func requeueEnvBody(repo, cli, model, effort string) string {
+	return `id: "requeue-env"
+cwd: ` + workdirQuote(repo) + `
+commands:
+  test_unit: "true"
+executor:
+  default_cli: "` + cli + `"
+  model: "` + model + `"
+  effort: "` + effort + `"
+constraints:
+  network: "approval_required"
+  secrets_policy: "never_read_env_files"
+  destructive_commands: "deny"
+setup:
+  commands:
+    - run: "true"
+      why: "no-op setup"
+worktree:
+  cleanup: false
+`
+}
+
+func writeRequeueCodexBackend(t *testing.T, creatorManifest, executorResult string) string {
+	t.Helper()
+	return writeFakeCommand(t, "codex", `out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-last-message)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+input="$(cat)"
+case "$input" in
+  *"acceptance skeleton creator"*)
+    mkdir -p internal/foo
+    printf 'package foo_test\n' > internal/foo/foo_test.go
+    printf '%s\n' '`+creatorManifest+`' > "$out"
+    ;;
+  *)
+    echo change > daemon-output.txt
+    printf '%s\n' '`+executorResult+`' > "$out"
+    printf '%s\n' '{"type":"turn.completed","usage":{}}'
+    ;;
+esac
+`)
+}
+
+func writeRequeueClaudeBackend(t *testing.T, executorResult string) string {
+	t.Helper()
+	return writeFakeClaude(t, `creator=0
+for arg in "$@"; do
+  case "$arg" in
+    *"Galley Acceptance Skeleton Manifest"*) creator=1 ;;
+  esac
+done
+if [ "$creator" = "1" ]; then
+  mkdir -p internal/foo
+  # Always rewrite so reused worktrees still record a creator workspace change.
+  printf 'package foo_test\n// requeue-creator-%s\n' "$(date +%s%N)" > internal/foo/foo_test.go
+  printf '%s\n' '{"type":"result","result":"{\"outputs\":[{\"ac_id\":\"AC1\",\"path\":\"internal/foo/foo_test.go\",\"kind\":\"go-test\",\"purpose\":\"verify AC1\",\"satisfies\":\"AC1 observable behavior\",\"integration_point\":\"executor completes this skeleton before acceptance\",\"implementation_required\":true}],\"no_skeletons\":[]}"}'
+  exit 0
+fi
+echo change > daemon-output.txt
+printf '%s\n' '`+executorResult+`'
+`)
+}
+
+// executorIdentity is the resolved executor a stage must have used.
+type executorIdentity struct {
+	CLI    string
+	Model  string
+	Effort string
+}
+
+func assertSetupIdentity(t *testing.T, result setuppreflight.Result, want executorIdentity) {
+	t.Helper()
+	got := executorIdentity{CLI: result.ExecutorCLI, Model: result.ExecutorModel, Effort: result.ExecutorEffort}
+	if got != want {
+		t.Fatalf("setup identity = %#v, want %#v", got, want)
+	}
+}
+
+// assertAuthoredExecutorStaysPartial pins that resolving an effective executor
+// never writes the resolved cli or effort back onto the authored task.
+func assertAuthoredExecutorStaysPartial(t *testing.T, executor task.Executor, stage string) {
+	t.Helper()
+	if executor.CLI != "" || executor.Effort != "" || executor.Model != "task-model" {
+		t.Fatalf("authored executor must stay partial after %s, got %#v", stage, executor)
 	}
 }

--- a/internal/daemon/executor_interruption_test.go
+++ b/internal/daemon/executor_interruption_test.go
@@ -15,17 +15,16 @@ import (
 	"github.com/shinpr/galley/internal/runner"
 	"github.com/shinpr/galley/internal/supervisor"
 	"github.com/shinpr/galley/internal/task"
-	"github.com/shinpr/galley/internal/workspace"
 )
 
-func countingSupervisor(calls *int32, verdict func(attempt int) supervisor.Verdict) func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error) {
-	return func(_ context.Context, _ Options, _ supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+func countingSupervisor(calls *int32, verdict func(attempt int) supervisor.Verdict) func(context.Context, supervisorRunRequest) (supervisor.Verdict, error) {
+	return func(_ context.Context, _ supervisorRunRequest) (supervisor.Verdict, error) {
 		n := atomic.AddInt32(calls, 1)
 		return verdict(int(n)), nil
 	}
 }
 
-func withSupervisorSeam(opts Options, seam func(context.Context, Options, supervisor.Evidence, string, string) (supervisor.Verdict, error)) Options {
+func withSupervisorSeam(opts Options, seam func(context.Context, supervisorRunRequest) (supervisor.Verdict, error)) Options {
 	deps := opts.daemonDependencies()
 	deps.supervisorRunner = seam
 	opts.dependencies = &deps
@@ -116,79 +115,124 @@ func TestExecutorInterruptionLifecycleMatrix(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			root := filepath.Join(t.TempDir(), ".agent-workflow")
-			repo := initDaemonGitRepo(t)
-			promptPath, schemaPath := writeDaemonPromptFiles(t)
-			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
-			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			writeDaemonTask(t, taskPath, repo)
-			setExecutorCLI(t, taskPath, tc.cli)
-			setLoopBudget(t, taskPath, 2)
-
-			opts := Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude"}
-			switch tc.cli {
-			case "codex":
-				opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
-				opts.CodexBin = writeRawExecutor(t, "codex", tc.stdout)
-			case "grok":
-				opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
-				opts.GrokBin = writeRawExecutor(t, "grok", tc.stdout)
-			case "glm":
-				opts.ClaudeBin = writeRawExecutor(t, "claude", tc.stdout)
-				opts.GLMAuthToken = "test-glm-token"
-			default:
-				opts.ClaudeBin = writeRawExecutor(t, "claude", tc.stdout)
-			}
-
 			var supCalls int32
-			opts = testDaemonOptions(opts)
-			opts = withSupervisorSeam(opts, countingSupervisor(&supCalls, func(int) supervisor.Verdict {
-				t.Errorf("supervisor must not run for a %s interruption", tc.name)
-				return supervisor.Verdict{Status: "accepted"}
-			}))
-			_ = Run(context.Background(), opts)
+			runInterruptedExecutor(t, interruptedRun{
+				Root: root, CaseName: tc.name, CLI: tc.cli, Stdout: tc.stdout, SupCalls: &supCalls,
+			})
 
 			failed := assertInterruptedFailedTask(t, root, &supCalls)
 			last := failed.Attempts[len(failed.Attempts)-1]
 			if last.Error.Kind != "executor_interrupted" {
 				t.Fatalf("error kind = %q, want executor_interrupted", last.Error.Kind)
 			}
-			for _, want := range tc.wantMessage {
-				if !strings.Contains(last.Error.Message, want) {
-					t.Fatalf("attempt error message missing %q: %q", want, last.Error.Message)
-				}
-			}
-			for _, unwanted := range tc.notMessage {
-				if strings.Contains(last.Error.Message, unwanted) {
-					t.Fatalf("attempt error message must not contain %q: %q", unwanted, last.Error.Message)
-				}
-			}
+			assertMessageContent(t, last.Error.Message, tc.wantMessage, tc.notMessage)
 			// task show consumes these fields to render the interruption and
 			// requeue recovery (see cli.isExecutorInterruption).
 			if last.Error.Phase != "executor" || last.SupervisorVerdict != "not_reviewed" || last.Error.ArtifactDir == "" {
 				t.Fatalf("task-show fields incomplete: %#v", last.Error)
 			}
-			terminalData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename))
-			var terminal runner.ExecutorTerminal
-			if err := json.Unmarshal(terminalData, &terminal); err != nil {
-				t.Fatalf("decode executor_terminal.json: %v", err)
-			}
-			if terminal.Normal {
-				t.Fatalf("executor_terminal.json Normal = true, want interrupted: %s", terminalData)
-			}
-			if terminal.Reason != tc.wantReason {
-				t.Fatalf("executor_terminal.json reason = %q, want %q", terminal.Reason, tc.wantReason)
-			}
-			if terminal.Provider != tc.wantProvider {
-				t.Fatalf("executor_terminal.json provider = %q, want %q", terminal.Provider, tc.wantProvider)
-			}
-			for _, want := range tc.wantMessage {
-				if !strings.Contains(string(terminalData), want) {
-					t.Fatalf("executor_terminal.json missing detail %q: %s", want, terminalData)
-				}
-			}
+			assertExecutorTerminalEvidence(t, root, terminalExpectation{
+				Reason: tc.wantReason, Provider: tc.wantProvider, Details: tc.wantMessage,
+			})
 		})
+	}
+}
+
+// interruptedRun is one task whose executor emits an interrupted terminal.
+type interruptedRun struct {
+	Root     string
+	CaseName string
+	CLI      string
+	Stdout   string
+	SupCalls *int32
+}
+
+// runInterruptedExecutor drives the task with a supervisor seam that must never
+// fire, so the test can prove the interruption bypasses review.
+func runInterruptedExecutor(t *testing.T, run interruptedRun) {
+	t.Helper()
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	taskPath := filepath.Join(run.Root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	setExecutorCLI(t, taskPath, run.CLI)
+	setLoopBudget(t, taskPath, 2)
+
+	opts := Options{Root: run.Root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude"}
+	applyInterruptedExecutorBins(t, &opts, run.CLI, run.Stdout)
+
+	opts = testDaemonOptions(opts)
+	opts = withSupervisorSeam(opts, countingSupervisor(run.SupCalls, func(int) supervisor.Verdict {
+		t.Errorf("supervisor must not run for a %s interruption", run.CaseName)
+		return supervisor.Verdict{Status: "accepted"}
+	}))
+	_ = Run(context.Background(), opts)
+}
+
+// applyInterruptedExecutorBins points the selected executor at a verbatim-stdout
+// fake; other providers keep a failing stub so a misdispatch is visible.
+func applyInterruptedExecutorBins(t *testing.T, opts *Options, cli, stdout string) {
+	t.Helper()
+	switch cli {
+	case "codex":
+		opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
+		opts.CodexBin = writeRawExecutor(t, "codex", stdout)
+	case "grok":
+		opts.ClaudeBin = writeFakeClaude(t, "exit 1\n")
+		opts.GrokBin = writeRawExecutor(t, "grok", stdout)
+	case "glm":
+		opts.ClaudeBin = writeRawExecutor(t, "claude", stdout)
+		opts.GLMAuthToken = "test-glm-token"
+	default:
+		opts.ClaudeBin = writeRawExecutor(t, "claude", stdout)
+	}
+}
+
+func assertMessageContent(t *testing.T, message string, want, unwanted []string) {
+	t.Helper()
+	for _, w := range want {
+		if !strings.Contains(message, w) {
+			t.Fatalf("attempt error message missing %q: %q", w, message)
+		}
+	}
+	for _, u := range unwanted {
+		if strings.Contains(message, u) {
+			t.Fatalf("attempt error message must not contain %q: %q", u, message)
+		}
+	}
+}
+
+// terminalExpectation is what executor_terminal.json must record for one
+// interrupted attempt.
+type terminalExpectation struct {
+	Reason   string
+	Provider string
+	Details  []string
+}
+
+func assertExecutorTerminalEvidence(t *testing.T, root string, want terminalExpectation) {
+	t.Helper()
+	terminalData := mustReadSingleGlob(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.ExecutorTerminalFilename))
+	var terminal runner.ExecutorTerminal
+	if err := json.Unmarshal(terminalData, &terminal); err != nil {
+		t.Fatalf("decode executor_terminal.json: %v", err)
+	}
+	if terminal.Normal {
+		t.Fatalf("executor_terminal.json Normal = true, want interrupted: %s", terminalData)
+	}
+	if terminal.Reason != want.Reason {
+		t.Fatalf("executor_terminal.json reason = %q, want %q", terminal.Reason, want.Reason)
+	}
+	if terminal.Provider != want.Provider {
+		t.Fatalf("executor_terminal.json provider = %q, want %q", terminal.Provider, want.Provider)
+	}
+	for _, detail := range want.Details {
+		if !strings.Contains(string(terminalData), detail) {
+			t.Fatalf("executor_terminal.json missing detail %q: %s", detail, terminalData)
+		}
 	}
 }
 
@@ -205,7 +249,7 @@ func TestInterruptedExecutorStagingFailureStaysInterrupted(t *testing.T) {
 	writeDaemonTask(t, taskPath, repo)
 	setLoopBudget(t, taskPath, 3)
 
-	stageFail := func(_ context.Context, _ Options, _, _ string, _ []string) error {
+	stageFail := func(_ context.Context, _ stageOutputRequest) error {
 		return context.Canceled
 	}
 	var supCalls int32
@@ -255,7 +299,7 @@ func TestInterruptedExecutorDiffCaptureFailureStaysInterrupted(t *testing.T) {
 	writeDaemonTask(t, taskPath, repo)
 	setLoopBudget(t, taskPath, 3)
 
-	diffFail := func(_ context.Context, _, _, _ string, _ workspace.Options) (executorflow.DiffArtifacts, error) {
+	diffFail := func(_ context.Context, _ executorflow.DiffCapture) (executorflow.DiffArtifacts, error) {
 		return executorflow.DiffArtifacts{Err: errors.New("git status: snapshot failed")}, nil
 	}
 	var supCalls int32
@@ -386,14 +430,15 @@ func TestInterruptionPreservesWorkspaceAndRequeueReuses(t *testing.T) {
 		if err := json.Unmarshal(data, &prepared); err != nil {
 			continue
 		}
-		if prepared.WorktreeReused {
-			reuseFound = true
-			if !prepared.Dirty {
-				t.Fatalf("reused worktree evidence must be dirty: %s", data)
-			}
-			if !strings.Contains(prepared.StatusPorcelain, "new-file.txt") {
-				t.Fatalf("reused worktree must still show retained change: %s", data)
-			}
+		if !prepared.WorktreeReused {
+			continue
+		}
+		reuseFound = true
+		if !prepared.Dirty {
+			t.Fatalf("reused worktree evidence must be dirty: %s", data)
+		}
+		if !strings.Contains(prepared.StatusPorcelain, "new-file.txt") {
+			t.Fatalf("reused worktree must still show retained change: %s", data)
 		}
 	}
 	if !reuseFound {

--- a/internal/daemon/executor_result_resolver.go
+++ b/internal/daemon/executor_result_resolver.go
@@ -38,11 +38,11 @@ func resolveExecutorResult(cli, stdoutPath, stdoutTail, lastMessagePath string) 
 	}
 	var resultErrs []error
 	if transport == provider.TransportCodex && lastMessagePath != "" {
-		if lastResult, lastErr := runner.ExtractCodexLastMessageFile(lastMessagePath); lastErr == nil {
+		lastResult, lastErr := runner.ExtractCodexLastMessageFile(lastMessagePath)
+		if lastErr == nil {
 			return lastResult, nil
-		} else {
-			resultErrs = append(resultErrs, fmt.Errorf("codex last-message parse failed: %w", lastErr))
 		}
+		resultErrs = append(resultErrs, fmt.Errorf("codex last-message parse failed: %w", lastErr))
 	}
 
 	fileResult, fileErr := runner.ExtractExecutorResultFile(stdoutPath)
@@ -78,15 +78,21 @@ func classifyExecutorTerminal(cli, stdoutPath, stdoutTail string, runErr error) 
 		return runner.GrokTerminal(data, runErr)
 	case provider.TransportCodex:
 		return runner.CodexTerminal(readExecutorStdout(stdoutPath, stdoutTail), runErr)
+	case provider.TransportClaude:
+		return claudeExecutorTerminal(cli, stdoutPath, stdoutTail, runErr)
 	default:
-		// cli is "claude", "glm", or empty (defaulting to claude); GLM shares
-		// Claude's transport but keeps its own provider identity in evidence.
-		providerID := cli
-		if providerID == "" {
-			providerID = "claude"
-		}
-		return runner.ClaudeTerminal(providerID, readExecutorStdout(stdoutPath, stdoutTail), runErr)
+		return claudeExecutorTerminal(cli, stdoutPath, stdoutTail, runErr)
 	}
+}
+
+// cli is "claude", "glm", or empty (defaulting to claude); GLM shares Claude's
+// transport but keeps its own provider identity in evidence.
+func claudeExecutorTerminal(cli, stdoutPath, stdoutTail string, runErr error) runner.ExecutorTerminal {
+	providerID := cli
+	if providerID == "" {
+		providerID = "claude"
+	}
+	return runner.ClaudeTerminal(providerID, readExecutorStdout(stdoutPath, stdoutTail), runErr)
 }
 
 func readExecutorStdout(stdoutPath, stdoutTail string) []byte {

--- a/internal/daemon/executor_result_resolver_test.go
+++ b/internal/daemon/executor_result_resolver_test.go
@@ -46,7 +46,7 @@ func TestMergeAttemptEvidenceDoesNotOverwriteSupervisorAcceptanceState(t *testin
 		AcceptanceCriteria: []runner.ExecutorAcceptanceCriterion{{
 			ID: "AC1", Status: "not_satisfied", Evidence: []string{"executor self-report"},
 		}},
-	}}, "run", "/work", "/attempt")
+	}}, attemptEvidencePaths{RunID: "run", WorkDir: "/work", AttemptDir: "/attempt"})
 
 	if loaded.AcceptanceCriteria[0].Status != "satisfied" {
 		t.Fatalf("acceptance status = %q, want supervisor-owned satisfied", loaded.AcceptanceCriteria[0].Status)
@@ -56,7 +56,7 @@ func TestMergeAttemptEvidenceDoesNotOverwriteSupervisorAcceptanceState(t *testin
 func TestCodexParseFailureEvidenceUsesProviderSpecificVocabulary(t *testing.T) {
 	t.Parallel()
 	loaded := task.Task{Executor: task.Executor{CLI: "codex"}}
-	mergeAttemptEvidence(&loaded, attemptOutcome{ParseErr: errors.New("invalid output")}, "run", "/work", "/attempt")
+	mergeAttemptEvidence(&loaded, attemptOutcome{ParseErr: errors.New("invalid output")}, attemptEvidencePaths{RunID: "run", WorkDir: "/work", AttemptDir: "/attempt"})
 	if len(loaded.Risks) != 1 {
 		t.Fatalf("risks = %#v", loaded.Risks)
 	}

--- a/internal/daemon/finalize_recovery_test.go
+++ b/internal/daemon/finalize_recovery_test.go
@@ -37,7 +37,15 @@ func finalizeRecoveryRepo(t *testing.T) (root, repo, remote, worktree, promptPat
 
 // writeBlockingGitHook installs a real git hook that rejects the operation
 // while marker exists, so finalization runs through hooks rather than around.
-func writeBlockingGitHook(t *testing.T, repo, hook, marker, message string) {
+type blockingHook struct {
+	Repo    string
+	Hook    string
+	Marker  string
+	Message string
+}
+
+func writeBlockingGitHook(t *testing.T, spec blockingHook) {
+	repo, hook, marker, message := spec.Repo, spec.Hook, spec.Marker, spec.Message
 	t.Helper()
 	path := filepath.Join(repo, ".git", "hooks", hook)
 	body := fmt.Sprintf("#!/bin/sh\nif [ -f %q ]; then\n  echo %q >&2\n  exit 1\nfi\nexit 0\n", marker, message)
@@ -70,7 +78,16 @@ esac
 `)
 }
 
-func finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin string) Options {
+type recoveryPaths struct {
+	Root       string
+	PromptPath string
+	SchemaPath string
+	ClaudeBin  string
+	GHBin      string
+}
+
+func finalizeRecoveryOptions(p recoveryPaths) Options {
+	root, promptPath, schemaPath, claudeBin, ghBin := p.Root, p.PromptPath, p.SchemaPath, p.ClaudeBin, p.GHBin
 	return Options{
 		Root:               root,
 		SystemPromptFile:   promptPath,
@@ -87,7 +104,7 @@ func finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin stri
 
 func gitOutputForTest(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -138,7 +155,7 @@ func TestFinalizeCommitFailureRecoversThroughRevisionLoop(t *testing.T) {
 	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
 	marker := filepath.Join(t.TempDir(), "block-commit")
 	writeMarkerFile(t, marker)
-	writeBlockingGitHook(t, repo, "pre-commit", marker, "pre-commit hook rejected the accepted change")
+	writeBlockingGitHook(t, blockingHook{Repo: repo, Hook: "pre-commit", Marker: marker, Message: "pre-commit hook rejected the accepted change"})
 	claudeBin := finalizeRepairExecutor(t, marker)
 	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
   echo https://github.com/example/galley/pull/501
@@ -148,7 +165,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 3)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: claudeBin, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -222,7 +239,7 @@ func TestFinalizePushFailureRecoversThroughRevisionLoop(t *testing.T) {
 	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
 	marker := filepath.Join(t.TempDir(), "block-push")
 	writeMarkerFile(t, marker)
-	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	writeBlockingGitHook(t, blockingHook{Repo: repo, Hook: "pre-push", Marker: marker, Message: "pre-push hook rejected the accepted branch"})
 	claudeBin := finalizeRepairExecutor(t, marker)
 	ghBin := writeFakeCommand(t, "gh", `if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
   echo https://github.com/example/galley/pull/502
@@ -232,7 +249,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 3)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: claudeBin, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -276,7 +293,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 3)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: claudeBin, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -300,7 +317,7 @@ func TestFinalizeFailureSurvivesRequeueAndFinalizesRetainedCommit(t *testing.T) 
 	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
 	marker := filepath.Join(t.TempDir(), "block-push")
 	writeMarkerFile(t, marker)
-	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	writeBlockingGitHook(t, blockingHook{Repo: repo, Hook: "pre-push", Marker: marker, Message: "pre-push hook rejected the accepted branch"})
 	firstClaude := writeFakeClaude(t, `echo change > daemon-output.txt
 echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
 `)
@@ -312,7 +329,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 1)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, firstClaude, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: firstClaude, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -344,7 +361,7 @@ fi
 	// retained worktree, retained review base, and the pending request.
 	secondClaude := writeFakeClaude(t, `echo '{"status":"completed","summary":"finalization blocker cleared","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["retained commit"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["blocking condition resolved"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
 `)
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, secondClaude, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: secondClaude, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -501,7 +518,7 @@ fi
 	firstClaude := finalizeRevisionProjectingClaude(t, `echo change > daemon-output.txt
 echo '{"status":"completed","summary":"done","files_modified":["daemon-output.txt"],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["diff"],"notes":"done"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
 `)
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, firstClaude, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: firstClaude, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -524,7 +541,7 @@ echo '{"status":"completed","summary":"done","files_modified":["daemon-output.tx
 	writeHookMessage(t, marker, "pre-push hook rejected the accepted branch (run 2)")
 	retainedClaude := finalizeRevisionProjectingClaude(t, `echo '{"status":"completed","summary":"finalization blocker addressed","files_modified":[],"acceptance_criteria":[{"id":"AC1","status":"satisfied","evidence":["retained commit"],"notes":"done"},{"id":"revision:finalize-attempt-1","status":"satisfied","evidence":["blocking condition resolved"],"notes":"finalization can rerun"}],"verification":[],"scope_expansions":[],"decisions":[],"risks":[]}'
 `)
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, retainedClaude, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: retainedClaude, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -533,21 +550,7 @@ echo '{"status":"completed","summary":"done","files_modified":["daemon-output.tx
 		t.Fatalf("second run did not publish a failed task: %v", err)
 	}
 	pending := findRevisionRequest(t, secondFailed, "finalize-attempt-1")
-	if pending.Status != "pending" {
-		t.Fatalf("second finalization failure left request status %q, want pending: %#v", pending.Status, pending)
-	}
-	if !strings.Contains(pending.Text, "git push failed") {
-		t.Fatalf("pending request lost the failed operation: %q", pending.Text)
-	}
-	if !strings.Contains(pending.Text, "(run 2)") || strings.Contains(pending.Text, "(run 1)") {
-		t.Fatalf("pending request does not describe the latest failure: %q", pending.Text)
-	}
-	if !strings.Contains(pending.Text, nthRunDir(t, root, 2)) {
-		t.Fatalf("pending request lost the second run's artifact location: %q", pending.Text)
-	}
-	if pending.Evidence != "" {
-		t.Fatalf("pending request kept stale addressed evidence: %q", pending.Evidence)
-	}
+	assertPendingDescribesLatestFailure(t, pending, nthRunDir(t, root, 2))
 	if secondFailed.ReviewProgress == nil || len(secondFailed.ReviewProgress.Acceptance) == 0 {
 		t.Fatalf("second run lost prior review passes: %#v", secondFailed.ReviewProgress)
 	}
@@ -566,7 +569,7 @@ echo '{"status":"completed","summary":"done","files_modified":["daemon-output.tx
 	if err := os.Remove(marker); err != nil {
 		t.Fatal(err)
 	}
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, retainedClaude, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: retainedClaude, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -622,7 +625,7 @@ func TestFinalizeFailurePreservesForeignRequestHoldingItsID(t *testing.T) {
 	seedRevisionRequest(t, taskPath, foreign)
 	marker := filepath.Join(t.TempDir(), "block-push")
 	writeMarkerFile(t, marker)
-	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	writeBlockingGitHook(t, blockingHook{Repo: repo, Hook: "pre-push", Marker: marker, Message: "pre-push hook rejected the accepted branch"})
 	claudeBin := writeFakeClaude(t, `case "$*" in
   *finalize-attempt-1-2*)
     rm -f `+marker+`
@@ -642,7 +645,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 3)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: claudeBin, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -731,7 +734,7 @@ func TestFinalizeFailureAfterAcceptedRevisionKeepsResolvedRequestsClosed(t *test
 	root, repo, remote, worktree, promptPath, schemaPath, taskPath := finalizeRecoveryRepo(t)
 	marker := filepath.Join(t.TempDir(), "block-push")
 	writeMarkerFile(t, marker)
-	writeBlockingGitHook(t, repo, "pre-push", marker, "pre-push hook rejected the accepted branch")
+	writeBlockingGitHook(t, blockingHook{Repo: repo, Hook: "pre-push", Marker: marker, Message: "pre-push hook rejected the accepted branch"})
 	// Attempt 1 reports risks, which the shared fake supervisor turns into a
 	// needs_revision finding; attempt 2 addresses it and is accepted.
 	claudeBin := writeFakeClaude(t, `case "$*" in
@@ -757,7 +760,7 @@ fi
 `)
 	setLoopBudget(t, taskPath, 4)
 
-	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(root, promptPath, schemaPath, claudeBin, ghBin)); err != nil {
+	if err := runTestDaemon(context.Background(), finalizeRecoveryOptions(recoveryPaths{Root: root, PromptPath: promptPath, SchemaPath: schemaPath, ClaudeBin: claudeBin, GHBin: ghBin})); err != nil {
 		t.Fatal(err)
 	}
 
@@ -844,5 +847,26 @@ func TestFinalizeRevisionRequestTruncationIsUTF8Safe(t *testing.T) {
 	}
 	if got := findRevisionRequest(t, reloaded, "finalize-attempt-1"); got.Text != request.Text {
 		t.Fatalf("persisted request text changed: got %q", got.Text)
+	}
+}
+
+// assertPendingDescribesLatestFailure pins that a repeated failure rewrites the
+// pending request to the newest run and drops stale addressed evidence.
+func assertPendingDescribesLatestFailure(t *testing.T, pending task.RevisionRequest, wantRunDir string) {
+	t.Helper()
+	if pending.Status != "pending" {
+		t.Fatalf("second finalization failure left request status %q, want pending: %#v", pending.Status, pending)
+	}
+	if !strings.Contains(pending.Text, "git push failed") {
+		t.Fatalf("pending request lost the failed operation: %q", pending.Text)
+	}
+	if !strings.Contains(pending.Text, "(run 2)") || strings.Contains(pending.Text, "(run 1)") {
+		t.Fatalf("pending request does not describe the latest failure: %q", pending.Text)
+	}
+	if !strings.Contains(pending.Text, wantRunDir) {
+		t.Fatalf("pending request lost the second run's artifact location: %q", pending.Text)
+	}
+	if pending.Evidence != "" {
+		t.Fatalf("pending request kept stale addressed evidence: %q", pending.Evidence)
 	}
 }

--- a/internal/daemon/git_paths_regression_test.go
+++ b/internal/daemon/git_paths_regression_test.go
@@ -24,12 +24,12 @@ func TestGitPathsRoundTrip(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	status, err := vcs.StatusPorcelainZ(t.Context(), vcs.Binaries{}, repo)
+	status, err := vcs.StatusPorcelainZ(t.Context(), vcs.Repo{WorkDir: repo})
 	if err != nil {
 		t.Fatal(err)
 	}
 	paths := reviewablePathsFromStatus(status, nil)
-	if err := vcs.StagePathsForReview(t.Context(), vcs.Binaries{}, repo, t.TempDir(), paths); err != nil {
+	if err := vcs.StagePathsForReview(t.Context(), vcs.Repo{WorkDir: repo, RunDir: t.TempDir()}, paths); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := workspace.CaptureSnapshot(t.Context(), repo, workspace.Options{})
@@ -42,7 +42,7 @@ func TestGitPathsRoundTrip(t *testing.T) {
 			t.Fatalf("missing path %q in %#v", name, changed)
 		}
 	}
-	if err := vcs.AddPaths(t.Context(), vcs.Binaries{}, repo, t.TempDir(), addEligiblePorcelainPaths(snapshot.StatusPorcelain)); err != nil {
+	if err := vcs.AddPaths(t.Context(), vcs.Repo{WorkDir: repo, RunDir: t.TempDir()}, addEligiblePorcelainPaths(snapshot.StatusPorcelain)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/daemon/grok_executor_failure_test.go
+++ b/internal/daemon/grok_executor_failure_test.go
@@ -24,41 +24,59 @@ func TestGrokExecutorProcessFailuresKeepGenericDaemonClassifications(t *testing.
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			root := filepath.Join(t.TempDir(), ".agent-workflow")
-			repo := initDaemonGitRepo(t)
-			promptPath, schemaPath := writeDaemonPromptFiles(t)
-			grokBin := filepath.Join(t.TempDir(), "missing-grok")
-			if !tc.missingBinary {
-				if err := os.WriteFile(grokBin, []byte("#!/bin/sh\n"+tc.body), 0o700); err != nil {
-					t.Fatal(err)
-				}
-			}
-			taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
-			if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			writeDaemonTask(t, taskPath, repo)
-			loaded, err := task.Load(taskPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			loaded.Executor.CLI = "grok"
-			if tc.total > 0 {
-				loaded.ExecutionPolicy.TimeoutMS = int(tc.total / time.Millisecond)
-			}
-			if err := task.Save(taskPath, loaded); err != nil {
-				t.Fatal(err)
-			}
-			setLoopBudget(t, taskPath, 1)
-			_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: writeFakeClaude(t, "exit 1\n"), GrokBin: grokBin, IdleTimeout: tc.idle})
-			failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
-			if err != nil {
-				t.Fatalf("failed task missing: %v", err)
-			}
-			if len(failed.Attempts) == 0 || failed.Attempts[0].Error == nil || failed.Attempts[0].Error.Kind != tc.wantKind {
-				t.Fatalf("attempt classification = %#v; want %s", failed.Attempts, tc.wantKind)
-			}
-			assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 1)
+			assertGrokFailureClassification(t, grokFailureCase{
+				Body: tc.body, WantKind: tc.wantKind, MissingBinary: tc.missingBinary,
+				Idle: tc.idle, Total: tc.total,
+			})
 		})
 	}
+}
+
+// grokFailureCase is one grok executor process failure and the attempt error
+// kind the daemon must record for it.
+type grokFailureCase struct {
+	Body          string
+	WantKind      string
+	MissingBinary bool
+	Idle          time.Duration
+	Total         time.Duration
+}
+
+func assertGrokFailureClassification(t *testing.T, tc grokFailureCase) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".agent-workflow")
+	repo := initDaemonGitRepo(t)
+	promptPath, schemaPath := writeDaemonPromptFiles(t)
+	grokBin := filepath.Join(t.TempDir(), "missing-grok")
+	if !tc.MissingBinary {
+		if err := os.WriteFile(grokBin, []byte("#!/bin/sh\n"+tc.Body), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	taskPath := filepath.Join(root, "tasks", "queued", "task.yaml")
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeDaemonTask(t, taskPath, repo)
+	loaded, err := task.Load(taskPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Executor.CLI = "grok"
+	if tc.Total > 0 {
+		loaded.ExecutionPolicy.TimeoutMS = int(tc.Total / time.Millisecond)
+	}
+	if err := task.Save(taskPath, loaded); err != nil {
+		t.Fatal(err)
+	}
+	setLoopBudget(t, taskPath, 1)
+	_ = runTestDaemon(context.Background(), Options{Root: root, SystemPromptFile: promptPath, JSONSchemaFile: schemaPath, Once: true, MaxConcurrentTasks: 1, Supervisor: "claude", ClaudeBin: writeFakeClaude(t, "exit 1\n"), GrokBin: grokBin, IdleTimeout: tc.Idle})
+	failed, err := task.Load(filepath.Join(root, "tasks", "failed", "task.yaml"))
+	if err != nil {
+		t.Fatalf("failed task missing: %v", err)
+	}
+	if len(failed.Attempts) == 0 || failed.Attempts[0].Error == nil || failed.Attempts[0].Error.Kind != tc.WantKind {
+		t.Fatalf("attempt classification = %#v; want %s", failed.Attempts, tc.WantKind)
+	}
+	assertGlobCount(t, filepath.Join(root, "runs", "*", "attempt-1", runartifact.RunResultFilename), 1)
 }

--- a/internal/daemon/input_reuse_regression_test.go
+++ b/internal/daemon/input_reuse_regression_test.go
@@ -25,19 +25,36 @@ func TestPrepareClaimedWorkspacePreservesEditedInputs(t *testing.T) {
 		if err := os.MkdirAll(runDir, 0o700); err != nil {
 			t.Fatal(err)
 		}
-		prepared, err := prepareClaimedWorkspace(t.Context(), Options{Root: root}, profile.Bundle{}, running, runDir, &loaded, task.Executor{})
+		prepared, err := prepareClaimedWorkspace(t.Context(), Options{Root: root}, claimedWorkspaceRequest{Profiles: profile.Bundle{}, RunningPath: running, RunDir: runDir, Loaded: &loaded, EffectiveExecutor: task.Executor{}})
 		if err != nil {
 			t.Fatal(err)
 		}
 		for _, file := range loaded.Files {
 			path := filepath.Join(prepared.CWD, file.Destination)
 			if i == 0 {
-				if err := os.WriteFile(path, []byte("executor edits"), 0o600); err != nil {
-					t.Fatal(err)
-				}
-			} else if data, err := os.ReadFile(path); err != nil || string(data) != "executor edits" {
-				t.Fatalf("lost prior work: %q %v", data, err)
+				seedExecutorEdit(t, path)
+				continue
 			}
+			assertExecutorEditPreserved(t, path)
 		}
+	}
+}
+
+const executorEditMarker = "executor edits"
+
+func seedExecutorEdit(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(executorEditMarker), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// assertExecutorEditPreserved pins that reusing a worktree keeps the executor's
+// prior edit to a task input file.
+func assertExecutorEditPreserved(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != executorEditMarker {
+		t.Fatalf("lost prior work: %q %v", data, err)
 	}
 }

--- a/internal/daemon/loop.go
+++ b/internal/daemon/loop.go
@@ -52,7 +52,16 @@ func asReviewStagingError(err error) (*reviewStagingError, bool) {
 
 const progressNoDiffThreshold = 2
 
-func defaultSupervisorRunner(ctx context.Context, opts Options, evidence supervisor.Evidence, tryDir, workDir string) (supervisor.Verdict, error) {
+// supervisorRunRequest is one supervisor invocation.
+type supervisorRunRequest struct {
+	Opts     Options
+	Evidence supervisor.Evidence
+	TryDir   string
+	WorkDir  string
+}
+
+func defaultSupervisorRunner(ctx context.Context, req supervisorRunRequest) (supervisor.Verdict, error) {
+	opts, evidence, tryDir, workDir := req.Opts, req.Evidence, req.TryDir, req.WorkDir
 	return supervisor.RunAdapter(ctx, supervisor.AdapterOptions{
 		Provider:     opts.Supervisor,
 		Model:        opts.SupervisorModel,
@@ -69,7 +78,57 @@ func defaultSupervisorRunner(ctx context.Context, opts Options, evidence supervi
 	}, evidence)
 }
 
-func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, runningPath string, loaded *task.Task, prepared claimedWorkspace, profiles profile.Bundle, runDir, runID string, effectiveExecutor task.Executor) error {
+// withoutStaticSkeletonOutputs drops rendered skeleton outputs from the prompt.
+// Runtime obligations own that content after preflight, so keeping both duplicates.
+func withoutStaticSkeletonOutputs(promptTask task.Task) task.Task {
+	if promptTask.Preflight == nil || promptTask.Preflight.AcceptanceSkeleton == nil {
+		return promptTask
+	}
+	cfgCopy := *promptTask.Preflight.AcceptanceSkeleton
+	cfgCopy.Outputs = nil
+	preflightCopy := *promptTask.Preflight
+	preflightCopy.AcceptanceSkeleton = &cfgCopy
+	promptTask.Preflight = &preflightCopy
+	return promptTask
+}
+
+// logAttemptFailure distinguishes a supervisor idle timeout and an executor
+// interruption from a task total-timeout expiry in the daemon log.
+func logAttemptFailure(taskID string, err error) {
+	if idle, ok := asSupervisorIdleTimeout(err); ok {
+		fmt.Fprintln(os.Stderr, idle.logLine(taskID))
+	}
+	if interruption, ok := asExecutorInterruptionError(err); ok {
+		fmt.Fprintf(os.Stderr, "galley: task %s executor interrupted (%s) before Supervisor review; preserving worktree for requeue\n", taskID, interruption.terminal.Reason)
+	}
+}
+
+// attemptMadeProgress excludes baseline-matching skeletons from the dirty set;
+// counting them every attempt would keep the no-diff invariant from firing.
+func attemptMadeProgress(outcome attemptOutcome, workDir string, preflightResult *skeletonpreflight.Result) bool {
+	if outcome.DiffErr != nil {
+		return false
+	}
+	progress, _ := hasNonSkeletonProgress(outcome.DiffSnapshot, workDir, preflightResult)
+	return progress
+}
+
+// supervisorLoopRequest is one claimed task's attempt/review loop.
+type supervisorLoopRequest struct {
+	Opts              Options
+	RunningPath       string
+	Loaded            *task.Task
+	Prepared          claimedWorkspace
+	Profiles          profile.Bundle
+	RunDir            string
+	RunID             string
+	EffectiveExecutor task.Executor
+}
+
+func runSupervisorLoop(execCtx, daemonCtx context.Context, req supervisorLoopRequest) error {
+	opts, runningPath, loaded := req.Opts, req.RunningPath, req.Loaded
+	prepared, profiles := req.Prepared, req.Profiles
+	runDir, runID, effectiveExecutor := req.RunDir, req.RunID, req.EffectiveExecutor
 	fmt.Fprintf(os.Stderr, "galley: task %s running in %s (run_id=%s)\n", loaded.ID, prepared.CWD, runID)
 	// Persist the resolved supervisor and its source as run evidence.
 	// Reviewers can then tell whether the per-task supervisor came from the
@@ -90,17 +149,7 @@ func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, running
 	supervisor.ReconcileReviewProgressWithContext(loaded, profiles, prepared.ReviewContractContext)
 	promptTask := executionTask(*loaded, prepared.CWD, effectiveExecutor)
 	if preflightResult != nil {
-		// Runtime obligations below are the source of truth after preflight.
-		// Suppress static task-output rendering here to avoid duplicate
-		// sections after processClaimedTask writes generated outputs back to
-		// the running task file for auditability.
-		if promptTask.Preflight != nil && promptTask.Preflight.AcceptanceSkeleton != nil {
-			cfgCopy := *promptTask.Preflight.AcceptanceSkeleton
-			cfgCopy.Outputs = nil
-			preflightCopy := *promptTask.Preflight
-			preflightCopy.AcceptanceSkeleton = &cfgCopy
-			promptTask.Preflight = &preflightCopy
-		}
+		promptTask = withoutStaticSkeletonOutputs(promptTask)
 	}
 	budget := attemptBudget(loaded.ExecutionPolicy.LoopBudget)
 	consecutiveNoDiff := 0
@@ -128,18 +177,10 @@ func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, running
 			EffectiveTask: effectiveTask,
 		})
 		if err != nil {
-			// When a supervisor idle timeout fails the task,
-			// emit one concise line in the existing Galley log tone so the
-			// daemon log distinguishes it from a task total-timeout expiry.
-			if idle, ok := asSupervisorIdleTimeout(err); ok {
-				fmt.Fprintln(os.Stderr, idle.logLine(loaded.ID))
-			}
-			if interruption, ok := asExecutorInterruptionError(err); ok {
-				fmt.Fprintf(os.Stderr, "galley: task %s executor interrupted (%s) before Supervisor review; preserving worktree for requeue\n", loaded.ID, interruption.terminal.Reason)
-			}
+			logAttemptFailure(loaded.ID, err)
 			return taskstate.FailMoveToStatus(opts.Root, runningPath, loaded, err)
 		}
-		mergeAttemptEvidence(loaded, review.Outcome, runID, prepared.CWD, review.AttemptDir)
+		mergeAttemptEvidence(loaded, review.Outcome, attemptEvidencePaths{RunID: runID, WorkDir: prepared.CWD, AttemptDir: review.AttemptDir})
 		supervisor.ApplyReviewProgressWithContext(loaded, profiles, prepared.ReviewContractContext, review.Verdict)
 		// Progress detection. The dirty-diff
 		// signal alone over-counts: preflight materialized skeleton files in
@@ -149,15 +190,10 @@ func runSupervisorLoop(execCtx, daemonCtx context.Context, opts Options, running
 		// skeleton files from the dirty set so changed skeletons (or any
 		// non-skeleton change) count as progress, while unchanged skeletons
 		// across repeated attempts let the existing no-diff invariant fire.
-		nonSkeletonProgress := false
-		if review.Outcome.DiffErr == nil {
-			progress, _ := hasNonSkeletonProgress(review.Outcome.DiffSnapshot, prepared.CWD, preflightResult)
-			nonSkeletonProgress = progress
-		}
-		if !nonSkeletonProgress {
-			consecutiveNoDiff++
-		} else {
+		if attemptMadeProgress(review.Outcome, prepared.CWD, preflightResult) {
 			consecutiveNoDiff = 0
+		} else {
+			consecutiveNoDiff++
 		}
 		fmt.Fprintf(os.Stderr, "galley: task %s attempt %d verdict=%s summary=%s\n", loaded.ID, attempt, review.Verdict.Status, review.Verdict.Summary)
 		loaded.Attempts[len(loaded.Attempts)-1].SupervisorVerdict = review.Verdict.Status
@@ -217,13 +253,13 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 	fmt.Fprintf(os.Stderr, "galley: task %s attempt %d/%s starting\n", req.Loaded.ID, req.Attempt, req.Loaded.ExecutionPolicy.LoopBudget.String())
 	attemptDir := filepath.Join(req.RunDir, runartifact.AttemptDirname(req.Attempt))
 	if err := os.MkdirAll(attemptDir, 0o700); err != nil {
-		appendFailureAttempt(req.Loaded, "attempt_setup", "attempt_setup_failed", err, req.RunDir)
+		appendFailureAttempt(req.Loaded, attemptFailure{Phase: "attempt_setup", Kind: "attempt_setup_failed", Err: err, ArtifactDir: req.RunDir})
 		return attemptReview{}, fmt.Errorf("create attempt dir %s: %w", attemptDir, err)
 	}
 	effectiveTask := req.EffectiveTask
 	effectiveTaskPath := runartifact.Path(attemptDir, runartifact.EffectiveTaskSnapshotFilename)
 	if err := task.Save(effectiveTaskPath, effectiveTask); err != nil {
-		appendFailureAttempt(req.Loaded, "attempt_setup", "attempt_setup_failed", err, attemptDir)
+		appendFailureAttempt(req.Loaded, attemptFailure{Phase: "attempt_setup", Kind: "attempt_setup_failed", Err: err, ArtifactDir: attemptDir})
 		return attemptReview{}, err
 	}
 	// Load the runtime preflight result before the executor attempt so the
@@ -233,17 +269,17 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "galley: task %s attempt %d could not load preflight result: %v\n", req.Loaded.ID, req.Attempt, err)
 	}
-	outcome, err := runExecutorAttempt(ctx, req.Opts, effectiveTask, req.Prepared.CWD, req.Prepared.BaseSHA, attemptDir, req.Prompt)
+	outcome, err := runExecutorAttempt(ctx, executorAttemptRequest{Opts: req.Opts, Loaded: effectiveTask, WorkDir: req.Prepared.CWD, BaseSHA: req.Prepared.BaseSHA, AttemptDir: attemptDir, Prompt: req.Prompt})
 	if err != nil {
 		// A review-time staging failure is recorded under a distinct phase
 		// and kind so the failed task surfaces the staging-related error to
 		// the supervisor and operators instead of mis-classifying it as an
 		// executor failure.
 		if _, ok := asReviewStagingError(err); ok {
-			appendFailureAttempt(req.Loaded, "review_staging", "review_staging_failed", err, attemptDir)
+			appendFailureAttempt(req.Loaded, attemptFailure{Phase: "review_staging", Kind: "review_staging_failed", Err: err, ArtifactDir: attemptDir})
 			return attemptReview{}, err
 		}
-		appendFailureAttempt(req.Loaded, "executor", classifyFailureKind("executor_failed", err), err, attemptDir)
+		appendFailureAttempt(req.Loaded, attemptFailure{Phase: "executor", Kind: classifyFailureKind("executor_failed", err), Err: err, ArtifactDir: attemptDir})
 		return attemptReview{}, err
 	}
 	// A provider or runtime interruption never reaches Supervisor and never
@@ -271,13 +307,13 @@ func runOneSupervisorAttempt(ctx context.Context, req supervisorAttemptRequest) 
 		SetupResult:            setupResultEvidence,
 		SetupEnvironmentUpdate: setupUpdateEvidence,
 	}
-	verdict, err := evaluateSupervisor(ctx, req.Opts, evidence, attemptDir, req.Prepared.CWD)
+	verdict, err := evaluateSupervisor(ctx, req.Opts, supervisorEvaluation{Evidence: evidence, AttemptDir: attemptDir, WorkDir: req.Prepared.CWD})
 	if err != nil {
 		appendSupervisorFailureAttempt(req.Loaded, outcome, err, attemptDir)
 		return attemptReview{}, err
 	}
 	if err := writeJSON(runartifact.Path(attemptDir, runartifact.SupervisorVerdictFilename), verdict); err != nil {
-		appendFailureAttempt(req.Loaded, "run_evidence", "run_evidence_failed", err, attemptDir)
+		appendFailureAttempt(req.Loaded, attemptFailure{Phase: "run_evidence", Kind: "run_evidence_failed", Err: err, ArtifactDir: attemptDir})
 		return attemptReview{}, err
 	}
 	return attemptReview{AttemptDir: attemptDir, Outcome: outcome, Verdict: verdict}, nil
@@ -317,7 +353,7 @@ func applySupervisorVerdict(execCtx, daemonCtx context.Context, req verdictAppli
 			fmt.Fprintf(os.Stderr, "galley: task %s accepted verdict rejected by acceptance gate: %s\n", req.Loaded.ID, reason)
 			return true, failVerdictApplication(req, "acceptance-gate", "Accepted verdict rejected by acceptance skeleton gate: "+reason, "Inspect preflight_result.json before re-finalizing.")
 		}
-		err := acceptSupervisorVerdict(execCtx, req.Opts, req.RunningPath, req.Loaded, req.Prepared, req.Profiles, req.RunDir, req.Verdict)
+		err := acceptSupervisorVerdict(execCtx, req)
 		// A finalization failure keeps the accepted work, worktree, and review
 		// progress and spends the next attempt of this loop repairing it.
 		if failure, ok := asFinalizeFailure(err); ok {
@@ -341,31 +377,18 @@ func applySupervisorVerdict(execCtx, daemonCtx context.Context, req verdictAppli
 
 func failVerdictApplication(req verdictApplication, riskPrefix, detail, mitigation string) error {
 	req.Loaded.Status = "failed"
-	appendRisk(req.Loaded, riskPrefix, "partial_verification", detail, mitigation, true)
+	appendRisk(req.Loaded, riskPrefix, riskSpec{Type: "partial_verification", Detail: detail, Mitigation: mitigation, HumanReview: true})
 	return taskstate.MoveToStatus(req.Opts.Root, req.RunningPath, req.Loaded)
 }
 
-func acceptSupervisorVerdict(ctx context.Context, opts Options, runningPath string, loaded *task.Task, prepared workspace.Prepared, profiles profile.Bundle, runDir string, verdict supervisor.Verdict) error {
+func acceptSupervisorVerdict(ctx context.Context, req verdictApplication) error {
+	opts, runningPath, loaded := req.Opts, req.RunningPath, req.Loaded
+	profiles, verdict := req.Profiles, req.Verdict
 	mergeDiscussionItems(loaded, profiles, verdict)
 	*loaded = (supervisorRevision{}).applyToTask(*loaded)
 	applyAcceptedAcceptanceCriteria(loaded)
-	if opts.CommitOnAccept {
-		fmt.Fprintf(os.Stderr, "galley: task %s accepted; finalizing commit/pr\n", loaded.ID)
-		if err := finalizeAcceptedChange(ctx, opts, loaded, prepared.CWD, prepared.BaseSHA, runDir); err != nil {
-			// A failed commit, push, or PR creation goes back to the verdict
-			// path; every other finalization failure still fails the task.
-			if _, ok := asFinalizeFailure(err); ok {
-				return err
-			}
-			loaded.Status = "failed"
-			appendRisk(loaded, "finalize", "partial_verification", err.Error(), "The executor diff and run evidence were stored; a supervisor should inspect and finish commit or PR creation.", true)
-			return taskstate.FailMoveToStatus(opts.Root, runningPath, loaded, err)
-		}
-		markFinalizeRevisionsAddressed(loaded)
-	} else if err := inputfiles.CleanupNonCommitted(prepared.CWD, loaded.Files); err != nil {
-		loaded.Status = "failed"
-		appendRisk(loaded, "input-file-cleanup", "partial_verification", err.Error(), "Remove non-committed task input files from the execution workspace before archiving or reusing it.", true)
-		return taskstate.FailMoveToStatus(opts.Root, runningPath, loaded, err)
+	if err := finalizeOrCleanup(ctx, req); err != nil {
+		return err
 	}
 	loaded.Status = "accepted"
 	if opts.OpenPR {
@@ -384,12 +407,20 @@ func executionTask(loaded task.Task, workDir string, effectiveExecutor task.Exec
 // evaluateSupervisor runs one supervisor evaluation for an executor attempt.
 // A failed supervisor invocation is preserved as evidence and returned to the
 // task-state path; Galley does not rerun the same model against unchanged input.
-func evaluateSupervisor(ctx context.Context, opts Options, evidence supervisor.Evidence, attemptDir, workDir string) (supervisor.Verdict, error) {
+// supervisorEvaluation is one supervisor evaluation of an attempt.
+type supervisorEvaluation struct {
+	Evidence   supervisor.Evidence
+	AttemptDir string
+	WorkDir    string
+}
+
+func evaluateSupervisor(ctx context.Context, opts Options, req supervisorEvaluation) (supervisor.Verdict, error) {
+	evidence, attemptDir, workDir := req.Evidence, req.AttemptDir, req.WorkDir
 	artifactDir := runartifact.Path(attemptDir, runartifact.SupervisorTryDirname)
 	if err := os.MkdirAll(artifactDir, 0o700); err != nil {
 		return supervisor.Verdict{}, fmt.Errorf("create supervisor artifact dir %s: %w", artifactDir, err)
 	}
-	verdict, err := opts.daemonDependencies().supervisorRunner(ctx, opts, evidence, artifactDir, workDir)
+	verdict, err := opts.daemonDependencies().supervisorRunner(ctx, supervisorRunRequest{Opts: opts, Evidence: evidence, TryDir: artifactDir, WorkDir: workDir})
 	if err != nil {
 		kind := supervisorFailureKind(err)
 		_ = writeJSON(runartifact.Path(artifactDir, runartifact.SupervisorErrorFilename), map[string]any{
@@ -436,23 +467,29 @@ func mergeDiscussionItems(loaded *task.Task, profiles profile.Bundle, verdict su
 			true,
 		)
 	}
-	if profiles.Quality != nil {
-		passed := map[string]bool{}
-		if loaded.ReviewProgress != nil {
-			for _, id := range loaded.ReviewProgress.Quality {
-				passed[id] = true
-			}
-		}
-		var gaps []string
-		for _, dimension := range profiles.Quality.ReviewDimensions {
-			if !passed[dimension.ID] {
-				gaps = append(gaps, dimension.ID)
-			}
-		}
-		if len(gaps) > 0 {
-			appendDiscussionItem(loaded, "Quality review gaps", strings.Join(gaps, ", "), true)
+	if gaps := qualityReviewGaps(loaded, profiles.Quality); len(gaps) > 0 {
+		appendDiscussionItem(loaded, "Quality review gaps", strings.Join(gaps, ", "), true)
+	}
+}
+
+// qualityReviewGaps lists the quality review dimensions the task has not passed.
+func qualityReviewGaps(loaded *task.Task, quality *profile.Quality) []string {
+	if quality == nil {
+		return nil
+	}
+	passed := map[string]bool{}
+	if loaded.ReviewProgress != nil {
+		for _, id := range loaded.ReviewProgress.Quality {
+			passed[id] = true
 		}
 	}
+	var gaps []string
+	for _, dimension := range quality.ReviewDimensions {
+		if !passed[dimension.ID] {
+			gaps = append(gaps, dimension.ID)
+		}
+	}
+	return gaps
 }
 
 func appendDiscussionItem(loaded *task.Task, topic, summary string, requiresHumanDecision bool) {
@@ -514,4 +551,53 @@ func writeSupervisorEvidence(runDir string, effectiveOpts Options) error {
 		"effort":        effectiveOpts.SupervisorEffort,
 		"effort_source": effortSource,
 	})
+}
+
+// finalizeOnAccept commits and opens the PR. A failed commit, push, or PR
+// creation returns to the verdict path; any other failure fails the task.
+func finalizeOnAccept(ctx context.Context, req verdictApplication) error {
+	opts, loaded, prepared := req.Opts, req.Loaded, req.Prepared
+	fmt.Fprintf(os.Stderr, "galley: task %s accepted; finalizing commit/pr\n", loaded.ID)
+	err := finalizeAcceptedChange(ctx, acceptedChange{Opts: opts, Loaded: loaded, WorkDir: prepared.CWD, BaseSHA: prepared.BaseSHA, RunDir: req.RunDir})
+	if err == nil {
+		markFinalizeRevisionsAddressed(loaded)
+		return nil
+	}
+	if _, ok := asFinalizeFailure(err); ok {
+		return err
+	}
+	loaded.Status = "failed"
+	appendRisk(loaded, "finalize", riskSpec{
+		Type:        "partial_verification",
+		Detail:      err.Error(),
+		Mitigation:  "The executor diff and run evidence were stored; a supervisor should inspect and finish commit or PR creation.",
+		HumanReview: true,
+	})
+	return taskstate.FailMoveToStatus(opts.Root, req.RunningPath, loaded, err)
+}
+
+// cleanupNonCommittedOnAccept removes context-only inputs from a workspace that
+// is kept without a commit.
+func cleanupNonCommittedOnAccept(req verdictApplication) error {
+	err := inputfiles.CleanupNonCommitted(req.Prepared.CWD, req.Loaded.Files)
+	if err == nil {
+		return nil
+	}
+	req.Loaded.Status = "failed"
+	appendRisk(req.Loaded, "input-file-cleanup", riskSpec{
+		Type:        "partial_verification",
+		Detail:      err.Error(),
+		Mitigation:  "Remove non-committed task input files from the execution workspace before archiving or reusing it.",
+		HumanReview: true,
+	})
+	return taskstate.FailMoveToStatus(req.Opts.Root, req.RunningPath, req.Loaded, err)
+}
+
+// finalizeOrCleanup commits and opens the PR, or removes context-only inputs
+// from the kept workspace when the daemon does not commit on accept.
+func finalizeOrCleanup(ctx context.Context, req verdictApplication) error {
+	if req.Opts.CommitOnAccept {
+		return finalizeOnAccept(ctx, req)
+	}
+	return cleanupNonCommittedOnAccept(req)
 }

--- a/internal/daemon/loop_supervisor_daemon_test.go
+++ b/internal/daemon/loop_supervisor_daemon_test.go
@@ -31,7 +31,7 @@ func TestDaemonSupervisorStallFailsAfterSingleInvocation(t *testing.T) {
 	claudeBin := writeFakeClaude(t, "echo change > daemon-output.txt\necho '{\"status\":\"completed\",\"summary\":\"done\",\"files_modified\":[\"daemon-output.txt\"],\"acceptance_criteria\":[{\"id\":\"AC1\",\"status\":\"satisfied\",\"evidence\":[\"diff\"],\"notes\":\"done\"}],\"verification\":[],\"scope_expansions\":[],\"decisions\":[],\"risks\":[]}'\n")
 	setLoopBudget(t, taskPath, 3)
 	calls := 0
-	stallingSupervisor := func(_ context.Context, _ Options, _ supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+	stallingSupervisor := func(_ context.Context, _ supervisorRunRequest) (supervisor.Verdict, error) {
 		calls++
 		return supervisor.Verdict{}, &proc.CommandError{Kind: proc.CommandErrorIdleTimeout, Err: errors.New("no output")}
 	}

--- a/internal/daemon/loop_supervisor_test.go
+++ b/internal/daemon/loop_supervisor_test.go
@@ -22,16 +22,16 @@ func runnerCommandErr(kind proc.CommandErrorKind, err error) error {
 func TestEvaluateSupervisorRunsOnceAndWritesVerdict(t *testing.T) {
 	attemptDir := t.TempDir()
 	calls := 0
-	runnerForTest := func(_ context.Context, _ Options, _ supervisor.Evidence, artifactDir, _ string) (supervisor.Verdict, error) {
+	runnerForTest := func(_ context.Context, req supervisorRunRequest) (supervisor.Verdict, error) {
 		calls++
-		if want := filepath.Join(attemptDir, "supervisor-try-1"); artifactDir != want {
-			t.Fatalf("artifactDir got %q, want %q", artifactDir, want)
+		if want := filepath.Join(attemptDir, "supervisor-try-1"); req.TryDir != want {
+			t.Fatalf("TryDir got %q, want %q", req.TryDir, want)
 		}
 		return supervisor.Verdict{Status: "accepted", Summary: "ok"}, nil
 	}
 
 	opts := Options{Supervisor: "codex", dependencies: &daemonDependencies{supervisorRunner: runnerForTest}}
-	verdict, err := evaluateSupervisor(context.Background(), opts, supervisor.Evidence{Task: task.Task{ID: "test"}}, attemptDir, attemptDir)
+	verdict, err := evaluateSupervisor(context.Background(), opts, supervisorEvaluation{Evidence: supervisor.Evidence{Task: task.Task{ID: "test"}}, AttemptDir: attemptDir, WorkDir: attemptDir})
 	if err != nil {
 		t.Fatalf("evaluateSupervisor returned error: %v", err)
 	}
@@ -55,13 +55,13 @@ func TestEvaluateSupervisorReturnsInvalidVerdictWithoutRetry(t *testing.T) {
 	attemptDir := t.TempDir()
 	calls := 0
 	wantErr := &supervisor.VerdictContractError{Err: errors.New("missing quality coverage")}
-	runnerForTest := func(_ context.Context, _ Options, _ supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+	runnerForTest := func(_ context.Context, _ supervisorRunRequest) (supervisor.Verdict, error) {
 		calls++
 		return supervisor.Verdict{}, wantErr
 	}
 
 	opts := Options{Supervisor: "codex", dependencies: &daemonDependencies{supervisorRunner: runnerForTest}}
-	_, err := evaluateSupervisor(context.Background(), opts, supervisor.Evidence{Task: task.Task{ID: "test"}}, attemptDir, attemptDir)
+	_, err := evaluateSupervisor(context.Background(), opts, supervisorEvaluation{Evidence: supervisor.Evidence{Task: task.Task{ID: "test"}}, AttemptDir: attemptDir, WorkDir: attemptDir})
 	if !errors.Is(err, wantErr) || calls != 1 {
 		t.Fatalf("err=%v calls=%d, want original error after one invocation", err, calls)
 	}
@@ -84,13 +84,13 @@ func TestEvaluateSupervisorReturnsInvalidVerdictWithoutRetry(t *testing.T) {
 func TestEvaluateSupervisorReturnsIdleTimeoutWithoutRetry(t *testing.T) {
 	attemptDir := t.TempDir()
 	calls := 0
-	runnerForTest := func(_ context.Context, _ Options, _ supervisor.Evidence, _, _ string) (supervisor.Verdict, error) {
+	runnerForTest := func(_ context.Context, _ supervisorRunRequest) (supervisor.Verdict, error) {
 		calls++
 		return supervisor.Verdict{}, runnerCommandErr(proc.CommandErrorIdleTimeout, errors.New("no output"))
 	}
 
 	opts := Options{Supervisor: "codex", IdleTimeout: 90 * time.Second, dependencies: &daemonDependencies{supervisorRunner: runnerForTest}}
-	_, err := evaluateSupervisor(context.Background(), opts, supervisor.Evidence{Task: task.Task{ID: "test"}}, attemptDir, attemptDir)
+	_, err := evaluateSupervisor(context.Background(), opts, supervisorEvaluation{Evidence: supervisor.Evidence{Task: task.Task{ID: "test"}}, AttemptDir: attemptDir, WorkDir: attemptDir})
 	idle, ok := asSupervisorIdleTimeout(err)
 	if !ok || calls != 1 {
 		t.Fatalf("err=%v calls=%d, want one typed idle-timeout failure", err, calls)

--- a/internal/daemon/maintenance_execution_race_test.go
+++ b/internal/daemon/maintenance_execution_race_test.go
@@ -85,23 +85,9 @@ func TestMaintenanceRequeueAndExecutionClaimStayRaceFree(t *testing.T) {
 	doneGlob := filepath.Join(root, "tasks", "done", "*.yaml")
 
 	resetRound := func() {
-		// Clear any prior round's queued/running copies and stale claim locks,
-		// then restore the source done task so publication has something to move.
-		for _, pattern := range []string{
-			queuedGlob, runningGlob,
+		removeMatching(t, queuedGlob, runningGlob,
 			filepath.Join(root, "tasks", "queued", "*.lock"),
-			filepath.Join(root, "tasks", "running", "*.lock"),
-		} {
-			matches, globErr := filepath.Glob(pattern)
-			if globErr != nil {
-				t.Fatal(globErr)
-			}
-			for _, m := range matches {
-				if rmErr := os.Remove(m); rmErr != nil && !os.IsNotExist(rmErr) {
-					t.Fatal(rmErr)
-				}
-			}
-		}
+			filepath.Join(root, "tasks", "running", "*.lock"))
 		if writeErr := os.WriteFile(donePath, doneBytes, 0o600); writeErr != nil {
 			t.Fatal(writeErr)
 		}
@@ -137,25 +123,7 @@ func TestMaintenanceRequeueAndExecutionClaimStayRaceFree(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			deadline := time.Now().Add(500 * time.Millisecond)
-			for {
-				queued, qErr := queue.QueuedTasks(root)
-				if qErr != nil {
-					errs <- fmt.Errorf("QueuedTasks failed: %w", qErr)
-					return
-				}
-				claimed := false
-				for _, qPath := range queued {
-					if _, claimErr := queue.ClaimTask(root, qPath); claimErr == nil {
-						claimed = true
-					}
-					// ErrClaimConflict or a missing-source rename error means the
-					// task was not claimed this pass; keep scanning/retrying.
-				}
-				if claimed || time.Now().After(deadline) {
-					return
-				}
-			}
+			claimUntilClaimedOrDeadline(root, errs)
 		}()
 
 		close(start)
@@ -170,48 +138,14 @@ func TestMaintenanceRequeueAndExecutionClaimStayRaceFree(t *testing.T) {
 		// Assert exactly-once placement: the requeued task lives in exactly one of
 		// queued or running, is never double-claimed (never in both), and is never
 		// lost. The source done task is removed exactly once when publication wins.
-		queuedMatches, gErr := filepath.Glob(queuedGlob)
-		if gErr != nil {
-			t.Fatal(gErr)
-		}
-		runningMatches, gErr := filepath.Glob(runningGlob)
-		if gErr != nil {
-			t.Fatal(gErr)
-		}
-		doneMatches, gErr := filepath.Glob(doneGlob)
-		if gErr != nil {
-			t.Fatal(gErr)
-		}
-		live := len(queuedMatches) + len(runningMatches) + len(doneMatches)
-		if live != 1 {
-			t.Fatalf("round %d: expected exactly one live copy of the task, got %d (queued=%v running=%v done=%v)",
-				round, live, queuedMatches, runningMatches, doneMatches)
-		}
-		if len(doneMatches) != 0 {
-			t.Fatalf("round %d: requeued task source remained in done after publication: %v", round, doneMatches)
-		}
-		if len(runningMatches) > 1 {
-			t.Fatalf("round %d: task was double-claimed into running: %v", round, runningMatches)
-		}
-		if len(queuedMatches) == 1 && len(runningMatches) == 1 {
-			t.Fatalf("round %d: task present in both queued and running (lost no-overwrite boundary)", round)
-		}
+		assertExactlyOneLiveCopy(t, round, taskGlobs{Queued: queuedGlob, Running: runningGlob, Done: doneGlob})
 	}
 
 	// Final state assertions over the canonical no-overwrite boundary: after the
 	// last round the task sits in exactly one terminal queue location.
-	finalQueued, err := filepath.Glob(queuedGlob)
-	if err != nil {
-		t.Fatal(err)
-	}
-	finalRunning, err := filepath.Glob(runningGlob)
-	if err != nil {
-		t.Fatal(err)
-	}
-	finalDone, err := filepath.Glob(doneGlob)
-	if err != nil {
-		t.Fatal(err)
-	}
+	finalQueued := globForTest(t, queuedGlob)
+	finalRunning := globForTest(t, runningGlob)
+	finalDone := globForTest(t, doneGlob)
 	if total := len(finalQueued) + len(finalRunning) + len(finalDone); total != 1 {
 		t.Fatalf("final placement: expected exactly one live copy, got %d (queued=%v running=%v done=%v)",
 			total, finalQueued, finalRunning, finalDone)
@@ -220,4 +154,75 @@ func TestMaintenanceRequeueAndExecutionClaimStayRaceFree(t *testing.T) {
 		t.Fatalf("final placement: requeued task source remained in done: %v", finalDone)
 	}
 	assertGlobCount(t, runningGlob, len(finalRunning))
+}
+
+func globForTest(t *testing.T, pattern string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return matches
+}
+
+func removeMatching(t *testing.T, patterns ...string) {
+	t.Helper()
+	for _, pattern := range patterns {
+		for _, m := range globForTest(t, pattern) {
+			if rmErr := os.Remove(m); rmErr != nil && !os.IsNotExist(rmErr) {
+				t.Fatal(rmErr)
+			}
+		}
+	}
+}
+
+// claimUntilClaimedOrDeadline claims queued tasks via the no-overwrite rename,
+// retrying briefly so it overlaps publication; a conflict just continues the scan.
+func claimUntilClaimedOrDeadline(root string, errs chan<- error) {
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		queued, qErr := queue.QueuedTasks(root)
+		if qErr != nil {
+			errs <- fmt.Errorf("QueuedTasks failed: %w", qErr)
+			return
+		}
+		claimed := false
+		for _, qPath := range queued {
+			if _, claimErr := queue.ClaimTask(root, qPath); claimErr == nil {
+				claimed = true
+			}
+		}
+		if claimed || time.Now().After(deadline) {
+			return
+		}
+	}
+}
+
+// taskGlobs are the queue-location globs one interleaving round asserts over.
+type taskGlobs struct {
+	Queued  string
+	Running string
+	Done    string
+}
+
+// assertExactlyOneLiveCopy checks exactly-once placement: the task lives in one
+// of queued or running, is never double-claimed or lost, and leaves done once.
+func assertExactlyOneLiveCopy(t *testing.T, round int, globs taskGlobs) {
+	t.Helper()
+	queued := globForTest(t, globs.Queued)
+	running := globForTest(t, globs.Running)
+	done := globForTest(t, globs.Done)
+	if live := len(queued) + len(running) + len(done); live != 1 {
+		t.Fatalf("round %d: expected exactly one live copy of the task, got %d (queued=%v running=%v done=%v)",
+			round, live, queued, running, done)
+	}
+	if len(done) != 0 {
+		t.Fatalf("round %d: requeued task source remained in done after publication: %v", round, done)
+	}
+	if len(running) > 1 {
+		t.Fatalf("round %d: task was double-claimed into running: %v", round, running)
+	}
+	if len(queued) == 1 && len(running) == 1 {
+		t.Fatalf("round %d: task present in both queued and running (lost no-overwrite boundary)", round)
+	}
 }

--- a/internal/daemon/maintenance_polling_independence_test.go
+++ b/internal/daemon/maintenance_polling_independence_test.go
@@ -70,7 +70,7 @@ func TestNormalDaemonPollsPRCommentsWhileExecutorAttemptIsRunning(t *testing.T) 
 
 	// Arrange: an actionable open-PR task in tasks/done whose PR comments must be
 	// polled while the executor above is still blocked.
-	writeDaemonEnvironmentProfile(t, root, repo, true, false)
+	writeDaemonEnvironmentProfile(t, commentProfileSpec{Root: root, Repo: repo, PollComments: true, ReplyComments: false})
 	donePath := filepath.Join(root, "tasks", "done", "open-pr.yaml")
 	writeDaemonTask(t, donePath, repo)
 	doneTask, err := task.Load(donePath)

--- a/internal/daemon/notifications.go
+++ b/internal/daemon/notifications.go
@@ -66,12 +66,12 @@ func deliverTerminalNotification(ctx context.Context, opts Options, base, runDir
 	if !ok {
 		return
 	}
-	if !cfg.Matches(published.Status) {
+	if !cfg.Matches(string(published.Status)) {
 		return
 	}
 	ev := notify.Event{
 		TaskID:  published.ID,
-		Status:  published.Status,
+		Status:  string(published.Status),
 		Repo:    published.Scope.CWD,
 		Summary: latestTaskSummary(published),
 		RunDir:  runDir,

--- a/internal/daemon/notifications_test.go
+++ b/internal/daemon/notifications_test.go
@@ -17,7 +17,14 @@ func shellPath(path string) string {
 	return "'" + strings.ReplaceAll(filepath.ToSlash(path), "'", `'\''`) + "'"
 }
 
-func writePublishedTask(t *testing.T, root, state, base string, tk task.Task) string {
+type publishedTaskSpec struct {
+	Root  string
+	State string
+	Base  string
+}
+
+func writePublishedTask(t *testing.T, spec publishedTaskSpec, tk task.Task) string {
+	root, state, base := spec.Root, spec.State, spec.Base
 	t.Helper()
 	dir := filepath.Join(root, "tasks", state)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -30,7 +37,7 @@ func writePublishedTask(t *testing.T, root, state, base string, tk task.Task) st
 	return p
 }
 
-func baseTask(id, status string) task.Task {
+func baseTask(id string, status task.Status) task.Task {
 	return task.Task{
 		ID:       id,
 		Mode:     "afk",
@@ -46,7 +53,7 @@ func baseTask(id, status string) task.Task {
 func TestNotifyTerminalPublicationFiresOnMatchingStatus(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "failed", "task-a.yaml", baseTask("task-a", "failed"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-a.yaml"}, baseTask("task-a", "failed"))
 	runDir := "/galley/runs/run-1"
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{
 		Enabled: true,
@@ -66,7 +73,7 @@ func TestNotifyTerminalPublicationFiresOnMatchingStatus(t *testing.T) {
 func TestNotifyTerminalPublicationFiresOnNeedsSupervisorReview(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "failed", "task-b.yaml", baseTask("task-b", "needs_supervisor_review"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-b.yaml"}, baseTask("task-b", "needs_supervisor_review"))
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{Enabled: true, Command: "touch " + shellPath(marker)}}
 	deliverTerminalNotification(context.Background(), opts, "task-b.yaml", "")
 	if _, err := os.Stat(marker); err != nil {
@@ -78,7 +85,7 @@ func TestNotifyTerminalPublicationFiresOnNeedsSupervisorReview(t *testing.T) {
 func TestNotifyTerminalPublicationSkipsNonDefaultStatus(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "done", "task-c.yaml", baseTask("task-c", "accepted"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "done", Base: "task-c.yaml"}, baseTask("task-c", "accepted"))
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{Enabled: true, Command: "touch " + shellPath(marker)}}
 	deliverTerminalNotification(context.Background(), opts, "task-c.yaml", "")
 	if _, err := os.Stat(marker); err == nil {
@@ -90,7 +97,7 @@ func TestNotifyTerminalPublicationSkipsNonDefaultStatus(t *testing.T) {
 func TestNotifyTerminalPublicationFiresOnOptInAccepted(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "done", "task-d.yaml", baseTask("task-d", "accepted"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "done", Base: "task-d.yaml"}, baseTask("task-d", "accepted"))
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{Enabled: true, On: []string{"accepted"}, Command: "touch " + shellPath(marker)}}
 	deliverTerminalNotification(context.Background(), opts, "task-d.yaml", "")
 	if _, err := os.Stat(marker); err != nil {
@@ -113,7 +120,7 @@ func TestNotifyTerminalPublicationSkipsWhenNotPublished(t *testing.T) {
 // AC5: a failing hook command must not panic and must not alter task state.
 func TestNotifyTerminalPublicationSwallowsHookFailure(t *testing.T) {
 	root := t.TempDir()
-	published := writePublishedTask(t, root, "failed", "task-e.yaml", baseTask("task-e", "failed"))
+	published := writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-e.yaml"}, baseTask("task-e", "failed"))
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{Enabled: true, Command: "exit 7"}}
 	// Must not panic.
 	deliverTerminalNotification(context.Background(), opts, "task-e.yaml", "")
@@ -127,7 +134,7 @@ func TestNotifyTerminalPublicationSwallowsHookFailure(t *testing.T) {
 func TestNotifyTerminalPublicationDisabled(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "failed", "task-f.yaml", baseTask("task-f", "failed"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-f.yaml"}, baseTask("task-f", "failed"))
 	// nil config
 	deliverTerminalNotification(context.Background(), Options{Root: root}, "task-f.yaml", "")
 	// disabled config
@@ -148,7 +155,7 @@ func TestNotifyTerminalPublicationDoesNotBlockOnSlowCommand(t *testing.T) {
 	}
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "fired")
-	writePublishedTask(t, root, "failed", "task-slow.yaml", baseTask("task-slow", "failed"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-slow.yaml"}, baseTask("task-slow", "failed"))
 	dispatcher := newNotificationDispatcher(context.Background())
 	opts := Options{Root: root, Notifications: &daemonconfig.NotificationConfig{
 		Enabled: true,
@@ -184,7 +191,7 @@ func TestNotifyTerminalPublicationStuckCommandKilledByTimeout(t *testing.T) {
 		t.Skip("uses a POSIX shell command")
 	}
 	root := t.TempDir()
-	writePublishedTask(t, root, "failed", "task-stuck.yaml", baseTask("task-stuck", "failed"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-stuck.yaml"}, baseTask("task-stuck", "failed"))
 	dispatcher := newNotificationDispatcher(context.Background())
 	opts := Options{
 		Root:             root,
@@ -219,7 +226,7 @@ func TestNotifyTerminalPublicationShutdownCancelsStuckCommand(t *testing.T) {
 		t.Skip("uses a POSIX shell command")
 	}
 	root := t.TempDir()
-	writePublishedTask(t, root, "failed", "task-shutdown.yaml", baseTask("task-shutdown", "failed"))
+	writePublishedTask(t, publishedTaskSpec{Root: root, State: "failed", Base: "task-shutdown.yaml"}, baseTask("task-shutdown", "failed"))
 	ctx, cancel := context.WithCancel(context.Background())
 	dispatcher := newNotificationDispatcher(ctx)
 	opts := Options{

--- a/internal/daemon/path_set.go
+++ b/internal/daemon/path_set.go
@@ -122,16 +122,11 @@ func parseStatusPorcelainZ(s string) []statusEntry {
 			// Staging uses only the destination; the source is already staged by Git.
 			idx2 := strings.IndexByte(rest, 0)
 			if idx2 < 0 {
-				if path != "" {
-					entries = append(entries, statusEntry{X: x, Y: y, Path: path})
-				}
-				return entries
+				return appendStatusEntry(entries, x, y, path)
 			}
 			rest = rest[idx2+1:]
 		}
-		if path != "" {
-			entries = append(entries, statusEntry{X: x, Y: y, Path: path})
-		}
+		entries = appendStatusEntry(entries, x, y, path)
 	}
 	return entries
 }
@@ -197,4 +192,11 @@ func nonCommittedInputDestinations(files []task.InputFile) []string {
 		paths = append(paths, dest)
 	}
 	return paths
+}
+
+func appendStatusEntry(entries []statusEntry, x, y byte, path string) []statusEntry {
+	if path == "" {
+		return entries
+	}
+	return append(entries, statusEntry{X: x, Y: y, Path: path})
 }

--- a/internal/daemon/pr.go
+++ b/internal/daemon/pr.go
@@ -19,22 +19,25 @@ import (
 	"github.com/shinpr/galley/internal/workspace"
 )
 
-func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task, workDir, baseSHA, runDir string) error {
+// acceptedChange is the accepted work a finalization commits and publishes.
+type acceptedChange struct {
+	Opts    Options
+	Loaded  *task.Task
+	WorkDir string
+	BaseSHA string
+	RunDir  string
+}
+
+func finalizeAcceptedChange(ctx context.Context, ch acceptedChange) error {
+	opts, loaded := ch.Opts, ch.Loaded
+	workDir, baseSHA, runDir := ch.WorkDir, ch.BaseSHA, ch.RunDir
 	if err := inputfiles.CleanupNonCommitted(workDir, loaded.Files); err != nil {
 		return err
 	}
 
 	snapshot, snapshotErr := workspace.CaptureSnapshotFromBase(ctx, workDir, baseSHA, workspaceOptions(opts))
 	if snapshotErr == nil && !snapshot.Dirty {
-		if loaded.PR.URL != "" {
-			loaded.PR.Status = "open"
-			return nil
-		}
-		if !opts.OpenPR {
-			loaded.PR.Status = "not_requested"
-			return nil
-		}
-		return fmt.Errorf("accepted task has no git diff to commit and no existing PR")
+		return finalizeWithoutDiff(loaded, opts.OpenPR)
 	}
 	if snapshotErr != nil {
 		return fmt.Errorf("capture final diff: %w", snapshotErr)
@@ -53,16 +56,8 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 		return fmt.Errorf("write pr body: %w", err)
 	}
 	if snapshot.StatusPorcelain != "" {
-		commitMessage := fmt.Sprintf("galley: %s", strutil.FirstNonEmpty(loaded.ID, "accepted task"))
-		// Skip git add when only already-staged deletions remain; they are
-		// still committed from the index.
-		if addPaths := addEligiblePorcelainPaths(snapshot.StatusPorcelain); len(addPaths) > 0 {
-			if err := vcs.AddPaths(ctx, vcsBinaries(opts), workDir, runDir, addPaths); err != nil {
-				return err
-			}
-		}
-		if err := vcs.Commit(ctx, vcsBinaries(opts), workDir, runDir, commitMessage); err != nil {
-			return &finalizeFailure{Err: err}
+		if err := commitAcceptedDiff(ctx, vcsRepo(opts, workDir, runDir), *loaded, snapshot.StatusPorcelain); err != nil {
+			return err
 		}
 	}
 	if !opts.OpenPR {
@@ -74,7 +69,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	// the remote already has the SHA or surfaces a non-fast-forward error
 	// unchanged for the caller to handle.
 	if err := retry.Do(ctx, func(ctx context.Context) error {
-		return vcs.PushCurrentBranch(ctx, vcsBinaries(opts), workDir, runDir)
+		return vcs.PushCurrentBranch(ctx, vcsRepo(opts, workDir, runDir))
 	}); err != nil {
 		return &finalizeFailure{Err: err}
 	}
@@ -91,7 +86,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	// failure surfaces unchanged.
 	var prURL string
 	err := retry.Do(ctx, func(ctx context.Context) error {
-		url, createErr := vcs.CreatePullRequest(ctx, vcsBinaries(opts), workDir, runDir, prBodyPath, opts.PRBase, prTitle(*loaded))
+		url, createErr := vcs.CreatePullRequest(ctx, vcsRepo(opts, workDir, runDir), vcs.PullRequestSpec{Title: prTitle(*loaded), BodyPath: prBodyPath, Base: opts.PRBase})
 		if createErr != nil {
 			return createErr
 		}
@@ -99,7 +94,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 		return nil
 	})
 	if err != nil {
-		recovered, viewErr := vcs.FetchPRURLForCurrentBranch(ctx, vcsBinaries(opts), workDir, runDir)
+		recovered, viewErr := vcs.FetchPRURLForCurrentBranch(ctx, vcsRepo(opts, workDir, runDir))
 		if viewErr != nil || recovered == "" {
 			return &finalizeFailure{Err: err}
 		}
@@ -117,7 +112,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 	// login. GET is idempotent, so retries are safe.
 	var authorLogin string
 	authorErr := retry.Do(ctx, func(ctx context.Context) error {
-		login, fetchErr := vcs.FetchPRAuthorLogin(ctx, vcsBinaries(opts), workDir, prURL)
+		login, fetchErr := vcs.FetchPRAuthorLogin(ctx, vcsRepo(opts, workDir, ""), prURL)
 		if fetchErr != nil {
 			return fetchErr
 		}
@@ -125,7 +120,7 @@ func finalizeAcceptedChange(ctx context.Context, opts Options, loaded *task.Task
 		return nil
 	})
 	if authorErr != nil {
-		appendRiskWithID(loaded, "pr-author-lookup-"+strutil.FirstNonEmpty(loaded.ID, "task"), "external_dependency", fmt.Sprintf("Galley created the PR but could not record its author login: %v", authorErr), "Re-run `gh api repos/{owner}/{repo}/pulls/{number}` after the GitHub API is reachable and set pr.author_login on the task YAML, or expect Galley to reject /galley PR comments until the author is known.", true)
+		appendRiskWithID(loaded, "pr-author-lookup-"+strutil.FirstNonEmpty(loaded.ID, "task"), riskSpec{Type: "external_dependency", Detail: fmt.Sprintf("Galley created the PR but could not record its author login: %v", authorErr), Mitigation: "Re-run `gh api repos/{owner}/{repo}/pulls/{number}` after the GitHub API is reachable and set pr.author_login on the task YAML, or expect Galley to reject /galley PR comments until the author is known.", HumanReview: true})
 		return nil
 	}
 	loaded.PR.AuthorLogin = authorLogin
@@ -330,16 +325,7 @@ func renderPRBody(loaded task.Task) string {
 	if decisions := prVisibleDecisions(loaded.Decisions); len(decisions) > 0 {
 		b.WriteString("\n## Key Decisions\n\n")
 		for _, decision := range decisions {
-			fmt.Fprintf(&b, "- `%s` %s -> %s\n", decision.ID, decision.Question, decision.Chosen)
-			if decision.Rationale != "" {
-				fmt.Fprintf(&b, "  - Rationale: %s\n", decision.Rationale)
-			}
-			if decision.Reversibility != "" {
-				fmt.Fprintf(&b, "  - Reversibility: %s\n", decision.Reversibility)
-			}
-			if decision.NeedsHumanReview {
-				fmt.Fprintf(&b, "  - Human review suggested: true\n")
-			}
+			renderPRDecision(&b, decision)
 		}
 	}
 	if len(loaded.DiscussionItems) > 0 {
@@ -426,4 +412,46 @@ func isResolvedAttemptRisk(risk task.Risk) bool {
 		}
 	}
 	return false
+}
+
+// finalizeWithoutDiff records the PR outcome for an accepted task whose
+// worktree carries no diff.
+func finalizeWithoutDiff(loaded *task.Task, openPR bool) error {
+	if loaded.PR.URL != "" {
+		loaded.PR.Status = "open"
+		return nil
+	}
+	if !openPR {
+		loaded.PR.Status = "not_requested"
+		return nil
+	}
+	return fmt.Errorf("accepted task has no git diff to commit and no existing PR")
+}
+
+// commitAcceptedDiff stages and commits the accepted change. git add is skipped
+// for already-staged deletions, which the index still commits.
+func commitAcceptedDiff(ctx context.Context, repo vcs.Repo, loaded task.Task, statusPorcelain string) error {
+	if addPaths := addEligiblePorcelainPaths(statusPorcelain); len(addPaths) > 0 {
+		if err := vcs.AddPaths(ctx, repo, addPaths); err != nil {
+			return err
+		}
+	}
+	message := fmt.Sprintf("galley: %s", strutil.FirstNonEmpty(loaded.ID, "accepted task"))
+	if err := vcs.Commit(ctx, repo, message); err != nil {
+		return &finalizeFailure{Err: err}
+	}
+	return nil
+}
+
+func renderPRDecision(b *strings.Builder, decision task.Decision) {
+	fmt.Fprintf(b, "- `%s` %s -> %s\n", decision.ID, decision.Question, decision.Chosen)
+	if decision.Rationale != "" {
+		fmt.Fprintf(b, "  - Rationale: %s\n", decision.Rationale)
+	}
+	if decision.Reversibility != "" {
+		fmt.Fprintf(b, "  - Reversibility: %s\n", decision.Reversibility)
+	}
+	if decision.NeedsHumanReview {
+		fmt.Fprintf(b, "  - Human review suggested: true\n")
+	}
 }

--- a/internal/daemon/pr_test.go
+++ b/internal/daemon/pr_test.go
@@ -74,76 +74,15 @@ func TestPRTitleTruncatesOnWordBoundary(t *testing.T) {
 	t.Parallel()
 
 	t.Run("english long goal breaks on whitespace", func(t *testing.T) {
-		t.Parallel()
-		// Build a goal whose rune length comfortably exceeds the current
-		// prTitleRuneBudget so the rune-budget pass engages and the cut must
-		// fall on a whitespace boundary inside the goal.
-		goal := "Fix Galley user-visible output so that supervisor-accepted tasks no longer show stale not_satisfied AC status in the PR body, and also extend the executor work order rendering so reviewers can audit every acceptance criterion together with the recorded supervisor verdict, decision rationale, residual risks, and verification commands without opening the underlying run evidence directory."
-		if len([]rune(goal)) <= prTitleRuneBudget {
-			t.Fatalf("test setup invariant: goal must exceed rune budget; len=%d budget=%d", len([]rune(goal)), prTitleRuneBudget)
-		}
-		title := prTitle(task.Task{Goal: goal})
-		if len([]rune(title)) > prTitleRuneBudget {
-			t.Fatalf("title exceeds rune budget: len=%d title=%q", len([]rune(title)), title)
-		}
-		if !strings.HasSuffix(title, prTitleEllipsis) {
-			t.Fatalf("expected ellipsis suffix, got %q", title)
-		}
-		// The character immediately before the ellipsis must not be a
-		// whitespace and must come from a complete word in the original goal.
-		core := strings.TrimSuffix(title, prTitleEllipsis)
-		core = strings.TrimRight(core, " \t")
-		if core == "" {
-			t.Fatalf("title core is empty after trimming whitespace: %q", title)
-		}
-		// The core must end at a word boundary in the original goal — i.e.,
-		// the next rune in the goal must be whitespace (or the goal must end).
-		if !strings.HasPrefix(goal, core) {
-			t.Fatalf("title core %q is not a prefix of goal", core)
-		}
-		next := goal[len(core):]
-		if next != "" && next[0] != ' ' && next[0] != '\t' {
-			t.Fatalf("title cut mid-word; next rune in goal is %q (title=%q)", string(next[0]), title)
-		}
+		assertEnglishLongGoalBreaksOnWhitespace(t)
 	})
 
 	t.Run("multibyte goal without whitespace falls back to rune cut", func(t *testing.T) {
-		t.Parallel()
-		// A long no-whitespace multibyte goal exercises both passes: the
-		// rune-budget pass takes the hard-cut fallback (no whitespace), then
-		// the byte-budget pass trims further because 3-byte runes overflow
-		// the 256-byte hard cap. The result must stay valid UTF-8, fit the
-		// byte budget, end with the ellipsis, and contain only complete 界
-		// runes (no partial UTF-8 sequences).
-		goal := strings.Repeat("界", prTitleRuneBudget+60)
-		title := prTitle(task.Task{Goal: goal})
-		if len(title) > prTitleByteBudget {
-			t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
-		}
-		if !utf8.ValidString(title) {
-			t.Fatalf("title is invalid UTF-8: %q", title)
-		}
-		if !strings.HasSuffix(title, prTitleEllipsis) {
-			t.Fatalf("expected ellipsis suffix on no-whitespace goal, got %q", title)
-		}
-		core := strings.TrimSuffix(title, prTitleEllipsis)
-		for _, r := range core {
-			if r != '界' {
-				t.Fatalf("title core contains unexpected rune %q in %q", r, title)
-			}
-		}
+		assertMultibyteGoalWithoutWhitespaceFallsBackToRuneCut(t)
 	})
 
 	t.Run("short goal stays untouched", func(t *testing.T) {
-		t.Parallel()
-		goal := "Tighten PR body status rendering"
-		title := prTitle(task.Task{Goal: goal})
-		if title != goal {
-			t.Fatalf("short goal should stay untouched, got %q", title)
-		}
-		if strings.HasSuffix(title, prTitleEllipsis) {
-			t.Fatalf("short goal should not gain ellipsis: %q", title)
-		}
+		assertShortGoalStaysUntouched(t)
 	})
 
 	// 4-byte UTF-8 runes such as emoji (🎉 = U+1F389, 4 bytes) can push a
@@ -152,29 +91,7 @@ func TestPRTitleTruncatesOnWordBoundary(t *testing.T) {
 	// must be trimmed back to <= 256 bytes while staying valid UTF-8 and
 	// keeping the ellipsis marker.
 	t.Run("4-byte runes stay within byte budget", func(t *testing.T) {
-		t.Parallel()
-		goal := strings.Repeat("🎉", 200)
-		title := prTitle(task.Task{Goal: goal})
-		if len(title) > prTitleByteBudget {
-			t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
-		}
-		if !utf8.ValidString(title) {
-			t.Fatalf("title is invalid UTF-8: %q", title)
-		}
-		if !strings.HasSuffix(title, prTitleEllipsis) {
-			t.Fatalf("expected ellipsis suffix on truncated 4-byte goal, got %q", title)
-		}
-		// The body before the ellipsis must consist entirely of complete
-		// 🎉 runes — no partial 4-byte sequences sneaking through.
-		core := strings.TrimSuffix(title, prTitleEllipsis)
-		if !utf8.ValidString(core) {
-			t.Fatalf("title core is invalid UTF-8: %q", core)
-		}
-		for _, r := range core {
-			if r != '🎉' {
-				t.Fatalf("title core contains unexpected rune %q in %q", r, title)
-			}
-		}
+		assert4ByteRunesStayWithinByteBudget(t)
 	})
 
 	// Mixed ASCII + 4-byte rune goal: GitHub's byte limit must hold even
@@ -182,25 +99,128 @@ func TestPRTitleTruncatesOnWordBoundary(t *testing.T) {
 	// bytes. The byte pass should still prefer a whitespace boundary so
 	// reviewers see complete words near the cut.
 	t.Run("ascii plus 4-byte runes break on whitespace under byte budget", func(t *testing.T) {
-		t.Parallel()
-		// 60 emoji * 4 bytes = 240 bytes, plus a long ASCII tail that
-		// forces a break inside the byte budget.
-		goal := strings.Repeat("🎉 ", 60) + "Tail context that should be dropped on truncation"
-		title := prTitle(task.Task{Goal: goal})
-		if len(title) > prTitleByteBudget {
-			t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
-		}
-		if !utf8.ValidString(title) {
-			t.Fatalf("title is invalid UTF-8: %q", title)
-		}
-		if !strings.HasSuffix(title, prTitleEllipsis) {
-			t.Fatalf("expected ellipsis suffix, got %q", title)
-		}
-		core := strings.TrimSuffix(title, prTitleEllipsis)
-		if strings.HasSuffix(core, " ") {
-			t.Fatalf("trailing whitespace before ellipsis: %q", title)
-		}
+		assertAsciiPlus4ByteRunesBreakOnWhitespaceUnderByteBudget(t)
 	})
+}
+
+func assertEnglishLongGoalBreaksOnWhitespace(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	// A goal past prTitleRuneBudget engages the rune-budget pass, whose cut
+	// must land on a whitespace boundary inside the goal.
+	goal := "Fix Galley user-visible output so that supervisor-accepted tasks no longer show stale not_satisfied AC status in the PR body, and also extend the executor work order rendering so reviewers can audit every acceptance criterion together with the recorded supervisor verdict, decision rationale, residual risks, and verification commands without opening the underlying run evidence directory."
+	if len([]rune(goal)) <= prTitleRuneBudget {
+		t.Fatalf("test setup invariant: goal must exceed rune budget; len=%d budget=%d", len([]rune(goal)), prTitleRuneBudget)
+	}
+	title := prTitle(task.Task{Goal: goal})
+	if len([]rune(title)) > prTitleRuneBudget {
+		t.Fatalf("title exceeds rune budget: len=%d title=%q", len([]rune(title)), title)
+	}
+	if !strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("expected ellipsis suffix, got %q", title)
+	}
+	// The character immediately before the ellipsis must not be a
+	// whitespace and must come from a complete word in the original goal.
+	core := strings.TrimSuffix(title, prTitleEllipsis)
+	core = strings.TrimRight(core, " \t")
+	if core == "" {
+		t.Fatalf("title core is empty after trimming whitespace: %q", title)
+	}
+	// The core must end at a word boundary in the original goal — i.e.,
+	// the next rune in the goal must be whitespace (or the goal must end).
+	if !strings.HasPrefix(goal, core) {
+		t.Fatalf("title core %q is not a prefix of goal", core)
+	}
+	next := goal[len(core):]
+	if next != "" && next[0] != ' ' && next[0] != '\t' {
+		t.Fatalf("title cut mid-word; next rune in goal is %q (title=%q)", string(next[0]), title)
+	}
+}
+
+func assertMultibyteGoalWithoutWhitespaceFallsBackToRuneCut(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	// A long no-whitespace multibyte goal exercises both passes; the result
+	// must stay valid UTF-8, fit the byte budget, and end with the ellipsis.
+	goal := strings.Repeat("界", prTitleRuneBudget+60)
+	title := prTitle(task.Task{Goal: goal})
+	if len(title) > prTitleByteBudget {
+		t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
+	}
+	if !utf8.ValidString(title) {
+		t.Fatalf("title is invalid UTF-8: %q", title)
+	}
+	if !strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("expected ellipsis suffix on no-whitespace goal, got %q", title)
+	}
+	core := strings.TrimSuffix(title, prTitleEllipsis)
+	for _, r := range core {
+		if r != '界' {
+			t.Fatalf("title core contains unexpected rune %q in %q", r, title)
+		}
+	}
+}
+
+func assertShortGoalStaysUntouched(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	goal := "Tighten PR body status rendering"
+	title := prTitle(task.Task{Goal: goal})
+	if title != goal {
+		t.Fatalf("short goal should stay untouched, got %q", title)
+	}
+	if strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("short goal should not gain ellipsis: %q", title)
+	}
+}
+
+func assert4ByteRunesStayWithinByteBudget(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	goal := strings.Repeat("🎉", 200)
+	title := prTitle(task.Task{Goal: goal})
+	if len(title) > prTitleByteBudget {
+		t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
+	}
+	if !utf8.ValidString(title) {
+		t.Fatalf("title is invalid UTF-8: %q", title)
+	}
+	if !strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("expected ellipsis suffix on truncated 4-byte goal, got %q", title)
+	}
+	// The body before the ellipsis must consist entirely of complete
+	// 🎉 runes — no partial 4-byte sequences sneaking through.
+	core := strings.TrimSuffix(title, prTitleEllipsis)
+	if !utf8.ValidString(core) {
+		t.Fatalf("title core is invalid UTF-8: %q", core)
+	}
+	for _, r := range core {
+		if r != '🎉' {
+			t.Fatalf("title core contains unexpected rune %q in %q", r, title)
+		}
+	}
+}
+
+func assertAsciiPlus4ByteRunesBreakOnWhitespaceUnderByteBudget(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	// 60 emoji * 4 bytes = 240 bytes, plus a long ASCII tail that
+	// forces a break inside the byte budget.
+	goal := strings.Repeat("🎉 ", 60) + "Tail context that should be dropped on truncation"
+	title := prTitle(task.Task{Goal: goal})
+	if len(title) > prTitleByteBudget {
+		t.Fatalf("title exceeds byte budget: bytes=%d title=%q", len(title), title)
+	}
+	if !utf8.ValidString(title) {
+		t.Fatalf("title is invalid UTF-8: %q", title)
+	}
+	if !strings.HasSuffix(title, prTitleEllipsis) {
+		t.Fatalf("expected ellipsis suffix, got %q", title)
+	}
+	core := strings.TrimSuffix(title, prTitleEllipsis)
+	if strings.HasSuffix(core, " ") {
+		t.Fatalf("trailing whitespace before ellipsis: %q", title)
+	}
 }
 
 func TestRenderPRBodyShowsSupervisorAcceptedStatus(t *testing.T) {

--- a/internal/daemon/preflight_freshness_test.go
+++ b/internal/daemon/preflight_freshness_test.go
@@ -25,7 +25,7 @@ func TestSetupDoesNotReuseSuccessWithoutInputEvidence(t *testing.T) {
 	if err := os.MkdirAll(current, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	_, reused, err := reuseReadySetup(root, "freshness", current, executor, "current-inputs")
+	_, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: "freshness", RunDir: current, Effective: executor, InputKey: "current-inputs"})
 	if err != nil || reused {
 		t.Fatalf("unverified prior inputs reused=%t: %v", reused, err)
 	}
@@ -41,7 +41,7 @@ func TestSymlinkedSetupSignalDisablesReuse(t *testing.T) {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 	prepared := claimedWorkspace{Prepared: workspace.Prepared{CWD: workDir}}
-	if key := preflightInputKey("setup", task.Task{}, profile.Bundle{}, prepared, task.Executor{}); key != "" {
+	if key := preflightInputKey("setup", preflightInputSources{Loaded: task.Task{}, Profiles: profile.Bundle{}, Prepared: prepared, Executor: task.Executor{}}); key != "" {
 		t.Fatal("symlink target freshness was assumed")
 	}
 }
@@ -58,72 +58,121 @@ func TestPreflightReuseTracksStageInputsAndPreservesEditedSkeletons(t *testing.T
 			if err := os.WriteFile(path, []byte("implemented test"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			prior := filepath.Join(root, "runs", "fresh-1")
-			setup := &setuppreflight.Result{Status: "ready"}
-			setuppreflight.ApplyExecutorIdentity(setup, executor)
-			if err := setuppreflight.WriteResult(prior, setup); err != nil {
-				t.Fatal(err)
-			}
-			skeleton := &skeletonpreflight.Result{Status: "completed", Outputs: []skeletonpreflight.Output{{ACID: "AC1", Path: "test.go"}}}
-			skeletonpreflight.ApplyExecutorIdentity(skeleton, executor)
-			if err := skeletonpreflight.WriteResult(prior, skeleton); err != nil {
-				t.Fatal(err)
-			}
-			for _, phase := range []string{"setup", "skeleton"} {
-				if err := recordPreflightInputs(prior, phase, preflightInputKey(phase, loaded, profiles, prepared, executor), prior); err != nil {
-					t.Fatal(err)
-				}
-			}
-			wantSetup, wantSkeleton := false, false
-			switch change {
-			case "unchanged":
-				wantSetup, wantSkeleton = true, true
-			case "ac":
-				loaded.AcceptanceCriteria[0].Text = "new requirement"
-			case "verification":
-				loaded.AcceptanceCriteria[0].Verification = "new check"
-			case "quality":
-				profiles.Quality.RequiredChecks = []profile.RequiredCheck{{ID: "new", Required: true}}
-			case "environment":
-				profiles.Environment.Commands = map[string]string{"test": "new command"}
-			case "workdir":
-				prepared.CWD = t.TempDir()
-			case "scope":
-				loaded.Scope.ForbiddenPaths = []string{"test.go"}
-			case "input":
-				prepared.ReviewContractContext.InputFilesDigest = "changed-input"
-			case "human-amendment":
-				loaded.RevisionRequests = []task.RevisionRequest{{Source: "manual", Text: "new expected behavior", Status: "pending"}}
-			case "manifest":
-				if err := os.WriteFile(filepath.Join(workDir, "go.mod"), []byte("module changed"), 0o600); err != nil {
-					t.Fatal(err)
-				}
-				wantSkeleton = true
-			case "missing-skeleton":
-				if err := os.Remove(path); err != nil {
-					t.Fatal(err)
-				}
-				wantSetup = true
-			case "runtime-results":
-				loaded.Status = "failed"
-				loaded.AcceptanceCriteria[0].Status = "satisfied"
-				skeletonpreflight.ApplyToTask(&loaded, skeleton)
-				wantSetup, wantSkeleton = true, true
-			}
+			skeleton := seedPriorPreflightRun(t, priorRunSeed{
+				Root: root, Loaded: loaded, Profiles: profiles, Prepared: prepared, Executor: executor,
+			})
+			wantSetup, wantSkeleton := applyFreshnessChange(t, change, &freshnessInputs{
+				Loaded: &loaded, Profiles: &profiles, Prepared: &prepared,
+				WorkDir: workDir, SkeletonPath: path, Skeleton: skeleton,
+			})
 			current := filepath.Join(root, "runs", "fresh-2")
-			_, gotSetup, err := reuseReadySetup(root, loaded.ID, current, executor, preflightInputKey("setup", loaded, profiles, prepared, executor))
+			_, gotSetup, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: loaded.ID, RunDir: current, Effective: executor, InputKey: preflightInputKey("setup", preflightInputSources{Loaded: loaded, Profiles: profiles, Prepared: prepared, Executor: executor})})
 			if err != nil || gotSetup != wantSetup {
 				t.Fatalf("setup reused=%t want=%t: %v", gotSetup, wantSetup, err)
 			}
-			_, gotSkeleton, err := reuseCompletedAcceptanceSkeleton(root, loaded.ID, current, executor, preflightInputKey("skeleton", loaded, profiles, prepared, executor), prepared.CWD)
+			_, gotSkeleton, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: loaded.ID, RunDir: current, Effective: executor, InputKey: preflightInputKey("skeleton", preflightInputSources{Loaded: loaded, Profiles: profiles, Prepared: prepared, Executor: executor}), WorkDir: prepared.CWD})
 			if err != nil || gotSkeleton != wantSkeleton {
 				t.Fatalf("skeleton reused=%t want=%t: %v", gotSkeleton, wantSkeleton, err)
 			}
 			if change != "missing-skeleton" {
-				if data, err := os.ReadFile(path); err != nil || string(data) != "implemented test" {
-					t.Fatalf("existing work changed: %q %v", data, err)
-				}
+				assertSkeletonUnchanged(t, path)
 			}
 		})
 	}
+}
+
+// freshnessInputs are the reuse-key inputs one freshness case mutates.
+type freshnessInputs struct {
+	Loaded       *task.Task
+	Profiles     *profile.Bundle
+	Prepared     *claimedWorkspace
+	WorkDir      string
+	SkeletonPath string
+	Skeleton     *skeletonpreflight.Result
+}
+
+// applyFreshnessChange mutates one reuse-key input and reports whether the
+// setup and skeleton stages should still be reusable afterwards.
+func applyFreshnessChange(t *testing.T, change string, in *freshnessInputs) (wantSetup, wantSkeleton bool) {
+	t.Helper()
+	switch change {
+	case "unchanged":
+		return true, true
+	case "ac":
+		in.Loaded.AcceptanceCriteria[0].Text = "new requirement"
+	case "verification":
+		in.Loaded.AcceptanceCriteria[0].Verification = "new check"
+	case "quality":
+		in.Profiles.Quality.RequiredChecks = []profile.RequiredCheck{{ID: "new", Required: true}}
+	case "environment":
+		in.Profiles.Environment.Commands = map[string]string{"test": "new command"}
+	case "workdir":
+		in.Prepared.CWD = t.TempDir()
+	case "scope":
+		in.Loaded.Scope.ForbiddenPaths = []string{"test.go"}
+	case "input":
+		in.Prepared.ReviewContractContext.InputFilesDigest = "changed-input"
+	case "human-amendment":
+		in.Loaded.RevisionRequests = []task.RevisionRequest{{Source: "manual", Text: "new expected behavior", Status: "pending"}}
+	case "manifest":
+		// A changed manifest invalidates setup discovery but not the skeleton.
+		if err := os.WriteFile(filepath.Join(in.WorkDir, "go.mod"), []byte("module changed"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return false, true
+	case "missing-skeleton":
+		// A deleted skeleton invalidates the skeleton stage but not setup.
+		if err := os.Remove(in.SkeletonPath); err != nil {
+			t.Fatal(err)
+		}
+		return true, false
+	case "runtime-results":
+		// Runtime results are excluded from the key, so both stages stay reusable.
+		in.Loaded.Status = "failed"
+		in.Loaded.AcceptanceCriteria[0].Status = "satisfied"
+		skeletonpreflight.ApplyToTask(in.Loaded, in.Skeleton)
+		return true, true
+	}
+	return false, false
+}
+
+func assertSkeletonUnchanged(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "implemented test" {
+		t.Fatalf("existing work changed: %q %v", data, err)
+	}
+}
+
+// priorRunSeed is the completed prior run a freshness case reuses from.
+type priorRunSeed struct {
+	Root     string
+	Loaded   task.Task
+	Profiles profile.Bundle
+	Prepared claimedWorkspace
+	Executor task.Executor
+}
+
+// seedPriorPreflightRun writes runs/fresh-1 with a ready setup, a completed
+// skeleton, and the recorded stage input keys, then returns the skeleton result.
+func seedPriorPreflightRun(t *testing.T, seed priorRunSeed) *skeletonpreflight.Result {
+	t.Helper()
+	prior := filepath.Join(seed.Root, "runs", "fresh-1")
+	setup := &setuppreflight.Result{Status: "ready"}
+	setuppreflight.ApplyExecutorIdentity(setup, seed.Executor)
+	if err := setuppreflight.WriteResult(prior, setup); err != nil {
+		t.Fatal(err)
+	}
+	skeleton := &skeletonpreflight.Result{Status: "completed", Outputs: []skeletonpreflight.Output{{ACID: "AC1", Path: "test.go"}}}
+	skeletonpreflight.ApplyExecutorIdentity(skeleton, seed.Executor)
+	if err := skeletonpreflight.WriteResult(prior, skeleton); err != nil {
+		t.Fatal(err)
+	}
+	sources := preflightInputSources{Loaded: seed.Loaded, Profiles: seed.Profiles, Prepared: seed.Prepared, Executor: seed.Executor}
+	for _, phase := range []string{"setup", "skeleton"} {
+		if err := recordPreflightInputs(prior, phase, preflightInputKey(phase, sources), prior); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return skeleton
 }

--- a/internal/daemon/preflight_inputs.go
+++ b/internal/daemon/preflight_inputs.go
@@ -39,7 +39,16 @@ func recordPreflightInputs(runDir, phase, key, source string) error {
 }
 
 // preflightInputKey excludes runtime results and binds reuse to the stage's current inputs.
-func preflightInputKey(phase string, loaded task.Task, profiles profile.Bundle, prepared claimedWorkspace, executor task.Executor) string {
+// preflightInputSources are the current inputs a preflight stage is keyed on.
+type preflightInputSources struct {
+	Loaded   task.Task
+	Profiles profile.Bundle
+	Prepared claimedWorkspace
+	Executor task.Executor
+}
+
+func preflightInputKey(phase string, sources preflightInputSources) string {
+	loaded, profiles, prepared, executor := sources.Loaded, sources.Profiles, sources.Prepared, sources.Executor
 	acceptance := append([]task.AcceptanceCriterion(nil), loaded.AcceptanceCriteria...)
 	for i := range acceptance {
 		acceptance[i].Status = ""
@@ -63,31 +72,8 @@ func preflightInputKey(phase string, loaded task.Task, profiles profile.Bundle, 
 		}
 	}
 	inputs["amendments"] = amendments
-	if phase == "setup" {
-		signals := make(map[string]string)
-		for _, path := range setuppreflight.DiscoverRepositorySignals(prepared.CWD) {
-			full := filepath.Join(prepared.CWD, path)
-			info, err := os.Lstat(full)
-			var data []byte
-			if err == nil && info.Mode()&os.ModeSymlink != 0 {
-				err = fmt.Errorf("symlinked setup input cannot establish freshness: %s", full)
-			} else if err == nil && info.Mode().IsRegular() {
-				data, err = os.ReadFile(full)
-			} else if err == nil {
-				err = fmt.Errorf("not a regular setup input: %s", full)
-			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "galley: setup reuse disabled: %v\n", err)
-				return ""
-			}
-			signals[path] = fmt.Sprintf("%s:%x", info.Mode(), sha256.Sum256(data))
-		}
-		inputs["repository_signals"] = signals
-		inputs["schema"] = schemas.SetupResult
-		inputs["prompts"] = []string{prompts.SetupExecutorCodex(), prompts.SetupExecutorClaude(), prompts.SetupExecutorGrok()}
-	} else {
-		inputs["schema"] = schemas.AcceptanceSkeletonManifest
-		inputs["prompts"] = []string{prompts.AcceptanceSkeletonCreatorCodex(), prompts.AcceptanceSkeletonCreator(), prompts.AcceptanceSkeletonCreatorGrok()}
+	if !addPhaseInputs(inputs, phase, prepared.CWD) {
+		return ""
 	}
 	data, err := json.Marshal(inputs)
 	if err != nil {
@@ -113,5 +99,59 @@ func reusableSkeletonFiles(workDir string, result *skeletonpreflight.Result) boo
 			return false
 		}
 	}
+	return true
+}
+
+// repositorySignals hashes the setup stage's repository inputs. It reports
+// false when any signal cannot establish freshness, which disables setup reuse.
+func repositorySignals(workDir string) (map[string]string, bool) {
+	signals := make(map[string]string)
+	for _, path := range setuppreflight.DiscoverRepositorySignals(workDir) {
+		full := filepath.Join(workDir, path)
+		info, err := os.Lstat(full)
+		data, err := readSetupSignal(full, info, err)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "galley: setup reuse disabled: %v\n", err)
+			return nil, false
+		}
+		signals[path] = fmt.Sprintf("%s:%x", info.Mode(), sha256.Sum256(data))
+	}
+	return signals, true
+}
+
+// readSetupSignal reads a regular setup input; a symlink or any other file kind
+// cannot establish freshness.
+func readSetupSignal(full string, info os.FileInfo, statErr error) ([]byte, error) {
+	if statErr != nil {
+		return nil, statErr
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("symlinked setup input cannot establish freshness: %s", full)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular setup input: %s", full)
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		return nil, fmt.Errorf("read setup input %s: %w", full, err)
+	}
+	return data, nil
+}
+
+// addPhaseInputs adds the phase-specific reuse key inputs. It reports false when
+// the setup phase cannot establish repository freshness, which disables reuse.
+func addPhaseInputs(inputs map[string]any, phase, workDir string) bool {
+	if phase != "setup" {
+		inputs["schema"] = schemas.AcceptanceSkeletonManifest
+		inputs["prompts"] = []string{prompts.AcceptanceSkeletonCreatorCodex(), prompts.AcceptanceSkeletonCreator(), prompts.AcceptanceSkeletonCreatorGrok()}
+		return true
+	}
+	signals, ok := repositorySignals(workDir)
+	if !ok {
+		return false
+	}
+	inputs["repository_signals"] = signals
+	inputs["schema"] = schemas.SetupResult
+	inputs["prompts"] = []string{prompts.SetupExecutorCodex(), prompts.SetupExecutorClaude(), prompts.SetupExecutorGrok()}
 	return true
 }

--- a/internal/daemon/preflight_reuse.go
+++ b/internal/daemon/preflight_reuse.go
@@ -18,7 +18,19 @@ import (
 	"github.com/shinpr/galley/internal/workspace"
 )
 
-func reuseReadySetup(root, taskID, runDir string, effective task.Executor, inputKey string) (*setuppreflight.Result, bool, error) {
+// preflightReuseQuery identifies which prior run a preflight result may be
+// reused from.
+type preflightReuseQuery struct {
+	Root      string
+	TaskID    string
+	RunDir    string
+	WorkDir   string
+	Effective task.Executor
+	InputKey  string
+}
+
+func reuseReadySetup(q preflightReuseQuery) (*setuppreflight.Result, bool, error) {
+	root, taskID, runDir, effective, inputKey := q.Root, q.TaskID, q.RunDir, q.Effective, q.InputKey
 	dirs, err := priorTaskRunDirs(root, taskID, runDir)
 	if err != nil {
 		return nil, false, err
@@ -48,7 +60,8 @@ func reuseReadySetup(root, taskID, runDir string, effective task.Executor, input
 	return nil, false, nil
 }
 
-func reuseCompletedAcceptanceSkeleton(root, taskID, runDir string, effective task.Executor, inputKey, workDir string) (*skeletonpreflight.Result, bool, error) {
+func reuseCompletedAcceptanceSkeleton(q preflightReuseQuery) (*skeletonpreflight.Result, bool, error) {
+	root, taskID, runDir, effective, inputKey, workDir := q.Root, q.TaskID, q.RunDir, q.Effective, q.InputKey, q.WorkDir
 	dirs, err := priorTaskRunDirs(root, taskID, runDir)
 	if err != nil {
 		return nil, false, err
@@ -88,7 +101,7 @@ func priorTaskRunDirs(root, taskID, currentRunDir string) ([]string, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("read prior run dirs under %s: %w", filepath.Join(root, "runs"), err)
 	}
 	prefix := taskID + "-"
 	type candidate struct {
@@ -124,7 +137,16 @@ func preflightReuseError(phase string, err error) error {
 
 // retainPriorReviewBase keeps a prior run's review base while a finalization
 // failure is still pending, so its accepted commit stays inside the diff.
-func retainPriorReviewBase(ctx context.Context, opts Options, loaded task.Task, runDir string, prepared *workspace.Prepared) {
+// reviewBaseRetention is the prepared workspace whose review base may need to
+// survive a pending finalization failure.
+type reviewBaseRetention struct {
+	Loaded   task.Task
+	RunDir   string
+	Prepared *workspace.Prepared
+}
+
+func retainPriorReviewBase(ctx context.Context, opts Options, req reviewBaseRetention) {
+	loaded, runDir, prepared := req.Loaded, req.RunDir, req.Prepared
 	if prepared == nil || !prepared.WorktreeReused || prepared.BaseSHA == "" {
 		return
 	}
@@ -140,7 +162,7 @@ func retainPriorReviewBase(ctx context.Context, opts Options, loaded task.Task, 
 	if prior == "" || prior == prepared.BaseSHA {
 		return
 	}
-	ancestor, err := vcs.IsAncestor(ctx, vcsBinaries(opts), prepared.CWD, prior, prepared.BaseSHA)
+	ancestor, err := vcs.IsAncestor(ctx, vcsRepo(opts, prepared.CWD, ""), prior, prepared.BaseSHA)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "galley: task %s could not verify the prior review base %s: %v\n", taskID, prior, err)
 		return

--- a/internal/daemon/preflight_reuse_test.go
+++ b/internal/daemon/preflight_reuse_test.go
@@ -54,11 +54,11 @@ func TestReuseCompletedPreflightsFindsEarlierSuccessfulRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	setupRes, setupReused, err := reuseReadySetup(root, taskID, currentRun, effective, "test")
+	setupRes, setupReused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: effective, InputKey: "test"})
 	if err != nil || !setupReused || setupRes.ReadinessEvidence != "ready once" {
 		t.Fatalf("setup reuse = (%+v, %v, %v)", setupRes, setupReused, err)
 	}
-	skeletonRes, skeletonReused, err := reuseCompletedAcceptanceSkeleton(root, taskID, currentRun, effective, "test", "")
+	skeletonRes, skeletonReused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: effective, InputKey: "test", WorkDir: ""})
 	if err != nil || !skeletonReused || len(skeletonRes.NoSkeletons) != 1 {
 		t.Fatalf("skeleton reuse = (%+v, %v, %v)", skeletonRes, skeletonReused, err)
 	}
@@ -77,10 +77,10 @@ func TestReuseCompletedPreflightsFallsBackWhenNoSuccessExists(t *testing.T) {
 	runDir := filepath.Join(root, "runs", "task-new-100")
 	effective := task.Executor{CLI: "claude", Effort: "high"}
 
-	if res, reused, err := reuseReadySetup(root, "task-new", runDir, effective, "test"); err != nil || reused || res != nil {
+	if res, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: "task-new", RunDir: runDir, Effective: effective, InputKey: "test"}); err != nil || reused || res != nil {
 		t.Fatalf("setup reuse = (%+v, %v, %v)", res, reused, err)
 	}
-	if res, reused, err := reuseCompletedAcceptanceSkeleton(root, "task-new", runDir, effective, "test", ""); err != nil || reused || res != nil {
+	if res, reused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: "task-new", RunDir: runDir, Effective: effective, InputKey: "test", WorkDir: ""}); err != nil || reused || res != nil {
 		t.Fatalf("skeleton reuse = (%+v, %v, %v)", res, reused, err)
 	}
 }
@@ -105,10 +105,10 @@ func TestReuseCompletedPreflightsRejectsMismatchedExecutorIdentity(t *testing.T)
 		t.Fatal(err)
 	}
 
-	if res, reused, err := reuseReadySetup(root, taskID, currentRun, current, "test"); err != nil || reused || res != nil {
+	if res, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: current, InputKey: "test"}); err != nil || reused || res != nil {
 		t.Fatalf("setup should not reuse mismatched identity: (%+v, %v, %v)", res, reused, err)
 	}
-	if res, reused, err := reuseCompletedAcceptanceSkeleton(root, taskID, currentRun, current, "test", ""); err != nil || reused || res != nil {
+	if res, reused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: current, InputKey: "test", WorkDir: ""}); err != nil || reused || res != nil {
 		t.Fatalf("skeleton should not reuse mismatched identity: (%+v, %v, %v)", res, reused, err)
 	}
 }
@@ -131,13 +131,13 @@ func TestReuseCompletedPreflightsDerivesSetupCLIFromProvider(t *testing.T) {
 	}
 	// Match when current also has empty model/effort (only CLI resolved).
 	matchEmpty := task.Executor{CLI: "claude"}
-	if res, reused, err := reuseReadySetup(root, taskID, currentRun, matchEmpty, "test"); err != nil || !reused || res == nil {
+	if res, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: matchEmpty, InputKey: "test"}); err != nil || !reused || res == nil {
 		t.Fatalf("expected provider-derived CLI match with empty model/effort: (%+v, %v, %v)", res, reused, err)
 	}
 	// Mismatch when current carries resolved model/effort that legacy lacks.
 	currentRun2 := filepath.Join(root, "runs", taskID+"-3")
 	full := task.Executor{CLI: "claude", Model: "m", Effort: "high"}
-	if res, reused, err := reuseReadySetup(root, taskID, currentRun2, full, "test"); err != nil || reused || res != nil {
+	if res, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun2, Effective: full, InputKey: "test"}); err != nil || reused || res != nil {
 		t.Fatalf("legacy provider-only evidence must not match full identity: (%+v, %v, %v)", res, reused, err)
 	}
 }
@@ -163,11 +163,11 @@ func TestReuseCompletedPreflightsMatchesExplicitEmptyModel(t *testing.T) {
 	}
 
 	// Same empty model reuses both preflights.
-	gotSetup, setupReused, err := reuseReadySetup(root, taskID, currentRun, effective, "test")
+	gotSetup, setupReused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: effective, InputKey: "test"})
 	if err != nil || !setupReused || gotSetup == nil || gotSetup.ExecutorModel != "" {
 		t.Fatalf("setup empty-model reuse = (%+v, %v, %v)", gotSetup, setupReused, err)
 	}
-	gotSkeleton, skeletonReused, err := reuseCompletedAcceptanceSkeleton(root, taskID, currentRun, effective, "test", "")
+	gotSkeleton, skeletonReused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: effective, InputKey: "test", WorkDir: ""})
 	if err != nil || !skeletonReused || gotSkeleton == nil || gotSkeleton.ExecutorModel != "" {
 		t.Fatalf("skeleton empty-model reuse = (%+v, %v, %v)", gotSkeleton, skeletonReused, err)
 	}
@@ -175,10 +175,10 @@ func TestReuseCompletedPreflightsMatchesExplicitEmptyModel(t *testing.T) {
 	// A later non-empty model must invalidate the empty-model evidence.
 	currentRun3 := filepath.Join(root, "runs", taskID+"-3")
 	withModel := task.Executor{CLI: "grok", Model: "grok-code", Effort: "low"}
-	if res, reused, err := reuseReadySetup(root, taskID, currentRun3, withModel, "test"); err != nil || reused || res != nil {
+	if res, reused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun3, Effective: withModel, InputKey: "test"}); err != nil || reused || res != nil {
 		t.Fatalf("setup must not reuse empty-model evidence for non-empty model: (%+v, %v, %v)", res, reused, err)
 	}
-	if res, reused, err := reuseCompletedAcceptanceSkeleton(root, taskID, currentRun3, withModel, "test", ""); err != nil || reused || res != nil {
+	if res, reused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun3, Effective: withModel, InputKey: "test", WorkDir: ""}); err != nil || reused || res != nil {
 		t.Fatalf("skeleton must not reuse empty-model evidence for non-empty model: (%+v, %v, %v)", res, reused, err)
 	}
 }
@@ -221,14 +221,14 @@ func TestReuseCompletedPreflightsEffortIdentityTransitions(t *testing.T) {
 				assertPersistedExecutorEffortEmpty(t, filepath.Join(priorRun, runartifact.PreflightResultFilename))
 			}
 
-			_, setupReused, err := reuseReadySetup(root, taskID, currentRun, current, "test")
+			_, setupReused, err := reuseReadySetup(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: current, InputKey: "test"})
 			if err != nil {
 				t.Fatalf("setup reuse err: %v", err)
 			}
 			if setupReused != tc.wantReuse {
 				t.Fatalf("setup reuse = %v, want %v (prior effort %q, current effort %q)", setupReused, tc.wantReuse, tc.prior, tc.current)
 			}
-			_, skeletonReused, err := reuseCompletedAcceptanceSkeleton(root, taskID, currentRun, current, "test", "")
+			_, skeletonReused, err := reuseCompletedAcceptanceSkeleton(preflightReuseQuery{Root: root, TaskID: taskID, RunDir: currentRun, Effective: current, InputKey: "test", WorkDir: ""})
 			if err != nil {
 				t.Fatalf("skeleton reuse err: %v", err)
 			}

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -87,27 +87,7 @@ func resolveWorktreeStartPoint(ctx context.Context, opts Options, sourceCWD, bas
 		return "", err
 	}
 	if hasOrigin {
-		// Refuse to fall back to a possibly stale refs/remotes/origin/<base>:
-		// surface the fetch failure through the workspace phase so
-		// `galley task show` exposes the reason in latest_error_*.
-		if err := fetchOriginRef(ctx, opts, sourceCWD, base); err != nil {
-			return "", fmt.Errorf(
-				"refresh %s in source repository %s for pr.base %q failed: %w; "+
-					"Galley refused to use the stale remote-tracking ref as the worktree start-point",
-				originRef, sourceCWD, base, err,
-			)
-		}
-		ok, err := refExists(ctx, opts, sourceCWD, originRef)
-		if err != nil {
-			return "", err
-		}
-		if ok {
-			return originRef, nil
-		}
-		return "", fmt.Errorf(
-			"resolve pr.base %q: %s missing in source repository %s after successful fetch (attempted refs: %s, %s)",
-			base, originRef, sourceCWD, originRef, headsRef,
-		)
+		return resolveOriginStartPoint(ctx, opts, originStartPoint{SourceCWD: sourceCWD, Base: base, OriginRef: originRef, HeadsRef: headsRef})
 	}
 	// Origin-less local repository: use the local branch as the start-point.
 	ok, err := refExists(ctx, opts, sourceCWD, headsRef)
@@ -201,32 +181,43 @@ func resolveEffectiveTaskOptions(opts Options, profiles profile.Bundle) effectiv
 		SupervisorModel:  opts.SupervisorModel,
 		SupervisorEffort: opts.SupervisorEffort,
 	}
-	if profiles.Environment != nil {
-		env := profiles.Environment
-		effective.OpenPR = env.PR.Enabled
-		effective.PRBase = env.PR.Base
-		effective.PollPRComments = env.PR.Comments.Enabled
-		effective.ReplyPRComments = env.PR.Comments.Reply
-		if env.Worktree.Cleanup != nil {
-			effective.CleanupWorktrees = *env.Worktree.Cleanup
-		}
-		if env.Supervisor != nil {
-			if env.Supervisor.DefaultCLI != "" {
-				effective.Supervisor = env.Supervisor.DefaultCLI
-				effective.SupervisorSource = SupervisorSourceRepoProfile
-			}
-			if env.Supervisor.Model != "" {
-				effective.SupervisorModel = env.Supervisor.Model
-			}
-			if env.Supervisor.Effort != "" {
-				effective.SupervisorEffort = env.Supervisor.Effort
-			}
-		}
-	}
+	effective.applyEnvironment(profiles.Environment)
 	if effective.OpenPR {
 		effective.CommitOnAccept = true
 	}
 	return effective
+}
+
+// applyEnvironment overrides the daemon-wide defaults with the repository's
+// environment profile. A nil profile leaves the defaults untouched.
+func (effective *effectiveTaskOptions) applyEnvironment(env *profile.Environment) {
+	if env == nil {
+		return
+	}
+	effective.OpenPR = env.PR.Enabled
+	effective.PRBase = env.PR.Base
+	effective.PollPRComments = env.PR.Comments.Enabled
+	effective.ReplyPRComments = env.PR.Comments.Reply
+	if env.Worktree.Cleanup != nil {
+		effective.CleanupWorktrees = *env.Worktree.Cleanup
+	}
+	effective.applySupervisor(env.Supervisor)
+}
+
+func (effective *effectiveTaskOptions) applySupervisor(sup *profile.SupervisorDefault) {
+	if sup == nil {
+		return
+	}
+	if sup.DefaultCLI != "" {
+		effective.Supervisor = sup.DefaultCLI
+		effective.SupervisorSource = SupervisorSourceRepoProfile
+	}
+	if sup.Model != "" {
+		effective.SupervisorModel = sup.Model
+	}
+	if sup.Effort != "" {
+		effective.SupervisorEffort = sup.Effort
+	}
 }
 
 func (effective effectiveTaskOptions) apply(opts Options) Options {
@@ -245,4 +236,35 @@ func (effective effectiveTaskOptions) apply(opts Options) Options {
 
 func effectiveOptionsForProfiles(opts Options, profiles profile.Bundle) Options {
 	return resolveEffectiveTaskOptions(opts, profiles).apply(opts)
+}
+
+// originStartPoint names the refs a pr.base start-point resolves through.
+type originStartPoint struct {
+	SourceCWD string
+	Base      string
+	OriginRef string
+	HeadsRef  string
+}
+
+// resolveOriginStartPoint refuses a possibly stale refs/remotes/origin/<base>;
+// a fetch failure surfaces in `galley task show` as latest_error_*.
+func resolveOriginStartPoint(ctx context.Context, opts Options, sp originStartPoint) (string, error) {
+	if err := fetchOriginRef(ctx, opts, sp.SourceCWD, sp.Base); err != nil {
+		return "", fmt.Errorf(
+			"refresh %s in source repository %s for pr.base %q failed: %w; "+
+				"Galley refused to use the stale remote-tracking ref as the worktree start-point",
+			sp.OriginRef, sp.SourceCWD, sp.Base, err,
+		)
+	}
+	ok, err := refExists(ctx, opts, sp.SourceCWD, sp.OriginRef)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return sp.OriginRef, nil
+	}
+	return "", fmt.Errorf(
+		"resolve pr.base %q: %s missing in source repository %s after successful fetch (attempted refs: %s, %s)",
+		sp.Base, sp.OriginRef, sp.SourceCWD, sp.OriginRef, sp.HeadsRef,
+	)
 }

--- a/internal/daemon/progress_baseline.go
+++ b/internal/daemon/progress_baseline.go
@@ -61,6 +61,7 @@ func hasNonSkeletonProgress(snapshot workspace.Snapshot, workDir string, preflig
 			// Skeleton was deleted or otherwise unreadable: that is an
 			// executor-visible change relative to the baseline, count it as
 			// progress.
+			//nolint:nilerr // unreadable skeleton is progress, not a failure
 			return true, nil
 		}
 		sum := sha256.Sum256(data)
@@ -117,20 +118,7 @@ func porcelainLinePaths(line string) []string {
 	body := line[3:]
 	var paths []string
 	if isRenameOrCopyStatus(line[0]) || isRenameOrCopyStatus(line[1]) {
-		separator := strings.Index(body, " -> ")
-		if strings.HasPrefix(body, `"`) {
-			for i := 1; i < len(body); i++ {
-				if body[i] == '\\' {
-					i++
-					continue
-				}
-				if body[i] == '"' {
-					separator = i + 1
-					break
-				}
-			}
-		}
-		if separator >= 0 && strings.HasPrefix(body[separator:], " -> ") {
+		if separator := renameSeparator(body); separator >= 0 {
 			paths = append(paths, unquoteGitPath(body[:separator]))
 			body = body[separator+4:]
 		}
@@ -141,6 +129,19 @@ func porcelainLinePaths(line string) []string {
 	return paths
 }
 
+// renameSeparator returns where a rename entry's source path ends, or -1 with
+// no " -> ". A quoted path ends at its closing quote, so an embedded " -> " is safe.
+func renameSeparator(body string) int {
+	separator := strings.Index(body, " -> ")
+	if strings.HasPrefix(body, `"`) {
+		separator = closingQuoteIndex(body)
+	}
+	if separator < 0 || !strings.HasPrefix(body[separator:], " -> ") {
+		return -1
+	}
+	return separator
+}
+
 func unquoteGitPath(path string) string {
 	if strings.HasPrefix(path, `"`) {
 		if decoded, err := strconv.Unquote(path); err == nil {
@@ -148,4 +149,19 @@ func unquoteGitPath(path string) string {
 		}
 	}
 	return path
+}
+
+// closingQuoteIndex returns the index just past a quoted path's closing quote,
+// or -1 when the quote is unterminated. Backslash escapes are skipped.
+func closingQuoteIndex(body string) int {
+	for i := 1; i < len(body); i++ {
+		if body[i] == '\\' {
+			i++
+			continue
+		}
+		if body[i] == '"' {
+			return i + 1
+		}
+	}
+	return -1
 }

--- a/internal/daemon/recovery.go
+++ b/internal/daemon/recovery.go
@@ -27,10 +27,12 @@ func ownerDaemonIsLive(owner queue.Owner) (bool, error) {
 	alive, err := daemonctl.Alive(owner.PID)
 	if err != nil || !alive {
 		// An inconclusive liveness probe is treated as not live; recovery is safe.
+		//nolint:nilerr // inconclusive probe means not live
 		return false, nil
 	}
 	info, err := daemonctl.ProcessInfo(owner.PID)
 	if err != nil {
+		//nolint:nilerr // inconclusive probe means not live
 		return false, nil
 	}
 	if owner.ProcessStartedAt != "" && info.StartedAt != "" && owner.ProcessStartedAt != info.StartedAt {

--- a/internal/daemon/review_staging_test.go
+++ b/internal/daemon/review_staging_test.go
@@ -236,7 +236,7 @@ func TestRunOnceAcceptedFinalizationExcludesNonCommittedInputFile(t *testing.T) 
 	worktreePath := taskWorktreePath(repo, doneTask.Worktree.Path)
 	// Non-committed input file destination must not be present in the HEAD
 	// tree even though review-time staging happened before finalization.
-	committedFiles, err := exec.Command("git", "-C", worktreePath, "show", "--name-only", "--format=", "HEAD").Output()
+	committedFiles, err := exec.CommandContext(t.Context(), "git", "-C", worktreePath, "show", "--name-only", "--format=", "HEAD").Output()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,12 +340,12 @@ func TestRunOnceReviewStagingFailureRecordsAttemptErrorBeforeSupervisor(t *testi
 	// Override the staging seam to capture invocation evidence under the
 	// attempt dir (so file-based evidence still exists for review) and then
 	// return an error that mimics a real `git add -A` failure.
-	stageForTest := func(_ context.Context, _ Options, workDir, attemptDir string, _ []string) error {
-		if err := os.MkdirAll(attemptDir, 0o700); err != nil {
-			return err
+	stageForTest := func(_ context.Context, req stageOutputRequest) error {
+		if err := os.MkdirAll(req.AttemptDir, 0o700); err != nil {
+			return fmt.Errorf("create attempt dir: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(attemptDir, "git_add_review_result.json"), []byte(`{"exit_code":128}`), 0o600); err != nil {
-			return err
+		if err := os.WriteFile(filepath.Join(req.AttemptDir, "git_add_review_result.json"), []byte(`{"exit_code":128}`), 0o600); err != nil {
+			return fmt.Errorf("write git add result: %w", err)
 		}
 		return fmt.Errorf("git add -A (review staging) failed: simulated index lock")
 	}

--- a/internal/daemon/risk.go
+++ b/internal/daemon/risk.go
@@ -6,22 +6,30 @@ import (
 	"github.com/shinpr/galley/internal/task"
 )
 
-func appendRisk(loaded *task.Task, prefix, riskType, detail, mitigation string, humanReview bool) {
+// riskSpec is one risk Galley records on the task.
+type riskSpec struct {
+	Type        string
+	Detail      string
+	Mitigation  string
+	HumanReview bool
+}
+
+func appendRisk(loaded *task.Task, prefix string, risk riskSpec) {
 	if loaded == nil {
 		return
 	}
-	appendRiskWithID(loaded, fmt.Sprintf("%s-%d", prefix, len(loaded.Risks)+1), riskType, detail, mitigation, humanReview)
+	appendRiskWithID(loaded, fmt.Sprintf("%s-%d", prefix, len(loaded.Risks)+1), risk)
 }
 
-func appendRiskWithID(loaded *task.Task, id, riskType, detail, mitigation string, humanReview bool) {
+func appendRiskWithID(loaded *task.Task, id string, risk riskSpec) {
 	if loaded == nil {
 		return
 	}
 	loaded.Risks = append(loaded.Risks, task.Risk{
 		ID:                   id,
-		Type:                 riskType,
-		Detail:               detail,
-		Mitigation:           mitigation,
-		HumanReviewSuggested: humanReview,
+		Type:                 risk.Type,
+		Detail:               risk.Detail,
+		Mitigation:           risk.Mitigation,
+		HumanReviewSuggested: risk.HumanReview,
 	})
 }

--- a/internal/daemon/setup_executor_preflight_test.go
+++ b/internal/daemon/setup_executor_preflight_test.go
@@ -158,22 +158,26 @@ setup:
 		t.Fatal(err)
 	}
 	// AC8: setup readiness must be recorded in task verification history.
-	foundSetup := false
+	assertSetupVerificationRecorded(t, doneTask, "environment.yaml=unchanged")
+}
+
+// assertSetupVerificationRecorded pins that the task's verification history
+// carries a passed <galley:setup> entry whose excerpt names wantExcerpt.
+func assertSetupVerificationRecorded(t *testing.T, doneTask task.Task, wantExcerpt string) {
+	t.Helper()
 	for _, vc := range doneTask.Verification.Commands {
-		if strings.HasPrefix(vc.Cmd, "<galley:setup") {
-			foundSetup = true
-			if vc.Status != "passed" {
-				t.Fatalf("setup verification status got %q, want passed", vc.Status)
-			}
-			if !strings.Contains(vc.OutputExcerpt, "environment.yaml=unchanged") {
-				t.Fatalf("unchanged-setup excerpt missing 'environment.yaml=unchanged': %q", vc.OutputExcerpt)
-			}
-			break
+		if !strings.HasPrefix(vc.Cmd, "<galley:setup") {
+			continue
 		}
+		if vc.Status != "passed" {
+			t.Fatalf("setup verification status got %q, want passed", vc.Status)
+		}
+		if !strings.Contains(vc.OutputExcerpt, wantExcerpt) {
+			t.Fatalf("setup excerpt missing %q: %q", wantExcerpt, vc.OutputExcerpt)
+		}
+		return
 	}
-	if !foundSetup {
-		t.Fatalf("task verification history missing <galley:setup> entry: %#v", doneTask.Verification.Commands)
-	}
+	t.Fatalf("task verification history missing <galley:setup> entry: %#v", doneTask.Verification.Commands)
 }
 
 // TestSetupPreflightAbsentSetupInvokesExecutorWithEnvironmentAndSignals proves
@@ -524,18 +528,7 @@ pr:
 	setupCalls := 0
 	withSetupExecutorRunner(t, func(_ context.Context, opts setuppreflight.Options) (*setuppreflight.Result, error) {
 		setupCalls++
-		source := setuppreflight.SourceDiscovered
-		if opts.Profiles.Environment != nil && opts.Profiles.Environment.Setup != nil {
-			source = setuppreflight.SourceEnvironmentSetup
-		}
-		return &setuppreflight.Result{
-			Status:             setuppreflight.StatusReady,
-			Commands:           []setuppreflight.CommandAttempt{{Run: "echo learned", Source: source, ExitCode: 0}},
-			SuccessfulCommands: []profile.SetupCommand{{Run: "echo learned", Why: "learned setup"}},
-			ReadinessEvidence:  "setup executor passed",
-			Source:             source,
-			Provider:           "claude",
-		}, nil
+		return learnedSetupResult(opts), nil
 	})
 	res1, update1, err := runSetupPreflight(context.Background(), setuppreflight.Options{
 		Task:                   setupTask(),
@@ -560,30 +553,7 @@ pr:
 		t.Fatalf("environment update missing setup diff: %+v", update1)
 	}
 
-	// Verify the file was atomically rewritten with the new setup AND unrelated
-	// content is preserved.
-	rewritten, err := os.ReadFile(envPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body := string(rewritten)
-	if !strings.Contains(body, "echo learned") {
-		t.Fatalf("setup not persisted: %s", body)
-	}
-	if !strings.Contains(body, "test_unit") || !strings.Contains(body, "approval_required") || !strings.Contains(body, "base: main") {
-		t.Fatalf("unrelated content lost in rewrite: %s", body)
-	}
-	// Re-validate the rewritten file end-to-end.
-	env2, err := profile.LoadEnvironment(envPath)
-	if err != nil {
-		t.Fatalf("reload rewritten env: %v", err)
-	}
-	if vr := profile.ValidateEnvironment(env2); !vr.Valid() {
-		t.Fatalf("rewritten env failed validation: %v", vr.Errors)
-	}
-	if env2.Setup == nil || len(env2.Setup.Commands) != 1 || env2.Setup.Commands[0].Run != "echo learned" {
-		t.Fatalf("rewritten env setup wrong: %+v", env2.Setup)
-	}
+	env2 := assertProfileRewrittenWithLearnedSetup(t, envPath)
 
 	// AC7 second-run reuse: re-running preflight with the persisted plan still
 	// invokes the setup executor, but as a seeded run that reuses the saved
@@ -608,10 +578,59 @@ pr:
 	if update2 != nil {
 		t.Fatalf("second run should not have rewritten environment.yaml: %+v", update2)
 	}
-	// All recorded commands should be from the seeded environment setup source.
-	for _, c := range res2.Commands {
+	assertAllCommandsSeeded(t, res2.Commands)
+}
+
+// learnedSetupResult mimics a setup executor that succeeds, reporting the
+// seeded source once environment.setup is present.
+func learnedSetupResult(opts setuppreflight.Options) *setuppreflight.Result {
+	source := setuppreflight.SourceDiscovered
+	if opts.Profiles.Environment != nil && opts.Profiles.Environment.Setup != nil {
+		source = setuppreflight.SourceEnvironmentSetup
+	}
+	return &setuppreflight.Result{
+		Status:             setuppreflight.StatusReady,
+		Commands:           []setuppreflight.CommandAttempt{{Run: "echo learned", Source: source, ExitCode: 0}},
+		SuccessfulCommands: []profile.SetupCommand{{Run: "echo learned", Why: "learned setup"}},
+		ReadinessEvidence:  "setup executor passed",
+		Source:             source,
+		Provider:           "claude",
+	}
+}
+
+// assertProfileRewrittenWithLearnedSetup pins that the atomic rewrite persisted
+// the learned setup, preserved unrelated content, and still validates.
+func assertProfileRewrittenWithLearnedSetup(t *testing.T, envPath string) profile.Environment {
+	t.Helper()
+	rewritten, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(rewritten)
+	if !strings.Contains(body, "echo learned") {
+		t.Fatalf("setup not persisted: %s", body)
+	}
+	if !strings.Contains(body, "test_unit") || !strings.Contains(body, "approval_required") || !strings.Contains(body, "base: main") {
+		t.Fatalf("unrelated content lost in rewrite: %s", body)
+	}
+	env, err := profile.LoadEnvironment(envPath)
+	if err != nil {
+		t.Fatalf("reload rewritten env: %v", err)
+	}
+	if vr := profile.ValidateEnvironment(env); !vr.Valid() {
+		t.Fatalf("rewritten env failed validation: %v", vr.Errors)
+	}
+	if env.Setup == nil || len(env.Setup.Commands) != 1 || env.Setup.Commands[0].Run != "echo learned" {
+		t.Fatalf("rewritten env setup wrong: %+v", env.Setup)
+	}
+	return env
+}
+
+func assertAllCommandsSeeded(t *testing.T, commands []setuppreflight.CommandAttempt) {
+	t.Helper()
+	for _, c := range commands {
 		if c.Source == setuppreflight.SourceDiscovered {
-			t.Fatalf("second run recorded discovered command but should use persisted seed plan: %+v", res2.Commands)
+			t.Fatalf("second run recorded discovered command but should use persisted seed plan: %+v", commands)
 		}
 	}
 }
@@ -674,7 +693,7 @@ func TestSetupPreflightSetupFailedClassifiesAndWritesEvidence(t *testing.T) {
 	// daemon helper used by processClaimedTask must yield phase=setup and
 	// kind=setup_failed in the task latest error.
 	tk := setupTask()
-	appendFailureAttempt(&tk, setuppreflight.Phase, setuppreflight.FailedKind, err, runDir)
+	appendFailureAttempt(&tk, attemptFailure{Phase: setuppreflight.Phase, Kind: setuppreflight.FailedKind, Err: err, ArtifactDir: runDir})
 	if len(tk.Attempts) == 0 || tk.Attempts[len(tk.Attempts)-1].Error == nil {
 		t.Fatalf("no attempt error appended")
 	}
@@ -990,49 +1009,13 @@ func TestSetupResultSchemaMatchesPersistedShape(t *testing.T) {
 // go.mod intentionally avoids one. It returns a list of human-readable
 // violation messages; an empty slice means the value satisfies the schema.
 func validateAgainstSchemaForTest(value any, schema map[string]any, path string) []string {
-	var errs []string
-	if typ, ok := schema["type"].(string); ok {
-		if !jsonTypeMatchesForTest(typ, value) {
-			errs = append(errs, fmt.Sprintf("%s: type mismatch: want %s, got %T", path, typ, value))
-			return errs
-		}
+	if typ, ok := schema["type"].(string); ok && !jsonTypeMatchesForTest(typ, value) {
+		return []string{fmt.Sprintf("%s: type mismatch: want %s, got %T", path, typ, value)}
 	}
-	if enum, ok := schema["enum"].([]any); ok {
-		matched := false
-		for _, allowed := range enum {
-			if allowed == value {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			errs = append(errs, fmt.Sprintf("%s: value %v not in enum %v", path, value, enum))
-		}
-	}
+	errs := validateEnumForTest(value, schema, path)
 	switch v := value.(type) {
 	case map[string]any:
-		props, _ := schema["properties"].(map[string]any)
-		additional, additionalSpecified := schema["additionalProperties"]
-		if required, ok := schema["required"].([]any); ok {
-			for _, r := range required {
-				name, _ := r.(string)
-				if _, has := v[name]; !has {
-					errs = append(errs, fmt.Sprintf("%s: missing required property %q", path, name))
-				}
-			}
-		}
-		for key, child := range v {
-			subSchema, declared := props[key].(map[string]any)
-			if !declared {
-				if additionalSpecified {
-					if allow, ok := additional.(bool); ok && !allow {
-						errs = append(errs, fmt.Sprintf("%s: property %q is not declared in schema and additionalProperties is false", path, key))
-					}
-				}
-				continue
-			}
-			errs = append(errs, validateAgainstSchemaForTest(child, subSchema, path+"."+key)...)
-		}
+		errs = append(errs, validateObjectForTest(v, schema, path)...)
 	case []any:
 		if items, ok := schema["items"].(map[string]any); ok {
 			for i, child := range v {
@@ -1041,6 +1024,56 @@ func validateAgainstSchemaForTest(value any, schema map[string]any, path string)
 		}
 	}
 	return errs
+}
+
+func validateEnumForTest(value any, schema map[string]any, path string) []string {
+	enum, ok := schema["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	for _, allowed := range enum {
+		if allowed == value {
+			return nil
+		}
+	}
+	return []string{fmt.Sprintf("%s: value %v not in enum %v", path, value, enum)}
+}
+
+func validateObjectForTest(v, schema map[string]any, path string) []string {
+	props, _ := schema["properties"].(map[string]any)
+	var errs []string
+	if required, ok := schema["required"].([]any); ok {
+		for _, r := range required {
+			name, _ := r.(string)
+			if _, has := v[name]; !has {
+				errs = append(errs, fmt.Sprintf("%s: missing required property %q", path, name))
+			}
+		}
+	}
+	for key, child := range v {
+		subSchema, declared := props[key].(map[string]any)
+		if !declared {
+			if msg := undeclaredPropertyErrorForTest(schema, path, key); msg != "" {
+				errs = append(errs, msg)
+			}
+			continue
+		}
+		errs = append(errs, validateAgainstSchemaForTest(child, subSchema, path+"."+key)...)
+	}
+	return errs
+}
+
+// undeclaredPropertyErrorForTest reports a property the schema does not declare
+// only when additionalProperties is explicitly false.
+func undeclaredPropertyErrorForTest(schema map[string]any, path, key string) string {
+	additional, specified := schema["additionalProperties"]
+	if !specified {
+		return ""
+	}
+	if allow, ok := additional.(bool); ok && !allow {
+		return fmt.Sprintf("%s: property %q is not declared in schema and additionalProperties is false", path, key)
+	}
+	return ""
 }
 
 func jsonTypeMatchesForTest(want string, value any) bool {

--- a/internal/daemon/slot_refill_test.go
+++ b/internal/daemon/slot_refill_test.go
@@ -37,17 +37,7 @@ func testSlotRefill(t *testing.T, recoverStale bool) {
 		if recoverStale && name == "third" {
 			path = filepath.Join(root, "tasks", "running", "c.yaml")
 		}
-		writeDaemonTask(t, path, initDaemonGitRepo(t))
-		loaded, err := task.Load(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		loaded.ID = name
-		loaded.ExecutionPolicy.TimeoutMS = 15000
-		loaded.Worktree.Path = filepath.Join("..", "worktrees", name)
-		if err := task.Save(path, loaded); err != nil {
-			t.Fatal(err)
-		}
+		writeSlotRefillTask(t, path, name)
 	}
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
@@ -65,27 +55,59 @@ func testSlotRefill(t *testing.T, recoverStale bool) {
 			t.Fatalf("daemon exited before refill: %v", err)
 		default:
 		}
-		if recoverStale && !madeStale {
-			if _, err := os.Stat(longStarted); err == nil {
-				old := time.Now().Add(-2 * time.Hour)
-				for _, name := range []string{"a.yaml", "c.yaml"} {
-					if err := os.Chtimes(filepath.Join(root, "tasks", "running", name), old, old); err != nil {
-						t.Fatal(err)
-					}
-				}
-				madeStale = true
-			}
+		if recoverStale && !madeStale && fileExists(longStarted) {
+			ageRunningClaims(t, root, "a.yaml", "c.yaml")
+			madeStale = true
 		}
-		if _, err := os.Stat(thirdStarted); err == nil {
-			if _, err := os.Stat(longStarted); err != nil {
-				t.Fatal("long task did not start")
-			}
-			if _, err := os.Stat(filepath.Join(root, "tasks", "running", "a.yaml")); err != nil {
-				t.Fatal("long task no longer running")
-			}
+		if fileExists(thirdStarted) {
+			assertLongTaskStillRunning(t, root, longStarted)
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("free slot stayed idle while the long task was running")
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// writeSlotRefillTask seeds one queued or running task with a long timeout and
+// its own worktree so the refill scenario can run them concurrently.
+func writeSlotRefillTask(t *testing.T, path, name string) {
+	t.Helper()
+	writeDaemonTask(t, path, initDaemonGitRepo(t))
+	loaded, err := task.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.ID = name
+	loaded.ExecutionPolicy.TimeoutMS = 15000
+	loaded.Worktree.Path = filepath.Join("..", "worktrees", name)
+	if err := task.Save(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ageRunningClaims backdates running claims so the daemon's stale-claim
+// recovery treats them as abandoned.
+func ageRunningClaims(t *testing.T, root string, names ...string) {
+	t.Helper()
+	old := time.Now().Add(-2 * time.Hour)
+	for _, name := range names {
+		if err := os.Chtimes(filepath.Join(root, "tasks", "running", name), old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertLongTaskStillRunning(t *testing.T, root, longStarted string) {
+	t.Helper()
+	if !fileExists(longStarted) {
+		t.Fatal("long task did not start")
+	}
+	if !fileExists(filepath.Join(root, "tasks", "running", "a.yaml")) {
+		t.Fatal("long task no longer running")
+	}
 }

--- a/internal/daemon/vcs.go
+++ b/internal/daemon/vcs.go
@@ -12,6 +12,11 @@ func vcsBinaries(opts Options) vcs.Binaries {
 	}
 }
 
+// vcsRepo names the worktree a git command runs in and where its evidence lands.
+func vcsRepo(opts Options, workDir, runDir string) vcs.Repo {
+	return vcs.Repo{Bins: vcsBinaries(opts), WorkDir: workDir, RunDir: runDir}
+}
+
 func workspaceOptions(opts Options) workspace.Options {
 	return workspace.Options{GitBin: opts.GitBin}
 }

--- a/internal/daemoncmd/command.go
+++ b/internal/daemoncmd/command.go
@@ -24,9 +24,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stopVerifiedForCommand = daemonctl.StopVerified
-var forceStopForCommand = daemonctl.ForceStop
-var afterInitialStopInspectForCommand func()
+var (
+	stopVerifiedForCommand            = daemonctl.StopVerified
+	forceStopForCommand               = daemonctl.ForceStop
+	afterInitialStopInspectForCommand func()
+)
 
 func NewCommand(use string) *cobra.Command {
 	var opts daemon.Options
@@ -42,34 +44,14 @@ func NewCommand(use string) *cobra.Command {
 		Short:         "Run the Galley file-backed task daemon",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
-			signals := make(chan os.Signal, 1)
-			signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-			defer signal.Stop(signals)
 			done := make(chan struct{})
-			go func() {
-				select {
-				case <-signals:
-					fmt.Fprintf(cmd.ErrOrStderr(), "galley: shutdown requested; active attempts have up to %s to finish\n", opts.ShutdownTimeout)
-					cancel()
-				case <-done:
-					return
-				}
-				select {
-				case <-signals:
-					fmt.Fprintln(cmd.ErrOrStderr(), "galley: second shutdown signal received; exiting")
-					os.Exit(130)
-				case <-done:
-				}
-			}()
-			if supervisorProvider != "" {
-				if !provider.IsSupervisor(supervisorProvider) {
-					return fmt.Errorf("--supervisor must be one of: %s", strings.Join(provider.SupervisorIDs(), ", "))
-				}
-				opts.Supervisor = supervisorProvider
-				opts.SupervisorSource = daemon.SupervisorSourceCLI
+			stopSignals := watchShutdownSignals(cmd, &opts, cancel, done)
+			defer stopSignals()
+			if err := applySupervisorFlag(&opts, supervisorProvider); err != nil {
+				return err
 			}
 			opts.Explicit = explicitOptionsFromFlags(cmd)
 			if pollInterval > 0 {
@@ -89,44 +71,21 @@ func NewCommand(use string) *cobra.Command {
 			if _, err := daemonconfig.EnsureDefault(opts.Root); err != nil {
 				return err
 			}
-			if cfg, present, err := daemonconfig.Load(opts.Root); err != nil {
+			cfg, present, err := daemonconfig.Load(opts.Root)
+			if err != nil {
 				return err
-			} else if present {
+			}
+			if present {
 				if err := applyDaemonConfig(&opts, &pollInterval, cfg); err != nil {
 					return err
 				}
 			}
-			daemonToken := os.Getenv(daemonctl.EnvToken)
-			if daemonToken != "" {
-				_ = os.Unsetenv(daemonctl.EnvToken)
+			releasePID, err := registerBackgroundDaemon(&opts, pidFile)
+			if err != nil {
+				return err
 			}
-			if daemonToken != "" && pidFile == "" {
-				return fmt.Errorf("%s requires --pid-file", daemonctl.EnvToken)
-			}
-			if daemonToken != "" {
-				exe, err := os.Executable()
-				if err != nil {
-					return err
-				}
-				resolved, err := daemon.Preflight(opts)
-				if err != nil {
-					return err
-				}
-				opts = resolved
-				meta := daemonctl.NewPIDFile(os.Getpid(), exe, opts.Root, os.Args).WithToken(daemonToken)
-				if err := daemonctl.WritePID(pidFile, meta); err != nil {
-					return err
-				}
-				if err := daemonctl.Heartbeat(pidFile, meta); err != nil {
-					return err
-				}
-				stopHeartbeat := startPIDHeartbeat(pidFile, meta)
-				defer func() {
-					stopHeartbeat()
-					_ = daemonctl.RemovePID(pidFile, os.Getpid())
-				}()
-			}
-			err := daemon.Run(ctx, opts)
+			defer releasePID()
+			err = daemon.Run(ctx, opts)
 			close(done)
 			return err
 		},
@@ -182,33 +141,18 @@ func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg da
 		opts.MaxConcurrentPerRepo = *cfg.MaxConcurrentPerRepo
 		opts.Explicit.MaxConcurrentPerRepo = true
 	}
-	if !opts.Explicit.PollInterval && cfg.PollInterval != "" {
-		if d, ok, err := daemonConfigDuration("poll_interval", cfg.PollInterval); err != nil {
-			return err
-		} else if ok {
+	durations := []daemonConfigDurationField{
+		{Name: "poll_interval", Value: cfg.PollInterval, Explicit: opts.Explicit.PollInterval, Apply: func(d time.Duration) {
 			*pollInterval = d
 			opts.PollInterval = d
-		}
+		}},
+		{Name: "claim_ttl", Value: cfg.ClaimTTL, Explicit: opts.Explicit.ClaimTTL, Apply: func(d time.Duration) { opts.ClaimTTL = d }},
+		{Name: "shutdown_timeout", Value: cfg.ShutdownTimeout, Explicit: opts.Explicit.ShutdownTimeout, Apply: func(d time.Duration) { opts.ShutdownTimeout = d }},
+		{Name: "idle_timeout", Value: cfg.IdleTimeout, Explicit: opts.Explicit.IdleTimeout, Apply: func(d time.Duration) { opts.IdleTimeout = d }},
 	}
-	if !opts.Explicit.ClaimTTL && cfg.ClaimTTL != "" {
-		if d, ok, err := daemonConfigDuration("claim_ttl", cfg.ClaimTTL); err != nil {
+	for _, field := range durations {
+		if err := field.apply(); err != nil {
 			return err
-		} else if ok {
-			opts.ClaimTTL = d
-		}
-	}
-	if !opts.Explicit.ShutdownTimeout && cfg.ShutdownTimeout != "" {
-		if d, ok, err := daemonConfigDuration("shutdown_timeout", cfg.ShutdownTimeout); err != nil {
-			return err
-		} else if ok {
-			opts.ShutdownTimeout = d
-		}
-	}
-	if !opts.Explicit.IdleTimeout && cfg.IdleTimeout != "" {
-		if d, ok, err := daemonConfigDuration("idle_timeout", cfg.IdleTimeout); err != nil {
-			return err
-		} else if ok {
-			opts.IdleTimeout = d
 		}
 	}
 	// Notifications come only from daemon.yaml; there is no CLI flag because the
@@ -218,6 +162,29 @@ func applyDaemonConfig(opts *daemon.Options, pollInterval *time.Duration, cfg da
 	// Provider API keys are injected only into selected child environments.
 	opts.GLMAuthToken = cfg.GLMAPIKey
 	opts.KimiAPIKey = cfg.KimiAPIKey
+	return nil
+}
+
+// daemonConfigDurationField is one daemon.yaml duration setting. A CLI flag
+// that set the same option keeps precedence, so an explicit field is skipped.
+type daemonConfigDurationField struct {
+	Name     string
+	Value    string
+	Explicit bool
+	Apply    func(time.Duration)
+}
+
+func (f daemonConfigDurationField) apply() error {
+	if f.Explicit || f.Value == "" {
+		return nil
+	}
+	d, ok, err := daemonConfigDuration(f.Name, f.Value)
+	if err != nil {
+		return err
+	}
+	if ok {
+		f.Apply(d)
+	}
 	return nil
 }
 
@@ -260,7 +227,7 @@ func newConfigInitCommand(opts *daemon.Options) *cobra.Command {
 		Short:         "Create daemon.yaml with documented defaults without starting the daemon",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// EnsureDefault is the sole daemon.yaml writer, so init creates the
 			// same editable defaults as daemon startup and preserves existing files.
 			created, err := daemonconfig.EnsureDefault(opts.Root)
@@ -294,92 +261,132 @@ func newStartCommand(opts *daemon.Options, pidFile, logFile *string, readinessTi
 		Short:         "Start Galley daemon in the background",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.Once {
-				return fmt.Errorf("start does not support --once")
-			}
-			// Ensure daemon.yaml exists under the selected root before the
-			// child daemon spawns. The background child cannot reliably
-			// surface a creation error to the operator, and operators expect
-			// to edit daemon.yaml immediately after `galley daemon start`
-			// returns. The child still re-loads daemon.yaml so any value
-			// written here is what the child resolves on first boot.
-			if _, err := daemonconfig.EnsureDefault(opts.Root); err != nil {
-				return err
-			}
-			paths := daemonctl.ResolvePaths(opts.Root, *pidFile, *logFile)
-			exe, err := os.Executable()
-			if err != nil {
-				return err
-			}
-			release, err := daemonctl.ReservePID(paths.PIDFile)
-			if err != nil {
-				return err
-			}
-			defer release()
-			if status, err := daemonctl.Inspect(paths.PIDFile, opts.Root, exe); err == nil {
-				if status.Alive && status.Verified {
-					return fmt.Errorf("galley daemon already running with pid %d", status.Meta.PID)
-				}
-				if status.Alive && !status.Verified {
-					return fmt.Errorf("refusing to replace pid file for unverified live pid %d", status.Meta.PID)
-				}
-				if !status.Alive {
-					if err := daemonctl.RemovePID(paths.PIDFile, status.Meta.PID); err != nil {
-						return err
-					}
-				}
-			} else if !errors.Is(err, daemonctl.ErrNotRunning) {
-				return err
-			}
-			if err := os.MkdirAll(opts.Root, 0o700); err != nil {
-				return fmt.Errorf("create root: %w", err)
-			}
-			if err := os.MkdirAll(filepath.Dir(paths.LogFile), 0o700); err != nil {
-				return fmt.Errorf("create log dir: %w", err)
-			}
-			log, err := os.OpenFile(paths.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-			if err != nil {
-				return fmt.Errorf("open log file: %w", err)
-			}
-			defer log.Close()
-			token, err := randomToken()
-			if err != nil {
-				return err
-			}
-			childArgs := foregroundArgs(os.Args[1:], cmd.Name())
-			childArgs = append(childArgs, "--pid-file", paths.PIDFile)
-			child := exec.Command(exe, childArgs...)
-			child.Stdout = log
-			child.Stderr = log
-			child.Stdin = nil
-			child.Env = append(os.Environ(), daemonctl.EnvToken+"="+token)
-			configureBackgroundProcess(child)
-			if err := child.Start(); err != nil {
-				return err
-			}
-			meta := daemonctl.NewPIDFile(child.Process.Pid, exe, opts.Root, append([]string{exe}, childArgs...)).WithToken(token)
-			if err := daemonctl.WritePID(paths.PIDFile, meta); err != nil {
-				// Cross-platform start cleanup uses SIGTERM on Unix and
-				// TerminateProcess on Windows so a PID write failure does
-				// not leave a background daemon running.
-				_ = daemonctl.TerminateChildProcess(child.Process)
-				return err
-			}
-			if err := waitReady(paths.PIDFile, opts.Root, exe, *readinessTimeout); err != nil {
-				// Same cross-platform start cleanup boundary as above: a
-				// readiness timeout must actually terminate the child on
-				// every OS, otherwise a slow-to-start daemon survives an
-				// aborted `galley daemon start` and races a subsequent
-				// retry against a stale process.
-				_ = daemonctl.TerminateChildProcess(child.Process)
-				_ = daemonctl.RemovePID(paths.PIDFile, child.Process.Pid)
-				return fmt.Errorf("%w; see log file %s", err, paths.LogFile)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "galley daemon started pid=%d\npid_file=%s\nlog_file=%s\n", child.Process.Pid, paths.PIDFile, paths.LogFile)
-			return child.Process.Release()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStartCommand(cmd, startRequest{Opts: opts, PIDFile: *pidFile, LogFile: *logFile, ReadinessTimeout: *readinessTimeout})
 		},
 	}
+}
+
+// startRequest is one `galley daemon start` invocation.
+type startRequest struct {
+	Opts             *daemon.Options
+	PIDFile          string
+	LogFile          string
+	ReadinessTimeout time.Duration
+}
+
+func runStartCommand(cmd *cobra.Command, req startRequest) error {
+	opts := req.Opts
+	if opts.Once {
+		return fmt.Errorf("start does not support --once")
+	}
+	// The background child cannot surface a creation error, so daemon.yaml is
+	// created here; the child re-loads it and resolves what is written.
+	if _, err := daemonconfig.EnsureDefault(opts.Root); err != nil {
+		return err
+	}
+	paths := daemonctl.ResolvePaths(opts.Root, req.PIDFile, req.LogFile)
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve galley executable: %w", err)
+	}
+	release, err := daemonctl.ReservePID(paths.PIDFile)
+	if err != nil {
+		return err
+	}
+	defer release()
+	if err := clearReplaceablePIDRecord(paths.PIDFile, opts.Root, exe); err != nil {
+		return err
+	}
+	log, err := openDaemonLog(opts.Root, paths.LogFile)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = log.Close() }()
+	child, meta, err := spawnBackgroundDaemon(cmd, spawnPlan{Exe: exe, Root: opts.Root, PIDFile: paths.PIDFile, Log: log})
+	if err != nil {
+		return err
+	}
+	if err := daemonctl.WritePID(paths.PIDFile, meta); err != nil {
+		// Cross-platform cleanup (SIGTERM on Unix, TerminateProcess on Windows)
+		// so a PID write failure leaves no background daemon running.
+		_ = daemonctl.TerminateChildProcess(child.Process)
+		return err
+	}
+	if err := waitReady(paths.PIDFile, opts.Root, exe, req.ReadinessTimeout); err != nil {
+		// Same cleanup boundary: a readiness timeout must terminate the child on
+		// every OS, or a slow starter races the next `galley daemon start`.
+		_ = daemonctl.TerminateChildProcess(child.Process)
+		_ = daemonctl.RemovePID(paths.PIDFile, child.Process.Pid)
+		return fmt.Errorf("%w; see log file %s", err, paths.LogFile)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "galley daemon started pid=%d\npid_file=%s\nlog_file=%s\n", child.Process.Pid, paths.PIDFile, paths.LogFile)
+	if err := child.Process.Release(); err != nil {
+		return fmt.Errorf("release background daemon process %d: %w", child.Process.Pid, err)
+	}
+	return nil
+}
+
+// clearReplaceablePIDRecord removes a stale PID record so a new daemon can take
+// its place. A live daemon (verified or not) is never replaced.
+func clearReplaceablePIDRecord(pidFile, root, exe string) error {
+	status, err := daemonctl.Inspect(pidFile, root, exe)
+	if err != nil {
+		if errors.Is(err, daemonctl.ErrNotRunning) {
+			return nil
+		}
+		return err
+	}
+	if status.Alive && status.Verified {
+		return fmt.Errorf("galley daemon already running with pid %d", status.Meta.PID)
+	}
+	if status.Alive {
+		return fmt.Errorf("refusing to replace pid file for unverified live pid %d", status.Meta.PID)
+	}
+	return daemonctl.RemovePID(pidFile, status.Meta.PID)
+}
+
+func openDaemonLog(root, logPath string) (*os.File, error) {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return nil, fmt.Errorf("create root: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	log, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	return log, nil
+}
+
+// spawnPlan is the background daemon child this start command launches.
+type spawnPlan struct {
+	Exe     string
+	Root    string
+	PIDFile string
+	Log     *os.File
+}
+
+func spawnBackgroundDaemon(cmd *cobra.Command, plan spawnPlan) (*exec.Cmd, daemonctl.PIDFile, error) {
+	token, err := randomToken()
+	if err != nil {
+		return nil, daemonctl.PIDFile{}, err
+	}
+	childArgs := foregroundArgs(os.Args[1:], cmd.Name())
+	childArgs = append(childArgs, "--pid-file", plan.PIDFile)
+	//nolint:noctx // the background daemon must outlive this start command
+	child := exec.Command(plan.Exe, childArgs...)
+	child.Stdout = plan.Log
+	child.Stderr = plan.Log
+	child.Stdin = nil
+	child.Env = append(os.Environ(), daemonctl.EnvToken+"="+token)
+	configureBackgroundProcess(child)
+	if err := child.Start(); err != nil {
+		return nil, daemonctl.PIDFile{}, fmt.Errorf("start background daemon: %w", err)
+	}
+	meta := daemonctl.NewPIDFile(child.Process.Pid, plan.Exe, plan.Root, append([]string{plan.Exe}, childArgs...)).WithToken(token)
+	return child, meta, nil
 }
 
 func newStopCommand(opts *daemon.Options, pidFile *string, stopTimeout *time.Duration) *cobra.Command {
@@ -389,134 +396,191 @@ func newStopCommand(opts *daemon.Options, pidFile *string, stopTimeout *time.Dur
 		Short:         "Stop a background Galley daemon",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			paths := daemonctl.ResolvePaths(opts.Root, *pidFile, "")
-			exe, err := os.Executable()
-			if err != nil {
-				return err
-			}
-			initial, err := daemonctl.Inspect(paths.PIDFile, opts.Root, exe)
-			if errors.Is(err, daemonctl.ErrNotRunning) {
-				return daemonctl.ErrNotRunning
-			}
-			if err != nil {
-				return err
-			}
-			if afterInitialStopInspectForCommand != nil {
-				afterInitialStopInspectForCommand()
-			}
-			var intentPath string
-			leader := false
-			if !force {
-				intentPath, leader, err = claimStopIntent(paths.PIDFile, initial.Meta)
-				if err != nil {
-					return err
-				}
-				status, inspectErr := daemonctl.Inspect(paths.PIDFile, opts.Root, exe)
-				if errors.Is(inspectErr, daemonctl.ErrNotRunning) || (inspectErr == nil && !sameDaemonIdentity(initial.Meta, status.Meta)) {
-					removeStopIntent(intentPath)
-					fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", initial.Meta.PID)
-					return nil
-				}
-				if inspectErr != nil {
-					if leader {
-						removeStopIntent(intentPath)
-					}
-					return inspectErr
-				}
-				initial = status
-				if !leader {
-					if err := waitForDaemonStop(paths.PIDFile, opts.Root, exe, initial.Meta, *stopTimeout); err != nil {
-						return err
-					}
-					removeStopIntent(intentPath)
-					fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", initial.Meta.PID)
-					return nil
-				}
-			}
-			status := initial
-			if !status.Alive {
-				if intentPath != "" {
-					removeStopIntent(intentPath)
-				}
-				// A stale daemon record means the daemon process is gone, but
-				// it may have left behind executor/supervisor child process
-				// groups it can no longer reap. Force stop must clean those up
-				// before discarding the record; on cleanup failure surface the
-				// surviving PIDs/PGIDs and keep the PID file so a follow-up
-				// action can target the same daemon record.
-				if err := cleanupOnForce(cmd, force, opts.Root, status.Meta, *stopTimeout); err != nil {
-					return err
-				}
-				failedTasks := 0
-				if force {
-					failedTasks, err = failOwnedRunningTasks(opts.Root, status.Meta)
-					if err != nil {
-						return err
-					}
-				}
-				if err := daemonctl.RemovePID(paths.PIDFile, status.Meta.PID); err != nil {
-					return err
-				}
-				if force && failedTasks > 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "galley daemon force stopped pid=%d\n", status.Meta.PID)
-					return nil
-				}
-				return daemonctl.ErrNotRunning
-			}
-			if !status.Verified {
-				if leader {
-					removeStopIntent(intentPath)
-				}
-				return fmt.Errorf("%w: pid=%d", daemonctl.ErrUnverifiedProcess, status.Meta.PID)
-			}
-			forced := false
-			if force {
-				wasForced, err := forceStopForCommand(status.Meta, *stopTimeout)
-				if err != nil && !errors.Is(err, daemonctl.ErrNotRunning) {
-					return err
-				}
-				defer removeStopIntent(stopIntentPath(paths.PIDFile, status.Meta))
-				forced = wasForced
-			} else {
-				if err := stopVerifiedForCommand(status.Meta, *stopTimeout); err != nil && !errors.Is(err, daemonctl.ErrNotRunning) {
-					return fmt.Errorf("shutdown remains in progress; normal stop will not signal again; use stop --force to recover, which interrupts active attempts: %w", err)
-				}
-				defer removeStopIntent(intentPath)
-			}
-			// Force stop must clean up the daemon's known active child
-			// process groups before reporting a stopped state or removing the
-			// PID file. The daemon intentionally puts executor and supervisor
-			// subprocesses into their own pgids, so killing only the daemon
-			// PID can orphan them. On child cleanup failure we
-			// surface a visible error that names the surviving PIDs/PGIDs and
-			// intentionally leave the PID file in place so a follow-up
-			// operator action can target the same daemon record instead of
-			// observing a falsely-clean stop.
-			if err := cleanupOnForce(cmd, force, opts.Root, status.Meta, *stopTimeout); err != nil {
-				return err
-			}
-			if force {
-				if _, err := failOwnedRunningTasks(opts.Root, status.Meta); err != nil {
-					return err
-				}
-			}
-			if err := daemonctl.RemovePID(paths.PIDFile, status.Meta.PID); err != nil {
-				return err
-			}
-			if forced {
-				fmt.Fprintf(cmd.OutOrStdout(), "galley daemon force stopped pid=%d\n", status.Meta.PID)
-			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", status.Meta.PID)
-			}
-			return nil
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStopCommand(cmd, stopRequest{Opts: opts, PIDFile: *pidFile, StopTimeout: *stopTimeout, Force: force})
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "After the stop timeout, send a verified SIGKILL to the daemon and to any known active executor or supervisor child process groups")
 	return cmd
 }
 
-func cleanupOnForce(cmd *cobra.Command, force bool, root string, owner daemonctl.PIDFile, stopTimeout time.Duration) error {
+// stopRequest is one `galley daemon stop` invocation.
+type stopRequest struct {
+	Opts        *daemon.Options
+	PIDFile     string
+	StopTimeout time.Duration
+	Force       bool
+}
+
+// stopIntent is the stop-intent marker this invocation claimed. Only the leader
+// signals the daemon; followers wait for the leader's stop to complete.
+type stopIntent struct {
+	Path   string
+	Leader bool
+}
+
+// stopSession is one stop invocation bound to the daemon record it targets.
+type stopSession struct {
+	Req   stopRequest
+	Paths daemonctl.Paths
+	Exe   string
+}
+
+func runStopCommand(cmd *cobra.Command, req stopRequest) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve galley executable: %w", err)
+	}
+	session := stopSession{Req: req, Paths: daemonctl.ResolvePaths(req.Opts.Root, req.PIDFile, ""), Exe: exe}
+	initial, err := daemonctl.Inspect(session.Paths.PIDFile, req.Opts.Root, exe)
+	if errors.Is(err, daemonctl.ErrNotRunning) {
+		return daemonctl.ErrNotRunning
+	}
+	if err != nil {
+		return err
+	}
+	if afterInitialStopInspectForCommand != nil {
+		afterInitialStopInspectForCommand()
+	}
+	var intent stopIntent
+	if !req.Force {
+		done, claimed, status, err := session.claimLeadership(cmd, initial)
+		if err != nil || done {
+			return err
+		}
+		intent, initial = claimed, status
+	}
+	if !initial.Alive {
+		return session.stopStaleDaemon(cmd, initial, intent)
+	}
+	if !initial.Verified {
+		if intent.Leader {
+			removeStopIntent(intent.Path)
+		}
+		return fmt.Errorf("%w: pid=%d", daemonctl.ErrUnverifiedProcess, initial.Meta.PID)
+	}
+	return session.stopLiveDaemon(cmd, initial, intent)
+}
+
+// claimLeadership claims the stop intent and re-inspects the record. done means
+// nothing is left: already stopped, identity changed, or the leader finished.
+func (s stopSession) claimLeadership(cmd *cobra.Command, initial daemonctl.Status) (bool, stopIntent, daemonctl.Status, error) {
+	intentPath, leader, err := claimStopIntent(s.Paths.PIDFile, initial.Meta)
+	if err != nil {
+		return false, stopIntent{}, initial, err
+	}
+	intent := stopIntent{Path: intentPath, Leader: leader}
+	status, inspectErr := daemonctl.Inspect(s.Paths.PIDFile, s.Req.Opts.Root, s.Exe)
+	if errors.Is(inspectErr, daemonctl.ErrNotRunning) || (inspectErr == nil && !sameDaemonIdentity(initial.Meta, status.Meta)) {
+		removeStopIntent(intentPath)
+		fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", initial.Meta.PID)
+		return true, intent, initial, nil
+	}
+	if inspectErr != nil {
+		if leader {
+			removeStopIntent(intentPath)
+		}
+		return false, intent, initial, inspectErr
+	}
+	if leader {
+		return false, intent, status, nil
+	}
+	if err := waitForDaemonStop(stopWait{PIDFile: s.Paths.PIDFile, Root: s.Req.Opts.Root, Executable: s.Exe, Target: status.Meta, Timeout: s.Req.StopTimeout}); err != nil {
+		return false, intent, status, err
+	}
+	removeStopIntent(intentPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", status.Meta.PID)
+	return true, intent, status, nil
+}
+
+// stopStaleDaemon discards a record whose process is gone, force-cleaning the
+// child groups first; on failure the PIDs surface and the PID file stays.
+func (s stopSession) stopStaleDaemon(cmd *cobra.Command, status daemonctl.Status, intent stopIntent) error {
+	if intent.Path != "" {
+		removeStopIntent(intent.Path)
+	}
+	if err := cleanupOnForce(cmd, s.forceCleanupFor(status)); err != nil {
+		return err
+	}
+	failedTasks := 0
+	if s.Req.Force {
+		var err error
+		failedTasks, err = failOwnedRunningTasks(s.Req.Opts.Root, status.Meta)
+		if err != nil {
+			return err
+		}
+	}
+	if err := daemonctl.RemovePID(s.Paths.PIDFile, status.Meta.PID); err != nil {
+		return err
+	}
+	if s.Req.Force && failedTasks > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "galley daemon force stopped pid=%d\n", status.Meta.PID)
+		return nil
+	}
+	return daemonctl.ErrNotRunning
+}
+
+// stopLiveDaemon signals a verified daemon and clears its record. Executor and
+// supervisor subprocesses hold their own pgids, so force stop reaps them first.
+func (s stopSession) stopLiveDaemon(cmd *cobra.Command, status daemonctl.Status, intent stopIntent) error {
+	forced, intentPath, err := s.signalDaemon(status, intent)
+	if err != nil {
+		return err
+	}
+	// The stop intent is released only after the PID file is cleared so a
+	// concurrent stop cannot observe a half-removed daemon record.
+	if intentPath != "" {
+		defer removeStopIntent(intentPath)
+	}
+	if err := cleanupOnForce(cmd, s.forceCleanupFor(status)); err != nil {
+		return err
+	}
+	if s.Req.Force {
+		if _, err := failOwnedRunningTasks(s.Req.Opts.Root, status.Meta); err != nil {
+			return err
+		}
+	}
+	if err := daemonctl.RemovePID(s.Paths.PIDFile, status.Meta.PID); err != nil {
+		return err
+	}
+	if forced {
+		fmt.Fprintf(cmd.OutOrStdout(), "galley daemon force stopped pid=%d\n", status.Meta.PID)
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "galley daemon stopped pid=%d\n", status.Meta.PID)
+	return nil
+}
+
+// signalDaemon stops the daemon and returns the stop-intent path to release
+// once the record is cleared; an error keeps the intent for a follow-up stop.
+func (s stopSession) signalDaemon(status daemonctl.Status, intent stopIntent) (forced bool, intentPath string, err error) {
+	if s.Req.Force {
+		wasForced, err := forceStopForCommand(status.Meta, s.Req.StopTimeout)
+		if err != nil && !errors.Is(err, daemonctl.ErrNotRunning) {
+			return false, "", err
+		}
+		return wasForced, stopIntentPath(s.Paths.PIDFile, status.Meta), nil
+	}
+	if err := stopVerifiedForCommand(status.Meta, s.Req.StopTimeout); err != nil && !errors.Is(err, daemonctl.ErrNotRunning) {
+		return false, "", fmt.Errorf("shutdown remains in progress; normal stop will not signal again; use stop --force to recover, which interrupts active attempts: %w", err)
+	}
+	return false, intent.Path, nil
+}
+
+func (s stopSession) forceCleanupFor(status daemonctl.Status) forceCleanup {
+	return forceCleanup{Force: s.Req.Force, Root: s.Req.Opts.Root, Owner: status.Meta, StopTimeout: s.Req.StopTimeout}
+}
+
+// forceCleanup is a force-stop's target daemon and its shutdown budget.
+type forceCleanup struct {
+	Force       bool
+	Root        string
+	Owner       daemonctl.PIDFile
+	StopTimeout time.Duration
+}
+
+func cleanupOnForce(cmd *cobra.Command, req forceCleanup) error {
+	force, root, owner, stopTimeout := req.Force, req.Root, req.Owner, req.StopTimeout
 	if !force {
 		return nil
 	}
@@ -534,19 +598,19 @@ func newStatusCommand(opts *daemon.Options, pidFile *string) *cobra.Command {
 		Short:         "Report background Galley daemon status",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if output != "text" && output != "json" {
 				return fmt.Errorf("unsupported output format %q", output)
 			}
 			paths := daemonctl.ResolvePaths(opts.Root, *pidFile, "")
 			exe, err := os.Executable()
 			if err != nil {
-				return err
+				return fmt.Errorf("resolve galley executable: %w", err)
 			}
 			status, err := daemonctl.Inspect(paths.PIDFile, opts.Root, exe)
 			if errors.Is(err, daemonctl.ErrNotRunning) {
 				if output == "json" {
-					return writeStatusJSON(cmd, opts, paths, nil, false, false)
+					return writeStatusJSON(cmd, opts, paths, daemonLiveness{Status: nil, Alive: false, Verified: false})
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), "galley daemon not running")
 				return nil
@@ -556,20 +620,20 @@ func newStatusCommand(opts *daemon.Options, pidFile *string) *cobra.Command {
 			}
 			if !status.Alive {
 				if output == "json" {
-					return writeStatusJSON(cmd, opts, paths, &status, false, status.Verified)
+					return writeStatusJSON(cmd, opts, paths, daemonLiveness{Status: &status, Alive: false, Verified: status.Verified})
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "galley daemon not running stale_pid=%d\n", status.Meta.PID)
 				return nil
 			}
 			if !status.Verified {
 				if output == "json" {
-					return writeStatusJSON(cmd, opts, paths, &status, true, false)
+					return writeStatusJSON(cmd, opts, paths, daemonLiveness{Status: &status, Alive: true, Verified: false})
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "galley daemon unverified pid=%d\n", status.Meta.PID)
 				return nil
 			}
 			if output == "json" {
-				return writeStatusJSON(cmd, opts, paths, &status, true, true)
+				return writeStatusJSON(cmd, opts, paths, daemonLiveness{Status: &status, Alive: true, Verified: true})
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "galley daemon running pid=%d\n", status.Meta.PID)
 			return nil
@@ -579,7 +643,15 @@ func newStatusCommand(opts *daemon.Options, pidFile *string) *cobra.Command {
 	return cmd
 }
 
-func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.Paths, status *daemonctl.Status, alive, verified bool) error {
+// daemonLiveness is what the status probe concluded about the daemon.
+type daemonLiveness struct {
+	Status   *daemonctl.Status
+	Alive    bool
+	Verified bool
+}
+
+func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.Paths, live daemonLiveness) error {
+	status, alive, verified := live.Status, live.Alive, live.Verified
 	// Daemon status intentionally does not surface daemon startup
 	// defaults that can be overridden by daemon.yaml or by per-repository
 	// environment.yaml. `supervisor` is omitted because a daemon-wide value
@@ -607,7 +679,10 @@ func writeStatusJSON(cmd *cobra.Command, opts *daemon.Options, paths daemonctl.P
 	}
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(payload)
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("encode daemon status: %w", err)
+	}
+	return nil
 }
 
 func waitReady(pidFile, root, executable string, timeout time.Duration) error {
@@ -655,7 +730,7 @@ func startPIDHeartbeat(pidFile string, meta daemonctl.PIDFile) func() {
 func randomToken() (string, error) {
 	var data [16]byte
 	if _, err := rand.Read(data[:]); err != nil {
-		return "", err
+		return "", fmt.Errorf("generate readiness token: %w", err)
 	}
 	return hex.EncodeToString(data[:]), nil
 }
@@ -671,4 +746,73 @@ func foregroundArgs(args []string, commandName string) []string {
 		out = append(out, arg)
 	}
 	return out
+}
+
+// watchShutdownSignals cancels the daemon on the first SIGINT/SIGTERM and exits
+// immediately on the second. The returned function stops the watch.
+func watchShutdownSignals(cmd *cobra.Command, opts *daemon.Options, cancel context.CancelFunc, done <-chan struct{}) func() {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-signals:
+			fmt.Fprintf(cmd.ErrOrStderr(), "galley: shutdown requested; active attempts have up to %s to finish\n", opts.ShutdownTimeout)
+			cancel()
+		case <-done:
+			return
+		}
+		select {
+		case <-signals:
+			fmt.Fprintln(cmd.ErrOrStderr(), "galley: second shutdown signal received; exiting")
+			os.Exit(130)
+		case <-done:
+		}
+	}()
+	return func() { signal.Stop(signals) }
+}
+
+func applySupervisorFlag(opts *daemon.Options, supervisorProvider string) error {
+	if supervisorProvider == "" {
+		return nil
+	}
+	if !provider.IsSupervisor(supervisorProvider) {
+		return fmt.Errorf("--supervisor must be one of: %s", strings.Join(provider.SupervisorIDs(), ", "))
+	}
+	opts.Supervisor = supervisorProvider
+	opts.SupervisorSource = daemon.SupervisorSourceCLI
+	return nil
+}
+
+// registerBackgroundDaemon claims the PID file when the one-shot environment
+// token marks this process as the `galley daemon start` child; the result releases it.
+func registerBackgroundDaemon(opts *daemon.Options, pidFile string) (func(), error) {
+	daemonToken := os.Getenv(daemonctl.EnvToken)
+	if daemonToken == "" {
+		return func() {}, nil
+	}
+	_ = os.Unsetenv(daemonctl.EnvToken)
+	if pidFile == "" {
+		return nil, fmt.Errorf("%s requires --pid-file", daemonctl.EnvToken)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve galley executable: %w", err)
+	}
+	resolved, err := daemon.Preflight(*opts)
+	if err != nil {
+		return nil, err
+	}
+	*opts = resolved
+	meta := daemonctl.NewPIDFile(os.Getpid(), exe, opts.Root, os.Args).WithToken(daemonToken)
+	if err := daemonctl.WritePID(pidFile, meta); err != nil {
+		return nil, err
+	}
+	if err := daemonctl.Heartbeat(pidFile, meta); err != nil {
+		return nil, err
+	}
+	stopHeartbeat := startPIDHeartbeat(pidFile, meta)
+	return func() {
+		stopHeartbeat()
+		_ = daemonctl.RemovePID(pidFile, os.Getpid())
+	}, nil
 }

--- a/internal/daemoncmd/force_unix_test.go
+++ b/internal/daemoncmd/force_unix_test.go
@@ -23,20 +23,19 @@ func spawnTrackedChild(t *testing.T, root string, reap bool, ownerOverride ...da
 	if err != nil {
 		t.Skip("sleep not available")
 	}
-	child := exec.Command(sleepPath, "60")
+	child := exec.CommandContext(t.Context(), sleepPath, "60")
 	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := child.Start(); err != nil {
 		t.Fatalf("start tracked child: %v", err)
 	}
+	// When reap is false, done is closed only by the cleanup below so callers
+	// can still select on it; the zombie is reaped after the assertions run.
 	done := make(chan struct{})
 	if reap {
 		go func() {
 			_, _ = child.Process.Wait()
 			close(done)
 		}()
-	} else {
-		// Closed only by the cleanup below so callers can still select on it.
-		// The zombie is reaped here, after the assertions have run.
 	}
 	t.Cleanup(func() {
 		_ = child.Process.Kill()

--- a/internal/daemoncmd/idle_force_test.go
+++ b/internal/daemoncmd/idle_force_test.go
@@ -38,7 +38,7 @@ func startUnresponsiveDaemon(t *testing.T) (root, pidFile string, pid int) {
 	if err != nil {
 		t.Skip("sh not available")
 	}
-	cmd := exec.Command(shPath, "-c", `trap "" TERM; printf ready; exec sleep 30`)
+	cmd := exec.CommandContext(t.Context(), shPath, "-c", `trap "" TERM; printf ready; exec sleep 30`)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemoncmd/process_windows.go
+++ b/internal/daemoncmd/process_windows.go
@@ -4,5 +4,5 @@ package daemoncmd
 
 import "os/exec"
 
-func configureBackgroundProcess(cmd *exec.Cmd) {
+func configureBackgroundProcess(_ *exec.Cmd) {
 }

--- a/internal/daemoncmd/stale_force_unix_test.go
+++ b/internal/daemoncmd/stale_force_unix_test.go
@@ -27,7 +27,7 @@ func startStaleDaemon(t *testing.T) (root, pidFile string) {
 	if err != nil {
 		t.Skip("true not available")
 	}
-	cmd := exec.Command(truePath)
+	cmd := exec.CommandContext(t.Context(), truePath)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start short-lived process: %v", err)
 	}

--- a/internal/daemoncmd/stop_lock.go
+++ b/internal/daemoncmd/stop_lock.go
@@ -29,7 +29,7 @@ func stopIntentPath(pidFile string, target daemonctl.PIDFile) string {
 func claimStopIntent(pidFile string, target daemonctl.PIDFile) (path string, leader bool, err error) {
 	path = stopIntentPath(pidFile, target)
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("create stop intent dir: %w", err)
 	}
 	err = os.Mkdir(path, 0o700)
 	if err == nil {
@@ -38,10 +38,20 @@ func claimStopIntent(pidFile string, target daemonctl.PIDFile) (path string, lea
 	if errors.Is(err, os.ErrExist) {
 		return path, false, nil
 	}
-	return "", false, err
+	return "", false, fmt.Errorf("claim stop intent %s: %w", path, err)
 }
 
-func waitForDaemonStop(pidFile, root, executable string, target daemonctl.PIDFile, timeout time.Duration) error {
+// stopWait identifies the daemon to wait on and how long to wait.
+type stopWait struct {
+	PIDFile    string
+	Root       string
+	Executable string
+	Target     daemonctl.PIDFile
+	Timeout    time.Duration
+}
+
+func waitForDaemonStop(w stopWait) error {
+	pidFile, root, executable, target, timeout := w.PIDFile, w.Root, w.Executable, w.Target, w.Timeout
 	deadline := time.Now().Add(timeout)
 	for {
 		status, err := daemonctl.Inspect(pidFile, root, executable)

--- a/internal/daemonconfig/config.go
+++ b/internal/daemonconfig/config.go
@@ -284,7 +284,7 @@ func Duration(value string) (time.Duration, bool, error) {
 	}
 	d, err := time.ParseDuration(value)
 	if err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("parse duration %q: %w", value, err)
 	}
 	return d, true, nil
 }

--- a/internal/daemonconfig/config_test.go
+++ b/internal/daemonconfig/config_test.go
@@ -102,13 +102,13 @@ func TestEnsureDefaultThenLoadRoundTripsDocumentedDefaults(t *testing.T) {
 		t.Fatalf("notifications must default to disabled, got enabled=true")
 	}
 	wantOn := DefaultNotificationEvents()
-	if got := file.Notifications.On; len(got) != len(wantOn) {
+	got := file.Notifications.On
+	if len(got) != len(wantOn) {
 		t.Fatalf("notifications.on got %v, want %v", got, wantOn)
-	} else {
-		for i := range wantOn {
-			if got[i] != wantOn[i] {
-				t.Fatalf("notifications.on[%d] got %q, want %q", i, got[i], wantOn[i])
-			}
+	}
+	for i := range wantOn {
+		if got[i] != wantOn[i] {
+			t.Fatalf("notifications.on[%d] got %q, want %q", i, got[i], wantOn[i])
 		}
 	}
 }

--- a/internal/daemonctl/child_unix.go
+++ b/internal/daemonctl/child_unix.go
@@ -3,6 +3,7 @@
 package daemonctl
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 )
@@ -19,5 +20,8 @@ func TerminateChildProcess(p *os.Process) error {
 	if p == nil {
 		return nil
 	}
-	return p.Signal(syscall.SIGTERM)
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("signal child %d: %w", p.Pid, err)
+	}
+	return nil
 }

--- a/internal/daemonctl/child_unix_test.go
+++ b/internal/daemonctl/child_unix_test.go
@@ -33,7 +33,7 @@ func TestTerminateChildProcessUnixUsesSIGTERM(t *testing.T) {
 	if err != nil {
 		t.Skipf("sleep not available: %v", err)
 	}
-	cmd := exec.Command(sleepPath, "30")
+	cmd := exec.CommandContext(t.Context(), sleepPath, "30")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep: %v", err)
 	}

--- a/internal/daemonctl/child_windows.go
+++ b/internal/daemonctl/child_windows.go
@@ -4,6 +4,7 @@ package daemonctl
 
 import (
 	"errors"
+	"fmt"
 	"os"
 )
 
@@ -25,7 +26,7 @@ func TerminateChildProcess(p *os.Process) error {
 		if errors.Is(err, os.ErrProcessDone) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("terminate child %d: %w", p.Pid, err)
 	}
 	return nil
 }

--- a/internal/daemonctl/child_windows_test.go
+++ b/internal/daemonctl/child_windows_test.go
@@ -27,7 +27,7 @@ func TestTerminateChildProcessWindowsNilIsNoOp(t *testing.T) {
 // before a failed `galley daemon start` returns an error.
 func TestTerminateChildProcessWindowsTerminatesLivingProcess(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}

--- a/internal/daemonctl/children.go
+++ b/internal/daemonctl/children.go
@@ -102,6 +102,12 @@ func cleanupRegisteredChildren(registryPath string, timeout time.Duration, kille
 			fmt.Fprintf(os.Stderr, "galley: SIGKILL pgid %d failed: %v\n", rec.PGID, err)
 		}
 	}
+	return awaitChildGroupExit(reg, killer, snapshot, timeout)
+}
+
+// awaitChildGroupExit polls killed process groups until gone or timed out;
+// on expiry it returns the survivors and prunes the confirmed-dead records.
+func awaitChildGroupExit(reg *proc.ChildRegistry, killer childKiller, snapshot []proc.ChildRecord, timeout time.Duration) ([]proc.ChildRecord, error) {
 	deadline := time.Now().Add(timeout)
 	remaining := snapshot
 	for {
@@ -117,26 +123,27 @@ func cleanupRegisteredChildren(registryPath string, timeout time.Duration, kille
 			return nil, nil
 		}
 		if timeout <= 0 || time.Now().After(deadline) {
-			killed := make([]proc.ChildRecord, 0, len(snapshot))
-			survivors := stillAlive
-			for _, rec := range snapshot {
-				dead := true
-				for _, alive := range survivors {
-					if alive.PID == rec.PID {
-						dead = false
-						break
-					}
-				}
-				if dead {
-					killed = append(killed, rec)
-				}
-			}
-			_ = pruneKilledFromRegistry(reg, killed)
-			return survivors, &ErrChildCleanupIncomplete{Remaining: survivors}
+			_ = pruneKilledFromRegistry(reg, deadRecords(snapshot, stillAlive))
+			return stillAlive, &ErrChildCleanupIncomplete{Remaining: stillAlive}
 		}
 		time.Sleep(50 * time.Millisecond)
 		remaining = stillAlive
 	}
+}
+
+// deadRecords returns the snapshot entries that are no longer among survivors.
+func deadRecords(snapshot, survivors []proc.ChildRecord) []proc.ChildRecord {
+	alive := make(map[int]bool, len(survivors))
+	for _, rec := range survivors {
+		alive[rec.PID] = true
+	}
+	dead := make([]proc.ChildRecord, 0, len(snapshot))
+	for _, rec := range snapshot {
+		if !alive[rec.PID] {
+			dead = append(dead, rec)
+		}
+	}
+	return dead
 }
 
 func pruneKilledFromRegistry(reg *proc.ChildRegistry, killed []proc.ChildRecord) error {

--- a/internal/daemonctl/children_test.go
+++ b/internal/daemonctl/children_test.go
@@ -30,12 +30,12 @@ func TestCleanupRegisteredChildrenSurfacesSurvivingPIDs(t *testing.T) {
 
 	var killCalls int32
 	killer := childKiller{
-		KillPGID: func(pgid int) error {
+		KillPGID: func(_ int) error {
 			atomic.AddInt32(&killCalls, 1)
 			return nil
 		},
-		AlivePID:  func(pid int) (bool, error) { return true, nil },
-		AlivePGID: func(pgid int) (bool, error) { return true, nil },
+		AlivePID:  func(_ int) (bool, error) { return true, nil },
+		AlivePGID: func(_ int) (bool, error) { return true, nil },
 	}
 
 	survivors, err := cleanupRegisteredChildren(registryPath, 100*time.Millisecond, killer)
@@ -80,15 +80,15 @@ func TestCleanupRegisteredChildrenPrunesRecordWhenProcessGroupDead(t *testing.T)
 
 	var killCalls, alivePIDCalls int32
 	killer := childKiller{
-		KillPGID: func(pgid int) error {
+		KillPGID: func(_ int) error {
 			atomic.AddInt32(&killCalls, 1)
 			return nil
 		},
-		AlivePID: func(pid int) (bool, error) {
+		AlivePID: func(_ int) (bool, error) {
 			atomic.AddInt32(&alivePIDCalls, 1)
 			return true, nil
 		},
-		AlivePGID: func(pgid int) (bool, error) { return false, nil },
+		AlivePGID: func(_ int) (bool, error) { return false, nil },
 	}
 
 	survivors, err := cleanupRegisteredChildren(registryPath, 100*time.Millisecond, killer)

--- a/internal/daemonctl/children_unix.go
+++ b/internal/daemonctl/children_unix.go
@@ -4,6 +4,7 @@ package daemonctl
 
 import (
 	"errors"
+	"fmt"
 	"syscall"
 )
 
@@ -22,7 +23,7 @@ func killProcessGroupByID(pgid int) error {
 	if errors.Is(err, syscall.ESRCH) {
 		return nil
 	}
-	return err
+	return fmt.Errorf("signal process group %d: %w", pgid, err)
 }
 
 // processGroupAlive reports whether any process in the pgid group is still
@@ -43,5 +44,5 @@ func processGroupAlive(pgid int) (bool, error) {
 	if errors.Is(err, syscall.EPERM) {
 		return true, nil
 	}
-	return false, err
+	return false, fmt.Errorf("probe process group %d: %w", pgid, err)
 }

--- a/internal/daemonctl/children_unix_test.go
+++ b/internal/daemonctl/children_unix_test.go
@@ -20,7 +20,7 @@ func TestCleanupRegisteredChildrenKillsLiveChildProcessGroup(t *testing.T) {
 	if err != nil {
 		t.Skip("sleep not available")
 	}
-	cmd := exec.Command(sleepPath, "60")
+	cmd := exec.CommandContext(t.Context(), sleepPath, "60")
 	// Match how proc.RunCommand puts subprocesses in their own pgid so the
 	// pgid-targeted SIGKILL path is the one under test.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -88,7 +88,7 @@ func TestCleanupRegisteredChildrenKeepsGroupWithDeadLeaderButLiveDescendant(t *t
 
 	// The leader establishes a fresh process group; the descendant joins that
 	// same pgid (setpgid(0, leaderPID)) so the group outlives the leader.
-	leader := exec.Command(sleepPath, "60")
+	leader := exec.CommandContext(t.Context(), sleepPath, "60")
 	leader.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := leader.Start(); err != nil {
 		t.Fatalf("start leader: %v", err)
@@ -99,7 +99,7 @@ func TestCleanupRegisteredChildrenKeepsGroupWithDeadLeaderButLiveDescendant(t *t
 	}
 	leaderPID := leader.Process.Pid
 
-	descendant := exec.Command(sleepPath, "60")
+	descendant := exec.CommandContext(t.Context(), sleepPath, "60")
 	descendant.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: pgid}
 	if err := descendant.Start(); err != nil {
 		_ = leader.Process.Kill()

--- a/internal/daemonctl/children_windows.go
+++ b/internal/daemonctl/children_windows.go
@@ -4,6 +4,7 @@ package daemonctl
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"syscall"
 )
@@ -15,13 +16,13 @@ func killProcessGroupByID(pgid int) error {
 	}
 	process, err := os.FindProcess(pgid)
 	if err != nil {
-		return err
+		return fmt.Errorf("find process %d: %w", pgid, err)
 	}
 	if err := process.Kill(); err != nil {
 		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("terminate process %d: %w", pgid, err)
 	}
 	return nil
 }

--- a/internal/daemonctl/control.go
+++ b/internal/daemonctl/control.go
@@ -76,11 +76,11 @@ func ReservePID(path string) (func(), error) {
 		if errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("pid file is locked: %s", lockPath)
 		}
-		return nil, err
+		return nil, fmt.Errorf("open pid lock %s: %w", lockPath, err)
 	}
 	if err := file.Close(); err != nil {
 		_ = os.Remove(lockPath)
-		return nil, err
+		return nil, fmt.Errorf("close pid lock %s: %w", lockPath, err)
 	}
 	return func() {
 		_ = os.Remove(lockPath)
@@ -144,7 +144,7 @@ func RemovePID(path string, pid int) error {
 		return nil
 	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+		return fmt.Errorf("remove pid file %s: %w", path, err)
 	}
 	return nil
 }
@@ -295,23 +295,22 @@ func ForceStop(meta PIDFile, timeout time.Duration) (bool, error) {
 	if err == nil || errors.Is(err, ErrNotRunning) {
 		return false, nil
 	}
-	if !errors.Is(err, ErrUnverifiedProcess) {
-		// Graceful stop timed out (or another transient failure): fall through to
-		// the verified force kill below. Unverified-process errors are returned as
-		// is so callers do not escalate to SIGKILL against an unknown process.
-		alive, aliveErr := Alive(meta.PID)
-		if aliveErr != nil {
-			return false, aliveErr
-		}
-		if !alive {
-			return false, nil
-		}
-		if killErr := KillVerified(meta, timeout); killErr != nil && !errors.Is(killErr, ErrNotRunning) {
-			return false, killErr
-		}
-		return true, nil
+	// An unverified process is returned as is so no SIGKILL reaches an unknown
+	// process; every other failure falls through to the verified force kill.
+	if errors.Is(err, ErrUnverifiedProcess) {
+		return false, err
 	}
-	return false, err
+	alive, aliveErr := Alive(meta.PID)
+	if aliveErr != nil {
+		return false, aliveErr
+	}
+	if !alive {
+		return false, nil
+	}
+	if killErr := KillVerified(meta, timeout); killErr != nil && !errors.Is(killErr, ErrNotRunning) {
+		return false, killErr
+	}
+	return true, nil
 }
 
 // KillVerified sends SIGKILL only to a process verified against its PID metadata.
@@ -326,13 +325,13 @@ func KillVerified(meta PIDFile, timeout time.Duration) error {
 func Kill(pid int, timeout time.Duration) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return err
+		return fmt.Errorf("find process %d: %w", pid, err)
 	}
 	if err := process.Kill(); err != nil {
 		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 			return ErrNotRunning
 		}
-		return err
+		return fmt.Errorf("kill process %d: %w", pid, err)
 	}
 	return waitExit(pid, timeout, "exit after SIGKILL")
 }

--- a/internal/daemonctl/control_unix.go
+++ b/internal/daemonctl/control_unix.go
@@ -4,6 +4,7 @@ package daemonctl
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"syscall"
 	"time"
@@ -14,7 +15,7 @@ import (
 func Alive(pid int) (bool, error) {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("find process %d: %w", pid, err)
 	}
 	err = process.Signal(syscall.Signal(0))
 	if err == nil {
@@ -29,20 +30,20 @@ func Alive(pid int) (bool, error) {
 	if errors.Is(err, syscall.EPERM) {
 		return true, nil
 	}
-	return false, err
+	return false, fmt.Errorf("probe process %d: %w", pid, err)
 }
 
 // Stop sends SIGTERM and waits for process exit until timeout.
 func Stop(pid int, timeout time.Duration) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return err
+		return fmt.Errorf("find process %d: %w", pid, err)
 	}
 	if err := process.Signal(syscall.SIGTERM); err != nil {
 		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
 			return ErrNotRunning
 		}
-		return err
+		return fmt.Errorf("signal process %d: %w", pid, err)
 	}
 	return waitExit(pid, timeout, "stop")
 }

--- a/internal/daemonctl/control_windows.go
+++ b/internal/daemonctl/control_windows.go
@@ -4,6 +4,8 @@ package daemonctl
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"os"
 	"syscall"
 	"time"
@@ -19,37 +21,45 @@ const stillActive = 259
 // pulling in `golang.org/x/sys/windows` for one numeric value.
 const processQueryLimitedInformation = 0x1000
 
+// windowsProcessID narrows a PID for the Windows process APIs, which take an
+// unsigned 32-bit id.
+func windowsProcessID(pid int) (uint32, error) {
+	if pid <= 0 || int64(pid) > int64(math.MaxUint32) {
+		return 0, fmt.Errorf("pid %d is outside the Windows process id range", pid)
+	}
+	return uint32(pid), nil
+}
+
 // Alive reports whether pid exists by opening the process and inspecting its
 // exit code. Windows has no signal(0) equivalent: `process.Signal(Signal(0))`
 // surfaces a raw "not supported by windows" error from the Go runtime.
 func Alive(pid int) (bool, error) {
-	if pid <= 0 {
-		return false, nil
-	}
-	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	id, err := windowsProcessID(pid)
 	if err != nil {
-		// ERROR_INVALID_PARAMETER (87) means the pid does not exist; the
-		// other documented failure mode here is access-denied, which still
-		// implies a live process owned by another user. Treat unknown errors
-		// as "not alive" so daemon status reports a clean stopped state
-		// rather than surfacing a Windows API error to the operator.
-		var errno syscall.Errno
-		if errors.As(err, &errno) {
-			if errno == syscall.Errno(5) /* ERROR_ACCESS_DENIED */ {
-				return true, nil
-			}
-			if errno == syscall.Errno(87) /* ERROR_INVALID_PARAMETER */ {
-				return false, nil
-			}
-		}
 		return false, nil
 	}
-	defer syscall.CloseHandle(handle)
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, id)
+	if err != nil {
+		return aliveFromOpenError(err), nil
+	}
+	defer func() { _ = syscall.CloseHandle(handle) }()
 	var code uint32
 	if err := syscall.GetExitCodeProcess(handle, &code); err != nil {
-		return false, err
+		return false, fmt.Errorf("read exit code of process %d: %w", pid, err)
 	}
 	return code == stillActive, nil
+}
+
+// aliveFromOpenError classifies an OpenProcess failure. ERROR_INVALID_PARAMETER
+// means the pid does not exist; ERROR_ACCESS_DENIED still implies a live
+// process owned by another user. Any other error reports not alive so daemon
+// status shows a clean stopped state instead of a raw Windows API error.
+func aliveFromOpenError(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	return errno == syscall.Errno(5) /* ERROR_ACCESS_DENIED */
 }
 
 // Stop terminates pid. Windows does not have a SIGTERM equivalent that can
@@ -69,13 +79,13 @@ func Stop(pid int, timeout time.Duration) error {
 	}
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return err
+		return fmt.Errorf("find process %d: %w", pid, err)
 	}
 	if err := process.Kill(); err != nil {
 		if errors.Is(err, os.ErrProcessDone) {
 			return ErrNotRunning
 		}
-		return err
+		return fmt.Errorf("terminate process %d: %w", pid, err)
 	}
 	return waitExit(pid, timeout, "stop")
 }

--- a/internal/daemonctl/control_windows_test.go
+++ b/internal/daemonctl/control_windows_test.go
@@ -54,7 +54,7 @@ func TestAliveReportsCurrentProcessAlive(t *testing.T) {
 // comparison and must report not-alive once a child has exited.
 func TestAliveReportsExitedProcessNotAlive(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("cmd.exe", "/C", "exit 0")
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/C", "exit 0")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestAliveReportsExitedProcessNotAlive(t *testing.T) {
 // state instead of surfacing a raw "process already finished" error.
 func TestStopReturnsNotRunningForExitedPID(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("cmd.exe", "/C", "exit 0")
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/C", "exit 0")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestStopReturnsNotRunningForExitedPID(t *testing.T) {
 // TerminateProcess path is still required to leave the process gone.
 func TestStopTerminatesLivingProcess(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestForceStopOnLiveProcessKills(t *testing.T) {
 	if err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}
-	cmd := exec.Command(cmdPath, "/C", "ping -n 30 127.0.0.1 > NUL")
+	cmd := exec.CommandContext(t.Context(), cmdPath, "/C", "ping -n 30 127.0.0.1 > NUL")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestForceStopOnLiveProcessKills(t *testing.T) {
 // or skipping cleanup entirely.
 func TestChildProcessGroupCleanupFallsBackToPID(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
+	cmd := exec.CommandContext(t.Context(), "cmd.exe", "/C", "ping -n 30 127.0.0.1 > NUL")
 	if err := cmd.Start(); err != nil {
 		t.Skipf("cmd.exe not available: %v", err)
 	}

--- a/internal/daemonctl/force_test.go
+++ b/internal/daemonctl/force_test.go
@@ -15,7 +15,7 @@ func TestForceStopGracefulSucceedsWithoutKill(t *testing.T) {
 	if err != nil {
 		t.Skip("sleep not available")
 	}
-	cmd := exec.Command(sleepPath, "10")
+	cmd := exec.CommandContext(t.Context(), sleepPath, "10")
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestForceStopKillsUnresponsiveDaemonAfterTimeout(t *testing.T) {
 		t.Skip("sh not available")
 	}
 	// Ignore SIGTERM so graceful stop times out and the verified force kill runs.
-	cmd := exec.Command(shPath, "-c", `trap "" TERM; sleep 10`)
+	cmd := exec.CommandContext(t.Context(), shPath, "-c", `trap "" TERM; sleep 10`)
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemonctl/pid_read_test.go
+++ b/internal/daemonctl/pid_read_test.go
@@ -34,32 +34,49 @@ func TestReadPIDFileReadFailures(t *testing.T) {
 			t.Parallel()
 			calls := 0
 			started := time.Now()
-			meta, err := readPIDFile("daemon.pid", tc.goos, func(path string) ([]byte, error) {
-				if path != "daemon.pid" {
-					t.Fatalf("read wrong PID file: %s", path)
-				}
-				failure := tc.failures[min(calls, len(tc.failures)-1)]
-				calls++
-				if failure != nil {
-					return nil, failure
-				}
-				return []byte(`{"pid":123}`), nil
-			})
+			meta, err := readPIDFile("daemon.pid", tc.goos, stubPIDReader(t, tc.failures, &calls))
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("read error = %v, want %v", err, tc.wantErr)
 			}
 			if err == nil && meta.PID != 123 {
 				t.Fatalf("read lost PID: %#v", meta)
 			}
-			if tc.wantCalls > 0 && calls != tc.wantCalls {
-				t.Fatalf("read attempts = %d, want %d", calls, tc.wantCalls)
-			}
-			if tc.wantCalls == 0 && calls < 2 {
-				t.Fatal("persistent conflict was not retried")
-			}
+			assertPIDReadAttempts(t, calls, tc.wantCalls)
 			if elapsed := time.Since(started); elapsed > 2*time.Second {
 				t.Fatalf("PID read was not bounded: %s", elapsed)
 			}
 		})
+	}
+}
+
+// stubPIDReader replays failures in order, repeating the last one once the list
+// is exhausted, and counts every attempt.
+func stubPIDReader(t *testing.T, failures []error, calls *int) func(string) ([]byte, error) {
+	t.Helper()
+	return func(path string) ([]byte, error) {
+		if path != "daemon.pid" {
+			t.Fatalf("read wrong PID file: %s", path)
+		}
+		failure := failures[min(*calls, len(failures)-1)]
+		*calls++
+		if failure != nil {
+			return nil, failure
+		}
+		return []byte(`{"pid":123}`), nil
+	}
+}
+
+// assertPIDReadAttempts checks the retry budget. wantCalls == 0 means the
+// conflict is persistent, so only "was it retried at all" can be asserted.
+func assertPIDReadAttempts(t *testing.T, calls, wantCalls int) {
+	t.Helper()
+	if wantCalls > 0 {
+		if calls != wantCalls {
+			t.Fatalf("read attempts = %d, want %d", calls, wantCalls)
+		}
+		return
+	}
+	if calls < 2 {
+		t.Fatal("persistent conflict was not retried")
 	}
 }

--- a/internal/daemonctl/process_unix.go
+++ b/internal/daemonctl/process_unix.go
@@ -4,6 +4,7 @@ package daemonctl
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -39,12 +40,14 @@ func ProcessInfo(pid int) (ProcessInfoResult, error) {
 	}, nil
 }
 
+// psField runs on its own bounded budget rather than a caller context: a
+// liveness probe must still answer while the caller is shutting down.
 func psField(pid, field string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	output, err := exec.CommandContext(ctx, "ps", "-p", pid, "-o", field).Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read ps field %s for pid %s: %w", field, pid, err)
 	}
 	return strings.TrimSpace(string(output)), nil
 }

--- a/internal/daemonctl/process_windows.go
+++ b/internal/daemonctl/process_windows.go
@@ -19,17 +19,20 @@ type ProcessInfoResult struct {
 // ProcessInfo returns stable identity fields directly from the Windows
 // process API without starting an external query process.
 func ProcessInfo(pid int) (ProcessInfoResult, error) {
-	if pid <= 0 {
-		return ProcessInfoResult{}, fmt.Errorf("query process %d: invalid pid", pid)
+	id, err := windowsProcessID(pid)
+	if err != nil {
+		return ProcessInfoResult{}, fmt.Errorf("query process: %w", err)
 	}
-	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	handle, err := windows.OpenProcess(processQueryLimitedInformation, false, id)
 	if err != nil {
 		return ProcessInfoResult{}, fmt.Errorf("query process %d: open: %w", pid, err)
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
-	pathBuffer := make([]uint16, 32768)
-	pathLength := uint32(len(pathBuffer))
+	// The buffer length is typed so the Windows API call needs no conversion.
+	const pathBufferLen uint32 = 32768
+	pathBuffer := make([]uint16, pathBufferLen)
+	pathLength := pathBufferLen
 	if err := windows.QueryFullProcessImageName(handle, 0, &pathBuffer[0], &pathLength); err != nil {
 		return ProcessInfoResult{}, fmt.Errorf("query process %d executable: %w", pid, err)
 	}
@@ -47,6 +50,6 @@ func ProcessInfo(pid int) (ProcessInfoResult, error) {
 
 // Zombie reports whether pid is a zombie process. Windows has no zombie
 // processes, so this is always false.
-func Zombie(pid int) bool {
+func Zombie(_ int) bool {
 	return false
 }

--- a/internal/executorflow/attempt.go
+++ b/internal/executorflow/attempt.go
@@ -55,9 +55,19 @@ type DiffArtifacts struct {
 	Err      error
 }
 
-func CaptureDiffArtifacts(ctx context.Context, workDir, baseSHA, attemptDir string, opts workspace.Options) (DiffArtifacts, error) {
-	snapshot, err := workspace.CaptureSnapshotFromBase(ctx, workDir, baseSHA, opts)
+// DiffCapture locates the attempt whose diff evidence is captured.
+type DiffCapture struct {
+	WorkDir    string
+	BaseSHA    string
+	AttemptDir string
+	Opts       workspace.Options
+}
+
+func CaptureDiffArtifacts(ctx context.Context, req DiffCapture) (DiffArtifacts, error) {
+	attemptDir := req.AttemptDir
+	snapshot, err := workspace.CaptureSnapshotFromBase(ctx, req.WorkDir, req.BaseSHA, req.Opts)
 	if err != nil {
+		//nolint:nilerr // the capture error is reported through DiffArtifacts.Err
 		return DiffArtifacts{Snapshot: snapshot, Err: err}, nil
 	}
 	dirty := snapshot.BranchDiff != "" || snapshot.StagedDiff != "" || snapshot.UnstagedDiff != ""

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -187,10 +187,10 @@ func TestWithExclusiveMarkerReportsCleanupFailure(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "task.lock")
 	err := WithExclusiveMarker(marker, func() error {
 		if err := os.Remove(marker); err != nil {
-			return err
+			return fmt.Errorf("remove marker: %w", err)
 		}
 		if err := os.Mkdir(marker, 0o700); err != nil {
-			return err
+			return fmt.Errorf("recreate marker as dir: %w", err)
 		}
 		return os.WriteFile(filepath.Join(marker, "blocker"), []byte("x"), 0o600)
 	})
@@ -224,37 +224,15 @@ func TestWriteFileNoOverwriteAtomicPublicationIsAtomic(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for {
-				data, err := os.ReadFile(path)
-				if err == nil {
-					if !bytes.Equal(data, payload) {
-						readResult <- fmt.Errorf(
-							"partial publication observed: got %d bytes, want %d",
-							len(data), len(payload),
-						)
-					}
-					return
-				}
-				if !errors.Is(err, os.ErrNotExist) {
-					if isTransientPublicationReadError(err) {
-						continue
-					}
-					readResult <- fmt.Errorf("unexpected read error: %w", err)
-					return
-				}
-			}
+			readResult <- pollForCompletePublication(path, payload)
 		}()
 
 		if err := WriteFileNoOverwriteAtomic(path, payload, 0o600); err != nil {
 			t.Fatalf("iter %d write: %v", i, err)
 		}
 		wg.Wait()
-		select {
-		case err := <-readResult:
-			if err != nil {
-				t.Fatalf("iter %d: %v", i, err)
-			}
-		default:
+		if err := <-readResult; err != nil {
+			t.Fatalf("iter %d: %v", i, err)
 		}
 
 		// After successful publication the reservation lock must be gone
@@ -282,15 +260,7 @@ func TestWriteFileAtomicReplacesContentsAndMode(t *testing.T) {
 	if string(data) != "new" {
 		t.Fatalf("contents got %q, want new", data)
 	}
-	if runtime.GOOS != "windows" {
-		info, err := os.Stat(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got := info.Mode().Perm(); got != 0o600 {
-			t.Fatalf("mode got %o, want 600", got)
-		}
-	}
+	assertFileMode(t, path, 0o600)
 }
 
 func isTransientPublicationReadError(err error) bool {
@@ -301,4 +271,37 @@ func isTransientPublicationReadError(err error) bool {
 	// violations to a racing reader. That still preserves the publication
 	// contract: the reader has not observed partial YAML bytes.
 	return errors.Is(err, syscall.Errno(32)) || errors.Is(err, syscall.Errno(33))
+}
+
+// pollForCompletePublication reads path until it exists and reports whether the
+// full payload was observed; a non-atomic publication surfaces as a short read.
+func pollForCompletePublication(path string, payload []byte) error {
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if !bytes.Equal(data, payload) {
+				return fmt.Errorf("partial publication observed: got %d bytes, want %d", len(data), len(payload))
+			}
+			return nil
+		}
+		if errors.Is(err, os.ErrNotExist) || isTransientPublicationReadError(err) {
+			continue
+		}
+		return fmt.Errorf("unexpected read error: %w", err)
+	}
+}
+
+// assertFileMode checks POSIX permission bits. Windows does not carry them.
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("mode got %o, want %o", got, want)
+	}
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -40,7 +40,7 @@ func WriteFileNoOverwriteAtomic(path string, data []byte, perm os.FileMode) erro
 		return err
 	}
 	err = WithExclusiveMarker(path+".lock", func() error {
-		return stageAndMove(dir, path, data, perm, publishNoReplace)
+		return stageAndMove(stagedWrite{Dir: dir, Path: path, Data: data, Perm: perm}, publishNoReplace)
 	})
 	var markerErr *markerExistsError
 	if errors.As(err, &markerErr) {
@@ -96,7 +96,7 @@ func prepareWriteDir(path string) (string, error) {
 }
 
 func stageAndRename(dir, path string, data []byte, perm os.FileMode) error {
-	return stageAndMove(dir, path, data, perm, func(src, dst string) error {
+	return stageAndMove(stagedWrite{Dir: dir, Path: path, Data: data, Perm: perm}, func(src, dst string) error {
 		if err := os.Rename(src, dst); err != nil {
 			return fmt.Errorf("rename temp file %s to %s: %w", src, dst, err)
 		}
@@ -104,7 +104,16 @@ func stageAndRename(dir, path string, data []byte, perm os.FileMode) error {
 	})
 }
 
-func stageAndMove(dir, path string, data []byte, perm os.FileMode, move func(string, string) error) error {
+// stagedWrite is one file staged in dir and then moved into place.
+type stagedWrite struct {
+	Dir  string
+	Path string
+	Data []byte
+	Perm os.FileMode
+}
+
+func stageAndMove(w stagedWrite, move func(string, string) error) error {
+	dir, path, data, perm := w.Dir, w.Path, w.Data, w.Perm
 	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("create temp file for %s: %w", path, err)

--- a/internal/fileutil/lock.go
+++ b/internal/fileutil/lock.go
@@ -7,13 +7,17 @@ import (
 )
 
 // TryLock holds an OS file lock until close or process exit; the inode remains reusable.
+// Callers supply a Galley-owned path: task.Queue builds it from the queue root
+// plus a sha256 hex digest of the task ID, so no task input reaches it unencoded.
 func TryLock(path string) (func(), error) {
+	//nolint:gosec // G703: path is Galley-owned; see the contract above
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create lock dir %s: %w", filepath.Dir(path), err)
 	}
+	//nolint:gosec // G703: path is Galley-owned; see the contract above
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("open lock file %s: %w", path, err)
 	}
 	if err := lockFile(file); err != nil {
 		_ = file.Close()

--- a/internal/fileutil/lock_test.go
+++ b/internal/fileutil/lock_test.go
@@ -39,7 +39,7 @@ func TestFileLockReleasesAfterProcessDeath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stdin.Close()
+	defer func() { _ = stdin.Close() }()
 	if err := child.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/fileutil/lock_unix.go
+++ b/internal/fileutil/lock_unix.go
@@ -3,11 +3,15 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 
 	"golang.org/x/sys/unix"
 )
 
 func lockFile(file *os.File) error {
-	return unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		return fmt.Errorf("flock: %w", err)
+	}
+	return nil
 }

--- a/internal/fileutil/lock_windows.go
+++ b/internal/fileutil/lock_windows.go
@@ -1,11 +1,15 @@
 package fileutil
 
 import (
+	"fmt"
 	"os"
 
 	"golang.org/x/sys/windows"
 )
 
 func lockFile(file *os.File) error {
-	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &windows.Overlapped{})
+	if err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &windows.Overlapped{}); err != nil {
+		return fmt.Errorf("lock file: %w", err)
+	}
+	return nil
 }

--- a/internal/fileutil/rename_noreplace.go
+++ b/internal/fileutil/rename_noreplace.go
@@ -39,14 +39,17 @@ func renameUnderMarkerFallback(src, dst string) error {
 	if _, err := os.Lstat(dst); err == nil {
 		return os.ErrExist
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
+		return fmt.Errorf("stat destination %s: %w", dst, err)
 	}
-	return os.Rename(src, dst)
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", src, dst, err)
+	}
+	return nil
 }
 
 func linkAndUnlinkNoReplace(src, dst string) error {
 	if err := os.Link(src, dst); err != nil {
-		return err
+		return fmt.Errorf("link %s to %s: %w", src, dst, err)
 	}
 	if err := os.Remove(src); err != nil {
 		rollbackErr := os.Remove(dst)

--- a/internal/fileutil/rename_noreplace_darwin.go
+++ b/internal/fileutil/rename_noreplace_darwin.go
@@ -4,6 +4,7 @@ package fileutil
 
 import (
 	"errors"
+	"fmt"
 
 	"golang.org/x/sys/unix"
 )
@@ -13,5 +14,8 @@ func renameNoReplace(src, dst string) error {
 	if errors.Is(err, unix.ENOTSUP) {
 		return errNoReplaceUnsupported
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("renamex_np %s to %s: %w", src, dst, err)
+	}
+	return nil
 }

--- a/internal/fileutil/rename_noreplace_linux.go
+++ b/internal/fileutil/rename_noreplace_linux.go
@@ -4,6 +4,7 @@ package fileutil
 
 import (
 	"errors"
+	"fmt"
 
 	"golang.org/x/sys/unix"
 )
@@ -13,5 +14,8 @@ func renameNoReplace(src, dst string) error {
 	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EOPNOTSUPP) {
 		return errNoReplaceUnsupported
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("renameat2 %s to %s: %w", src, dst, err)
+	}
+	return nil
 }

--- a/internal/fileutil/rename_noreplace_windows.go
+++ b/internal/fileutil/rename_noreplace_windows.go
@@ -3,6 +3,8 @@
 package fileutil
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,17 +23,17 @@ func renameNoReplace(src, dst string) error {
 	}
 	srcPtr, err := windows.UTF16PtrFromString(srcPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode source path %s: %w", srcPath, err)
 	}
 	dstPtr, err := windows.UTF16PtrFromString(dstPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode destination path %s: %w", dstPath, err)
 	}
 	if err := windows.MoveFile(srcPtr, dstPtr); err != nil {
-		if err == windows.ERROR_ALREADY_EXISTS || err == windows.ERROR_FILE_EXISTS {
+		if errors.Is(err, windows.ERROR_ALREADY_EXISTS) || errors.Is(err, windows.ERROR_FILE_EXISTS) {
 			return os.ErrExist
 		}
-		return err
+		return fmt.Errorf("move %s to %s: %w", srcPath, dstPath, err)
 	}
 	return nil
 }
@@ -39,7 +41,7 @@ func renameNoReplace(src, dst string) error {
 func windowsMovePath(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve absolute path %s: %w", path, err)
 	}
 	abs = filepath.Clean(abs)
 	if strings.HasPrefix(abs, `\\?\`) || strings.HasPrefix(abs, `\??\`) || len(abs) < 248 {

--- a/internal/inputfiles/input_files.go
+++ b/internal/inputfiles/input_files.go
@@ -52,6 +52,7 @@ func PrepareReusing(workDir string, files []task.InputFile, prior []Prepared) ([
 		}
 		// Check the existing ancestor before MkdirAll, then the final parent after
 		// creation, so a symlinked parent cannot redirect copies outside workDir.
+		//nolint:gosec // G301: destination is inside the worktree checkout
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			_ = CleanupPrepared(prepared)
 			return nil, fmt.Errorf("create input file dir %s: %w", filepath.Dir(dst), err)
@@ -60,36 +61,17 @@ func PrepareReusing(workDir string, files []task.InputFile, prior []Prepared) ([
 			_ = CleanupPrepared(prepared)
 			return nil, fmt.Errorf("files[%d].destination: %w", i, err)
 		}
-		reused := false
-		contentSHA256 := ""
-		for _, known := range prior {
-			if known.Source != file.Source || known.Destination != filepath.Clean(file.Destination) || known.Commit != file.Commit || filepath.Clean(known.Path) != filepath.Clean(dst) {
-				continue
-			}
-			info, statErr := os.Lstat(dst)
-			if os.IsNotExist(statErr) {
-				break
-			}
-			if statErr != nil || !info.Mode().IsRegular() {
-				_ = CleanupPrepared(prepared)
-				return nil, fmt.Errorf("reused input must be a regular file: %s (%v)", dst, statErr)
-			}
-			data, readErr := os.ReadFile(dst)
-			if readErr != nil {
-				_ = CleanupPrepared(prepared)
-				return nil, readErr
-			}
-			sum := sha256.Sum256(data)
-			contentSHA256 = hex.EncodeToString(sum[:])
-			reused = true
-			break
+		contentSHA256, reused, err := reusePriorInput(file, dst, prior)
+		if err != nil {
+			_ = CleanupPrepared(prepared)
+			return nil, err
 		}
 		if !reused {
 			contentSHA256, err = copyFileNoOverwrite(file.Source, dst)
-		}
-		if err != nil {
-			_ = CleanupPrepared(prepared)
-			return nil, fmt.Errorf("copy input file %s to %s: %w", file.Source, dst, err)
+			if err != nil {
+				_ = CleanupPrepared(prepared)
+				return nil, fmt.Errorf("copy input file %s to %s: %w", file.Source, dst, err)
+			}
 		}
 		prepared = append(prepared, Prepared{
 			Source:        file.Source,
@@ -180,7 +162,7 @@ func copyFileNoOverwrite(src, dst string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open %s: %w", src, err)
 	}
-	defer source.Close()
+	defer func() { _ = source.Close() }()
 	openedInfo, err := source.Stat()
 	if err != nil {
 		return "", fmt.Errorf("stat opened source %s: %w", src, err)
@@ -265,6 +247,7 @@ func pruneEmptyParents(root, dir string) error {
 			return nil
 		}
 		rel, err := filepath.Rel(root, dir)
+		//nolint:nilerr // leaving the root stops pruning; that is the safe end state
 		if err != nil || rel == ".." || filepath.IsAbs(rel) || rel == "." || strings.HasPrefix(rel, "../") {
 			return nil
 		}
@@ -273,7 +256,7 @@ func pruneEmptyParents(root, dir string) error {
 			if os.IsNotExist(err) {
 				return nil
 			}
-			return err
+			return fmt.Errorf("read dir %s: %w", dir, err)
 		}
 		if len(entries) > 0 {
 			return nil
@@ -282,8 +265,35 @@ func pruneEmptyParents(root, dir string) error {
 			if os.IsNotExist(err) {
 				return nil
 			}
-			return err
+			return fmt.Errorf("remove empty dir %s: %w", dir, err)
 		}
 		dir = filepath.Dir(dir)
 	}
+}
+
+// reusePriorInput returns the digest of an input a prior run already placed when
+// source, destination, and commit match; reused=false means the caller copies it.
+func reusePriorInput(file task.InputFile, dst string, prior []Prepared) (string, bool, error) {
+	for _, known := range prior {
+		if known.Source != file.Source || known.Destination != filepath.Clean(file.Destination) || known.Commit != file.Commit || filepath.Clean(known.Path) != filepath.Clean(dst) {
+			continue
+		}
+		info, statErr := os.Lstat(dst)
+		if os.IsNotExist(statErr) {
+			return "", false, nil
+		}
+		if statErr != nil {
+			return "", false, fmt.Errorf("reused input must be a regular file: %s: %w", dst, statErr)
+		}
+		if !info.Mode().IsRegular() {
+			return "", false, fmt.Errorf("reused input must be a regular file: %s", dst)
+		}
+		data, readErr := os.ReadFile(dst)
+		if readErr != nil {
+			return "", false, fmt.Errorf("read reused input %s: %w", dst, readErr)
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:]), true, nil
+	}
+	return "", false, nil
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -110,7 +110,7 @@ func BuildCommand(command string, ev Event, opts Options) (proc.Command, func(),
 	if goos == "" {
 		goos = runtime.GOOS
 	}
-	argv, cleanup, _, err := profilecmd.ShellArgvForOSWithResolver(goos, command, opts.ScratchDir, profile.RequiredCheckEnvironment{}, opts.Resolver)
+	argv, cleanup, _, err := profilecmd.ShellArgvForOSWithResolver(profilecmd.ShellRequest{GOOS: goos, Command: command, ScratchDir: opts.ScratchDir, Shell: profile.RequiredCheckEnvironment{}}, opts.Resolver)
 	if err != nil {
 		return proc.Command{}, nil, err
 	}

--- a/internal/preflight/setup/contract.go
+++ b/internal/preflight/setup/contract.go
@@ -12,7 +12,20 @@ import (
 // When the failure occurred before the executor could run (request marshaling,
 // command plan construction) the executor-specific arguments may be zero
 // values and only the message is recorded.
-func setupExecutorFailureResult(message, provider, executorRun string, exitCode int, stdout, stderr string, inspected []string) *Result {
+// setupExecutorFailure is one failed setup-executor invocation.
+type setupExecutorFailure struct {
+	Message     string
+	Provider    string
+	ExecutorRun string
+	ExitCode    int
+	Stdout      string
+	Stderr      string
+	Inspected   []string
+}
+
+func setupExecutorFailureResult(f setupExecutorFailure) *Result {
+	message, provider, executorRun := f.Message, f.Provider, f.ExecutorRun
+	exitCode, stdout, stderr, inspected := f.ExitCode, f.Stdout, f.Stderr, f.Inspected
 	res := &Result{
 		Status:         StatusFailed,
 		Commands:       []CommandAttempt{},

--- a/internal/preflight/setup/evidence.go
+++ b/internal/preflight/setup/evidence.go
@@ -46,11 +46,11 @@ func LoadEnvironmentUpdate(runDir string) (*EnvironmentUpdate, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("read environment update: %w", err)
 	}
 	var update EnvironmentUpdate
 	if err := json.Unmarshal(data, &update); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode environment update: %w", err)
 	}
 	return &update, nil
 }
@@ -73,20 +73,7 @@ func LoadRunEvidence(runDir, runID string) (*Result, *EnvironmentUpdate) {
 	update, uerr := LoadEnvironmentUpdate(runDir)
 	if uerr != nil {
 		fmt.Fprintf(os.Stderr, "galley: could not load setup environment update for run %s: %v\n", runID, uerr)
-		if res == nil {
-			res = &Result{
-				Status:   StatusFailed,
-				Commands: []CommandAttempt{},
-			}
-		}
-		if res.Error == "" {
-			res.Error = "environment_update.json could not be loaded: " + uerr.Error()
-		} else {
-			res.Error += "; environment_update.json could not be loaded: " + uerr.Error()
-		}
-		if res.RepairGuidance == "" {
-			res.RepairGuidance = "Inspect the run directory and restore readable setup evidence before trusting setup readiness."
-		}
+		res = recordEnvironmentUpdateFailure(res, uerr)
 	}
 	return res, update
 }
@@ -100,11 +87,11 @@ func LoadResult(runDir string) (*Result, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("read setup result: %w", err)
 	}
 	var res Result
 	if err := json.Unmarshal(data, &res); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode setup result: %w", err)
 	}
 	return &res, nil
 }
@@ -118,4 +105,22 @@ func WriteEnvironmentUpdate(runDir string, update *EnvironmentUpdate) error {
 		return fmt.Errorf("create setup run dir: %w", err)
 	}
 	return jsonio.Write(runartifact.Path(runDir, runartifact.SetupEnvironmentUpdateFilename), update)
+}
+
+// recordEnvironmentUpdateFailure folds an unreadable environment_update.json
+// into the setup result so readers cannot mistake it for a healthy setup.
+func recordEnvironmentUpdateFailure(res *Result, uerr error) *Result {
+	if res == nil {
+		res = &Result{Status: StatusFailed, Commands: []CommandAttempt{}}
+	}
+	detail := "environment_update.json could not be loaded: " + uerr.Error()
+	if res.Error == "" {
+		res.Error = detail
+	} else {
+		res.Error += "; " + detail
+	}
+	if res.RepairGuidance == "" {
+		res.RepairGuidance = "Inspect the run directory and restore readable setup evidence before trusting setup readiness."
+	}
+	return res
 }

--- a/internal/preflight/setup/provider.go
+++ b/internal/preflight/setup/provider.go
@@ -34,7 +34,11 @@ func marshalSetupExecutorRequest(opts Options, signals []string) ([]byte, error)
 		"repository_signals": signals,
 		"worktree":           opts.WorkDir,
 	}
-	return json.MarshalIndent(request, "", " ")
+	payload, err := json.MarshalIndent(request, "", " ")
+	if err != nil {
+		return nil, fmt.Errorf("encode setup executor request: %w", err)
+	}
+	return payload, nil
 }
 
 func BuildExecutorCommandPlan(opts Options, payload []byte) (proc.Command, string, error) {
@@ -46,22 +50,30 @@ func BuildExecutorCommandPlan(opts Options, payload []byte) (proc.Command, strin
 	case provider.TransportGrok:
 		cmd, err := buildGrokSetupExecutorCommandPlan(opts, payload)
 		return cmd, string(transport), err
+	case provider.TransportClaude:
+		return buildClaudeSetupPlan(opts, payload)
 	default:
-		cmd, err := buildClaudeSetupExecutorCommandPlan(opts, payload)
-		if err != nil {
-			return proc.Command{}, "claude", err
-		}
-		if err := runner.ConfigureClaudeProvider(&cmd, runner.ClaudeProviderOptions{
-			Provider: opts.Task.Executor.CLI,
-			Credentials: runner.ClaudeCredentials{
-				GLMAuthToken: opts.GLMAuthToken,
-				KimiAPIKey:   opts.KimiAPIKey,
-			},
-		}); err != nil {
-			return proc.Command{}, "claude", err
-		}
-		return cmd, "claude", nil
+		return buildClaudeSetupPlan(opts, payload)
 	}
+}
+
+// An unknown or empty transport falls back to Claude, which also carries the
+// GLM and Kimi provider identities.
+func buildClaudeSetupPlan(opts Options, payload []byte) (proc.Command, string, error) {
+	cmd, err := buildClaudeSetupExecutorCommandPlan(opts, payload)
+	if err != nil {
+		return proc.Command{}, "claude", err
+	}
+	if err := runner.ConfigureClaudeProvider(&cmd, runner.ClaudeProviderOptions{
+		Provider: opts.Task.Executor.CLI,
+		Credentials: runner.ClaudeCredentials{
+			GLMAuthToken: opts.GLMAuthToken,
+			KimiAPIKey:   opts.KimiAPIKey,
+		},
+	}); err != nil {
+		return proc.Command{}, "claude", err
+	}
+	return cmd, "claude", nil
 }
 
 func buildGrokSetupExecutorCommandPlan(opts Options, payload []byte) (proc.Command, error) {

--- a/internal/preflight/setup/result_parser.go
+++ b/internal/preflight/setup/result_parser.go
@@ -17,65 +17,95 @@ import (
 // from the provider's canonical output surface. Codex emits the final JSON
 // message through `--output-last-message`; Claude streams the JSON through
 // stdout JSONL.
+// ResolveExecutorResult extracts the setup executor's result: Grok from its
+// envelope, Codex from a last-message file, every transport from stdout as well.
 func ResolveExecutorResult(opts Options, stdoutTail string) (*Result, error) {
-	if task.ExecutorTransport(opts.Task) == provider.TransportGrok {
-		data, readErr := os.ReadFile(runartifact.Path(opts.RunDir, runartifact.SetupExecutorStdoutFilename))
-		if readErr != nil {
-			data = []byte(stdoutTail)
+	switch task.ExecutorTransport(opts.Task) {
+	case provider.TransportGrok:
+		return resolveGrokSetupResult(opts, stdoutTail)
+	case provider.TransportCodex:
+		if res, ok := resolveCodexSetupResult(opts); ok {
+			return res, nil
 		}
-		if err := runner.WriteGrokCompletionMetadata(runartifact.Path(opts.RunDir, runartifact.GrokSetupCompletionFilename), data); err != nil {
-			return nil, err
-		}
-		envelope, err := runner.DecodeGrokEnvelope(data)
-		if err != nil {
-			return nil, err
-		}
-		var result Result
-		if err := json.Unmarshal(runner.GrokResultPayload(envelope), &result); err != nil {
-			return nil, fmt.Errorf("decode grok setup result: %w", err)
-		}
-		if result.Status == "" || result.Commands == nil {
-			return nil, fmt.Errorf("invalid grok setup result")
-		}
-		normalizeResult(&result)
-		return &result, nil
-	}
-	if task.ExecutorTransport(opts.Task) == provider.TransportCodex {
-		lastMessagePath := filepath.Join(opts.RunDir, runartifact.SetupCodexDirname, runner.CodexLastMessageFilename)
-		if data, err := os.ReadFile(lastMessagePath); err == nil {
-			if res, ok := parseResultText(string(data)); ok {
-				return res, nil
-			}
-		}
+	case provider.TransportClaude:
 	}
 	if res, ok := parseResultText(stdoutTail); ok {
 		return res, nil
 	}
+	if res, ok := scanStdoutForResult(stdoutTail); ok {
+		return res, nil
+	}
+	return nil, fmt.Errorf("setup executor result JSON not found")
+}
+
+func resolveGrokSetupResult(opts Options, stdoutTail string) (*Result, error) {
+	data, readErr := os.ReadFile(runartifact.Path(opts.RunDir, runartifact.SetupExecutorStdoutFilename))
+	if readErr != nil {
+		data = []byte(stdoutTail)
+	}
+	if err := runner.WriteGrokCompletionMetadata(runartifact.Path(opts.RunDir, runartifact.GrokSetupCompletionFilename), data); err != nil {
+		return nil, err
+	}
+	envelope, err := runner.DecodeGrokEnvelope(data)
+	if err != nil {
+		return nil, err
+	}
+	var result Result
+	if err := json.Unmarshal(runner.GrokResultPayload(envelope), &result); err != nil {
+		return nil, fmt.Errorf("decode grok setup result: %w", err)
+	}
+	if result.Status == "" || result.Commands == nil {
+		return nil, fmt.Errorf("invalid grok setup result")
+	}
+	normalizeResult(&result)
+	return &result, nil
+}
+
+func resolveCodexSetupResult(opts Options) (*Result, bool) {
+	lastMessagePath := filepath.Join(opts.RunDir, runartifact.SetupCodexDirname, runner.CodexLastMessageFilename)
+	data, err := os.ReadFile(lastMessagePath)
+	if err != nil {
+		return nil, false
+	}
+	return parseResultText(string(data))
+}
+
+// scanStdoutForResult reads each captured stdout line as a JSON event and looks
+// for the result payload under the keys the executors use.
+func scanStdoutForResult(stdoutTail string) (*Result, bool) {
 	for _, line := range strings.Split(strings.TrimSpace(stdoutTail), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 		var event map[string]json.RawMessage
-		if err := json.Unmarshal([]byte(line), &event); err == nil {
-			for _, key := range []string{"result", "response", "message"} {
-				raw, ok := event[key]
-				if !ok {
-					continue
-				}
-				var text string
-				if err := json.Unmarshal(raw, &text); err == nil {
-					if res, ok := parseResultText(text); ok {
-						return res, nil
-					}
-				}
-				if res, ok := parseResultRaw(raw); ok {
-					return res, nil
-				}
-			}
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+		if res, ok := resultFromEvent(event); ok {
+			return res, true
 		}
 	}
-	return nil, fmt.Errorf("setup executor result JSON not found")
+	return nil, false
+}
+
+func resultFromEvent(event map[string]json.RawMessage) (*Result, bool) {
+	for _, key := range []string{"result", "response", "message"} {
+		raw, ok := event[key]
+		if !ok {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(raw, &text); err == nil {
+			if res, ok := parseResultText(text); ok {
+				return res, true
+			}
+		}
+		if res, ok := parseResultRaw(raw); ok {
+			return res, true
+		}
+	}
+	return nil, false
 }
 
 func parseResultText(text string) (*Result, bool) {

--- a/internal/preflight/setup/run.go
+++ b/internal/preflight/setup/run.go
@@ -60,10 +60,8 @@ func Run(ctx context.Context, opts Options) (*Result, *EnvironmentUpdate, error)
 		if writeErr := recordSetupProfileUpdateFailure(opts.RunDir, perr); writeErr != nil {
 			perr = errors.Join(perr, writeErr)
 		}
-		if res != nil {
-			markSetupFailed(res, "learned setup plan persistence failed: "+perr.Error(), "Inspect setup_result.json and environment_update.json, fix environment.yaml, and requeue the task.")
-			_ = WriteResult(opts.RunDir, res)
-		}
+		markSetupFailed(res, "learned setup plan persistence failed: "+perr.Error(), "Inspect setup_result.json and environment_update.json, fix environment.yaml, and requeue the task.")
+		_ = WriteResult(opts.RunDir, res)
 		return res, nil, fmt.Errorf("setup phase failed: persist learned setup plan: %w", perr)
 	}
 	if update != nil {
@@ -82,14 +80,14 @@ func RunExecutor(ctx context.Context, opts Options) (*Result, error) {
 	}
 	payload, perr := marshalSetupExecutorRequest(opts, signals)
 	if perr != nil {
-		return setupExecutorFailureResult("plan setup executor request: "+perr.Error(), "", "", 0, "", "", signals), perr
+		return setupExecutorFailureResult(setupExecutorFailure{Message: "plan setup executor request: " + perr.Error(), Provider: "", ExecutorRun: "", ExitCode: 0, Stdout: "", Stderr: "", Inspected: signals}), perr
 	}
 	commandPlan, provider, perr := BuildExecutorCommandPlan(opts, payload)
 	if perr != nil {
-		return setupExecutorFailureResult("plan setup executor command: "+perr.Error(), provider, "", 0, "", "", signals), perr
+		return setupExecutorFailureResult(setupExecutorFailure{Message: "plan setup executor command: " + perr.Error(), Provider: provider, ExecutorRun: "", ExitCode: 0, Stdout: "", Stderr: "", Inspected: signals}), perr
 	}
 	if err := writeSetupExecutorCommandPlan(opts.RunDir, commandPlan); err != nil {
-		return setupExecutorFailureResult("write setup executor command plan: "+err.Error(), provider, "", 0, "", "", signals), err
+		return setupExecutorFailureResult(setupExecutorFailure{Message: "write setup executor command plan: " + err.Error(), Provider: provider, ExecutorRun: "", ExitCode: 0, Stdout: "", Stderr: "", Inspected: signals}), err
 	}
 	out, runErr := RunExecutorCommand(ctx, opts, commandPlan)
 	executorRun := fmt.Sprintf("<setup_executor:%s>", provider)
@@ -99,7 +97,7 @@ func RunExecutor(ctx context.Context, opts Options) (*Result, error) {
 		if runErr != nil {
 			message = fmt.Sprintf("setup executor exited %d: %s", out.ExitCode, truncateExcerpt(out.Stderr))
 		}
-		failure := setupExecutorFailureResult(message, provider, executorRun, out.ExitCode, out.Stdout, out.Stderr, signals)
+		failure := setupExecutorFailureResult(setupExecutorFailure{Message: message, Provider: provider, ExecutorRun: executorRun, ExitCode: out.ExitCode, Stdout: out.Stdout, Stderr: out.Stderr, Inspected: signals})
 		return failure, errors.Join(fmt.Errorf("setup executor failed: %w", parseErr), runErr)
 	}
 	parsed.Provider = provider

--- a/internal/preflight/setup/util.go
+++ b/internal/preflight/setup/util.go
@@ -118,14 +118,16 @@ func DiscoverRepositorySignals(workDir string) []string {
 			out = append(out, name)
 		}
 	}
-	if scripts, err := os.ReadDir(filepath.Join(workDir, "scripts")); err == nil {
-		for _, entry := range scripts {
-			if len(out) >= maxResultFiles {
-				break
-			}
-			if !entry.IsDir() {
-				out = append(out, filepath.Join("scripts", entry.Name()))
-			}
+	scripts, err := os.ReadDir(filepath.Join(workDir, "scripts"))
+	if err != nil {
+		return out
+	}
+	for _, entry := range scripts {
+		if len(out) >= maxResultFiles {
+			break
+		}
+		if !entry.IsDir() {
+			out = append(out, filepath.Join("scripts", entry.Name()))
 		}
 	}
 	return out

--- a/internal/preflight/skeleton/creator.go
+++ b/internal/preflight/skeleton/creator.go
@@ -191,25 +191,7 @@ func runBuiltinCreatorCommand(ctx context.Context, opts Options, commandPlan pro
 // the manifest directly on stdout.
 func resolveCreatorManifest(opts Options, stdoutTail, stdoutPath string) (creatorManifest, error) {
 	if task.ExecutorTransport(opts.Task) == provider.TransportGrok {
-		data, readErr := os.ReadFile(stdoutPath)
-		if readErr != nil {
-			data = []byte(stdoutTail)
-		}
-		if err := runner.WriteGrokCompletionMetadata(filepath.Join(opts.RunDir, runartifact.GrokSkeletonCompletionFilename), data); err != nil {
-			return creatorManifest{}, err
-		}
-		envelope, err := runner.DecodeGrokEnvelope(data)
-		if err != nil {
-			return creatorManifest{}, err
-		}
-		var manifest creatorManifest
-		if err := json.Unmarshal(runner.GrokResultPayload(envelope), &manifest); err != nil {
-			return creatorManifest{}, fmt.Errorf("decode grok creator manifest: %w", err)
-		}
-		if manifest.Outputs == nil || manifest.NoSkeletons == nil {
-			return creatorManifest{}, fmt.Errorf("invalid grok creator manifest: outputs and no_skeletons are required")
-		}
-		return manifest, nil
+		return resolveGrokCreatorManifest(opts, stdoutTail, stdoutPath)
 	}
 	if task.ExecutorTransport(opts.Task) == provider.TransportCodex {
 		lastMessagePath := filepath.Join(opts.RunDir, runner.CodexLastMessageFilename)
@@ -286,6 +268,7 @@ func parseCreatorManifestLine(line string) (creatorManifest, bool, error) {
 	}
 	var event map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		//nolint:nilerr // a non-JSON line simply is not a manifest
 		return creatorManifest{}, false, nil
 	}
 	for _, key := range []string{"result", "response", "message"} {
@@ -324,4 +307,26 @@ func parseCreatorManifestRaw(data []byte) (creatorManifest, bool) {
 		return creatorManifest{}, false
 	}
 	return manifest, true
+}
+
+func resolveGrokCreatorManifest(opts Options, stdoutTail, stdoutPath string) (creatorManifest, error) {
+	data, readErr := os.ReadFile(stdoutPath)
+	if readErr != nil {
+		data = []byte(stdoutTail)
+	}
+	if err := runner.WriteGrokCompletionMetadata(filepath.Join(opts.RunDir, runartifact.GrokSkeletonCompletionFilename), data); err != nil {
+		return creatorManifest{}, err
+	}
+	envelope, err := runner.DecodeGrokEnvelope(data)
+	if err != nil {
+		return creatorManifest{}, err
+	}
+	var manifest creatorManifest
+	if err := json.Unmarshal(runner.GrokResultPayload(envelope), &manifest); err != nil {
+		return creatorManifest{}, fmt.Errorf("decode grok creator manifest: %w", err)
+	}
+	if manifest.Outputs == nil || manifest.NoSkeletons == nil {
+		return creatorManifest{}, fmt.Errorf("invalid grok creator manifest: outputs and no_skeletons are required")
+	}
+	return manifest, nil
 }

--- a/internal/preflight/skeleton/prompt.go
+++ b/internal/preflight/skeleton/prompt.go
@@ -12,7 +12,7 @@ func AppendObligations(prompt string, res *Result) string {
 	var b strings.Builder
 	b.WriteString("\n## Acceptance Skeleton Obligations (Runtime)\n\n")
 	if res.Status == "failed" {
-		b.WriteString(fmt.Sprintf("Acceptance skeleton preflight failed (%s); see preflight_result.json for details.\n", failureMessage(res)))
+		fmt.Fprintf(&b, "Acceptance skeleton preflight failed (%s); see preflight_result.json for details.\n", failureMessage(res))
 		return prompt + b.String()
 	}
 	if len(res.Outputs) == 0 {
@@ -21,13 +21,13 @@ func AppendObligations(prompt string, res *Result) string {
 	}
 	b.WriteString("Galley pre-created the following AC-linked test skeletons in the worktree before this attempt. Read each skeleton, complete the implementation it verifies, and keep the assertions meaningful. Do not delete skeleton files, leave placeholder assertions, skip the tests, or weaken their assertions.\n\n")
 	for _, out := range res.Outputs {
-		b.WriteString(fmt.Sprintf("- AC `%s` -> `%s` (kind=%s, implementation_required=%t)\n", out.ACID, out.Path, out.Kind, out.ImplementationRequired))
-		b.WriteString(fmt.Sprintf("  Purpose: %s\n", out.Purpose))
+		fmt.Fprintf(&b, "- AC `%s` -> `%s` (kind=%s, implementation_required=%t)\n", out.ACID, out.Path, out.Kind, out.ImplementationRequired)
+		fmt.Fprintf(&b, "  Purpose: %s\n", out.Purpose)
 		if out.Satisfies != "" {
-			b.WriteString(fmt.Sprintf("  Satisfies: %s\n", out.Satisfies))
+			fmt.Fprintf(&b, "  Satisfies: %s\n", out.Satisfies)
 		}
 		if out.IntegrationPoint != "" {
-			b.WriteString(fmt.Sprintf("  Integration point: %s\n", out.IntegrationPoint))
+			fmt.Fprintf(&b, "  Integration point: %s\n", out.IntegrationPoint)
 		}
 	}
 	b.WriteString("\nCompletion obligations: every implementation_required skeleton above must be implemented and covered by the normal required verification checks before the supervisor accepts the attempt.\n")

--- a/internal/preflight/skeleton/snapshot.go
+++ b/internal/preflight/skeleton/snapshot.go
@@ -144,12 +144,14 @@ func HashesMatchBaseline(workDir string, baseline Baseline) (bool, error) {
 	for _, h := range baseline.SkeletonHashes {
 		fullPath := filepath.Join(workDir, h.Path)
 		if err := ensureRealPathInsideWorktree(workDir, fullPath); err != nil {
+			//nolint:nilerr // a path outside the worktree counts as changed baseline
 			return false, nil
 		}
 		data, err := os.ReadFile(fullPath)
 		if err != nil {
 			// A missing skeleton means the executor altered baseline state;
 			// treat that as progress so the no-diff invariant cannot trigger.
+			//nolint:nilerr // a missing skeleton counts as changed baseline
 			return false, nil
 		}
 		sum := sha256.Sum256(data)

--- a/internal/preflight/skeleton/snapshot_test.go
+++ b/internal/preflight/skeleton/snapshot_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSnapshotPreflightFilesExcludesGitMetadata(t *testing.T) {
 	root := t.TempDir()
-	if err := exec.Command("git", "init", root).Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), "git", "init", root).Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "src.go"), []byte("package src"), 0o600); err != nil {
@@ -37,7 +37,7 @@ func TestSnapshotPreflightFilesUsesConfiguredGitBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 	root := t.TempDir()
-	if err := exec.Command(gitBin, "init", root).Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), gitBin, "init", root).Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "source.ts"), []byte("source"), 0o600); err != nil {
@@ -56,7 +56,7 @@ func TestSnapshotPreflightFilesUsesConfiguredGitBinary(t *testing.T) {
 
 func TestSnapshotPreflightFilesExcludesGitIgnoredCaches(t *testing.T) {
 	root := t.TempDir()
-	if err := exec.Command("git", "init", root).Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), "git", "init", root).Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n"), 0o600); err != nil {
@@ -85,14 +85,14 @@ func TestSnapshotPreflightFilesExcludesGitIgnoredCaches(t *testing.T) {
 
 func TestSnapshotPreflightFilesIncludesTrackedAndNonIgnoredUntrackedFiles(t *testing.T) {
 	root := t.TempDir()
-	if err := exec.Command("git", "init", root).Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), "git", "init", root).Run(); err != nil {
 		t.Fatal(err)
 	}
 	tracked := filepath.Join(root, "tracked.txt")
 	if err := os.WriteFile(tracked, []byte("tracked"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := exec.Command("git", "-C", root, "add", "tracked.txt").Run(); err != nil {
+	if err := exec.CommandContext(t.Context(), "git", "-C", root, "add", "tracked.txt").Run(); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "new.txt"), []byte("new"), 0o600); err != nil {

--- a/internal/preflight/skeleton/validation.go
+++ b/internal/preflight/skeleton/validation.go
@@ -35,7 +35,7 @@ func (r acceptanceSkeletonPreflightRun) validateNoSkeletonDeclarations(declarati
 				message: fmt.Sprintf("no_skeletons entry %d for ac_id %q must have a reason", i, ns.ACID),
 			}
 		}
-		noSkeletons = append(noSkeletons, NoOutput{ACID: ns.ACID, Reason: ns.Reason})
+		noSkeletons = append(noSkeletons, NoOutput(ns))
 	}
 	return noSkeletons, nil
 }

--- a/internal/proc/env_test.go
+++ b/internal/proc/env_test.go
@@ -96,7 +96,7 @@ func envHelperCommand(t *testing.T, keys ...string) Command {
 	return Command{Argv: argv}
 }
 
-func TestGalleyEnvHelperProcess(t *testing.T) {
+func TestGalleyEnvHelperProcess(_ *testing.T) {
 	if os.Getenv("GO_WANT_GALLEY_ENV_HELPER") != "1" {
 		return
 	}

--- a/internal/proc/execute.go
+++ b/internal/proc/execute.go
@@ -128,11 +128,7 @@ func envNameMatches(kv string, names []string) bool {
 		name = kv[:i]
 	}
 	for _, n := range names {
-		if runtime.GOOS == "windows" {
-			if strings.EqualFold(name, n) {
-				return true
-			}
-		} else if name == n {
+		if envNameEqual(name, n) {
 			return true
 		}
 	}
@@ -153,41 +149,19 @@ func RunCommand(ctx context.Context, command Command, opts RunOptions) (RunResul
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(runCtx, command.Argv[0], command.Argv[1:]...)
-	// The cancellation branch below owns tree termination. CommandContext's
-	// default parent-only kill can orphan children before taskkill finds them.
-	cmd.Cancel = nil
-	cmd.SysProcAttr = processGroupAttr()
-	if command.WorkDir != "" {
-		cmd.Dir = command.WorkDir
-	}
-	if len(command.EnvAppend) > 0 || len(command.EnvRemove) > 0 {
-		cmd.Env = childEnv(command.EnvRemove, command.EnvAppend)
-	}
-	if command.Stdin != "" {
-		cmd.Stdin = strings.NewReader(command.Stdin)
-	}
+	cmd := buildExecCmd(runCtx, command)
 
-	tailBytes := opts.TailBytes
-	if tailBytes == 0 {
-		tailBytes = defaultTailBytes
-	}
-	stdout := newTailBuffer(tailBytes)
-	stderr := newTailBuffer(tailBytes)
-	stdoutWriter, stdoutFile, err := captureWriter(stdout, opts.StdoutPath)
+	sinks, err := newCaptureSinks(opts)
 	if err != nil {
 		return RunResult{}, err
 	}
-	stderrWriter, stderrFile, err := captureWriter(stderr, opts.StderrPath)
-	if err != nil {
-		_ = stdoutFile.Close()
-		return RunResult{}, err
-	}
+	stdout, stderr := sinks.stdout, sinks.stderr
+	stdoutFile, stderrFile := sinks.stdoutFile, sinks.stderrFile
 
 	var lastActivity atomic.Int64
 	lastActivity.Store(time.Now().UnixNano())
-	cmd.Stdout = &activityWriter{w: stdoutWriter, last: &lastActivity}
-	cmd.Stderr = &activityWriter{w: stderrWriter, last: &lastActivity}
+	cmd.Stdout = &activityWriter{w: sinks.stdoutWriter, last: &lastActivity}
+	cmd.Stderr = &activityWriter{w: sinks.stderrWriter, last: &lastActivity}
 
 	if err := cmd.Start(); err != nil {
 		_ = stdoutFile.Close()
@@ -199,26 +173,7 @@ func RunCommand(ctx context.Context, command Command, opts RunOptions) (RunResul
 	// --force can SIGKILL it if the daemon itself is being torn down.
 	// Registration is best-effort: unregister always runs when Wait returns so
 	// transient registry write errors cannot leak entries.
-	registry := DefaultChildRegistry()
-	if scoped, ok := ctx.Value(childRegistryContextKey{}).(*ChildRegistry); ok {
-		registry = scoped
-	}
-	if registry != nil && cmd.Process != nil {
-		pgid := cmd.Process.Pid
-		if reportedPGID, perr := processGroupID(cmd); perr == nil && reportedPGID > 0 {
-			pgid = reportedPGID
-		}
-		_ = registry.Register(ChildRecord{
-			PID:     cmd.Process.Pid,
-			PGID:    pgid,
-			Argv0:   command.Argv[0],
-			WorkDir: command.WorkDir,
-		})
-	}
-	registeredPID := 0
-	if cmd.Process != nil {
-		registeredPID = cmd.Process.Pid
-	}
+	registry, registeredPID := registerChildProcess(ctx, cmd, command)
 
 	done := make(chan error, 1)
 	go func() {
@@ -228,29 +183,7 @@ func RunCommand(ctx context.Context, command Command, opts RunOptions) (RunResul
 	var idleTimedOut atomic.Bool
 	watchdogStop := make(chan struct{})
 	if opts.IdleTimeout > 0 {
-		go func() {
-			interval := opts.IdleTimeout / 4
-			if interval < minIdleCheckInterval {
-				interval = minIdleCheckInterval
-			}
-			if interval > maxIdleCheckInterval {
-				interval = maxIdleCheckInterval
-			}
-			ticker := time.NewTicker(interval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-watchdogStop:
-					return
-				case now := <-ticker.C:
-					if now.Sub(time.Unix(0, lastActivity.Load())) >= opts.IdleTimeout {
-						idleTimedOut.Store(true)
-						killProcessGroup(cmd)
-						return
-					}
-				}
-			}
-		}()
+		go watchIdleOutput(idleWatch{Cmd: cmd, Timeout: opts.IdleTimeout, LastActivity: &lastActivity, TimedOut: &idleTimedOut, Stop: watchdogStop})
 	}
 
 	var runErr error
@@ -281,26 +214,26 @@ func RunCommand(ctx context.Context, command Command, opts RunOptions) (RunResul
 	if cmd.ProcessState != nil {
 		result.ExitCode = cmd.ProcessState.ExitCode()
 	}
-	var closeErr error
-	if !waitTimedOut {
-		closeErr = errors.Join(stdoutFile.Close(), stderrFile.Close())
+	release := func() error {
+		err := errors.Join(stdoutFile.Close(), stderrFile.Close())
 		if registry != nil && registeredPID > 0 {
 			_ = registry.Unregister(registeredPID)
 		}
-	} else {
+		return err
+	}
+	var closeErr error
+	if waitTimedOut {
 		// cmd.Wait owns the stdout/stderr copy goroutines. Closing the capture
 		// files before it returns can race with those writers, so final close is
 		// deferred to a goroutine. If the OS never reaps the process, this leaks
-		// until the daemon exits; at that point returning is preferable to blocking
-		// all task processing indefinitely.
+		// until the daemon exits; at that point returning is preferable to
+		// blocking all task processing indefinitely.
 		go func() {
 			<-done
-			_ = stdoutFile.Close()
-			_ = stderrFile.Close()
-			if registry != nil && registeredPID > 0 {
-				_ = registry.Unregister(registeredPID)
-			}
+			_ = release()
 		}()
+	} else {
+		closeErr = release()
 	}
 	if result.IdleTimedOut {
 		return result, errors.Join(&CommandError{
@@ -346,6 +279,7 @@ func (a *activityWriter) Write(p []byte) (int, error) {
 	if n > 0 {
 		a.last.Store(time.Now().UnixNano())
 	}
+	//nolint:wrapcheck // io.Writer contract: the underlying error passes through
 	return n, err
 }
 
@@ -392,4 +326,120 @@ func (b *tailBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return string(append([]byte(nil), b.data...))
+}
+
+// buildExecCmd prepares the child. RunCommand owns tree termination, so
+// CommandContext's parent-only kill is disabled to avoid orphaning children.
+func buildExecCmd(runCtx context.Context, command Command) *exec.Cmd {
+	cmd := exec.CommandContext(runCtx, command.Argv[0], command.Argv[1:]...)
+	cmd.Cancel = nil
+	cmd.SysProcAttr = processGroupAttr()
+	if command.WorkDir != "" {
+		cmd.Dir = command.WorkDir
+	}
+	if len(command.EnvAppend) > 0 || len(command.EnvRemove) > 0 {
+		cmd.Env = childEnv(command.EnvRemove, command.EnvAppend)
+	}
+	if command.Stdin != "" {
+		cmd.Stdin = strings.NewReader(command.Stdin)
+	}
+	return cmd
+}
+
+// captureSinks are the in-memory tails and optional evidence files a command's
+// stdout and stderr are copied to.
+type captureSinks struct {
+	stdout       *tailBuffer
+	stderr       *tailBuffer
+	stdoutWriter io.Writer
+	stderrWriter io.Writer
+	stdoutFile   io.Closer
+	stderrFile   io.Closer
+}
+
+func newCaptureSinks(opts RunOptions) (captureSinks, error) {
+	tailBytes := opts.TailBytes
+	if tailBytes == 0 {
+		tailBytes = defaultTailBytes
+	}
+	sinks := captureSinks{stdout: newTailBuffer(tailBytes), stderr: newTailBuffer(tailBytes)}
+	stdoutWriter, stdoutFile, err := captureWriter(sinks.stdout, opts.StdoutPath)
+	if err != nil {
+		return captureSinks{}, err
+	}
+	stderrWriter, stderrFile, err := captureWriter(sinks.stderr, opts.StderrPath)
+	if err != nil {
+		_ = stdoutFile.Close()
+		return captureSinks{}, err
+	}
+	sinks.stdoutWriter, sinks.stdoutFile = stdoutWriter, stdoutFile
+	sinks.stderrWriter, sinks.stderrFile = stderrWriter, stderrFile
+	return sinks, nil
+}
+
+// registerChildProcess tracks the child process group so `daemon stop --force`
+// can reach it. It is best-effort: unregister always runs when Wait returns.
+func registerChildProcess(ctx context.Context, cmd *exec.Cmd, command Command) (*ChildRegistry, int) {
+	registry := DefaultChildRegistry()
+	if scoped, ok := ctx.Value(childRegistryContextKey{}).(*ChildRegistry); ok {
+		registry = scoped
+	}
+	if cmd.Process == nil {
+		return registry, 0
+	}
+	if registry != nil {
+		pgid := cmd.Process.Pid
+		if reportedPGID, err := processGroupID(cmd); err == nil && reportedPGID > 0 {
+			pgid = reportedPGID
+		}
+		_ = registry.Register(ChildRecord{
+			PID:     cmd.Process.Pid,
+			PGID:    pgid,
+			Argv0:   command.Argv[0],
+			WorkDir: command.WorkDir,
+		})
+	}
+	return registry, cmd.Process.Pid
+}
+
+// idleWatch is one command's idle-output watchdog.
+type idleWatch struct {
+	Cmd          *exec.Cmd
+	Timeout      time.Duration
+	LastActivity *atomic.Int64
+	TimedOut     *atomic.Bool
+	Stop         <-chan struct{}
+}
+
+func watchIdleOutput(w idleWatch) {
+	interval := w.Timeout / 4
+	if interval < minIdleCheckInterval {
+		interval = minIdleCheckInterval
+	}
+	if interval > maxIdleCheckInterval {
+		interval = maxIdleCheckInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.Stop:
+			return
+		case now := <-ticker.C:
+			if now.Sub(time.Unix(0, w.LastActivity.Load())) >= w.Timeout {
+				w.TimedOut.Store(true)
+				killProcessGroup(w.Cmd)
+				return
+			}
+		}
+	}
+}
+
+// envNameEqual compares environment variable names using the platform's
+// case rule: Windows environment names are case-insensitive.
+func envNameEqual(name, want string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(name, want)
+	}
+	return name == want
 }

--- a/internal/proc/git_test.go
+++ b/internal/proc/git_test.go
@@ -1,6 +1,7 @@
 package proc
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -99,40 +100,21 @@ func TestProductionGitInvocationsUseGitArgs(t *testing.T) {
 			return walkErr
 		}
 		if entry.IsDir() {
-			switch entry.Name() {
-			case ".git", ".claude", "node_modules", "vendor":
-				return filepath.SkipDir
-			}
-			return nil
+			return skipVendoredDir(entry)
 		}
 		rel, err := filepath.Rel(repoRoot, path)
 		if err != nil {
-			return err
+			return fmt.Errorf("relativize %s: %w", path, err)
 		}
 		rel = filepath.ToSlash(rel)
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		if rel == "internal/proc/git.go" {
+		if !isScannedProductionGoFile(path, rel) {
 			return nil
 		}
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse %s: %w", path, err)
 		}
-		ast.Inspect(file, func(node ast.Node) bool {
-			switch n := node.(type) {
-			case *ast.CallExpr:
-				if gitExecArgIndex(n) >= 0 {
-					violations = append(violations, rel+":"+fset.Position(n.Pos()).String())
-				}
-			case *ast.CompositeLit:
-				if stringSliceStartsWithGit(n) {
-					violations = append(violations, rel+":"+fset.Position(n.Pos()).String())
-				}
-			}
-			return true
-		})
+		violations = append(violations, gitArgvViolations(fset, file, rel)...)
 		return nil
 	})
 	if err != nil {
@@ -194,4 +176,40 @@ func isGitExpr(expr ast.Expr) bool {
 	default:
 		return false
 	}
+}
+
+func skipVendoredDir(entry os.DirEntry) error {
+	switch entry.Name() {
+	case ".git", ".claude", "node_modules", "vendor":
+		return filepath.SkipDir
+	}
+	return nil
+}
+
+// isScannedProductionGoFile excludes tests and proc/git.go itself, which owns
+// the sanctioned git argv construction.
+func isScannedProductionGoFile(path, rel string) bool {
+	if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		return false
+	}
+	return rel != "internal/proc/git.go"
+}
+
+// gitArgvViolations reports every direct git invocation that bypasses GitArgs.
+func gitArgvViolations(fset *token.FileSet, file *ast.File, rel string) []string {
+	var violations []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.CallExpr:
+			if gitExecArgIndex(n) >= 0 {
+				violations = append(violations, rel+":"+fset.Position(n.Pos()).String())
+			}
+		case *ast.CompositeLit:
+			if stringSliceStartsWithGit(n) {
+				violations = append(violations, rel+":"+fset.Position(n.Pos()).String())
+			}
+		}
+		return true
+	})
+	return violations
 }

--- a/internal/proc/process_unix.go
+++ b/internal/proc/process_unix.go
@@ -3,6 +3,7 @@
 package proc
 
 import (
+	"fmt"
 	"os/exec"
 	"syscall"
 )
@@ -30,5 +31,9 @@ func processGroupID(cmd *exec.Cmd) (int, error) {
 	if cmd.Process == nil {
 		return 0, syscall.ESRCH
 	}
-	return syscall.Getpgid(cmd.Process.Pid)
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		return 0, fmt.Errorf("get process group for pid %d: %w", cmd.Process.Pid, err)
+	}
+	return pgid, nil
 }

--- a/internal/proc/process_windows.go
+++ b/internal/proc/process_windows.go
@@ -21,6 +21,7 @@ func killProcessGroup(cmd *exec.Cmd) {
 	// so an idle/timeout/cancel does not leave orphaned children holding worktree
 	// locks. If taskkill cannot terminate the tree, fall back to killing the
 	// direct child so the call never becomes a no-op.
+	//nolint:noctx // termination runs after the command's context is already cancelled
 	if err := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid)).Run(); err != nil {
 		_ = cmd.Process.Kill()
 	}

--- a/internal/proc/registry.go
+++ b/internal/proc/registry.go
@@ -106,7 +106,7 @@ func (r *ChildRegistry) load() ([]ChildRecord, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("read child registry %s: %w", r.path, err)
 	}
 	if len(data) == 0 {
 		return nil, nil
@@ -243,7 +243,7 @@ func (r *ChildRegistry) Clear() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err := os.Remove(r.path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+		return fmt.Errorf("remove child registry %s: %w", r.path, err)
 	}
 	return nil
 }

--- a/internal/proc/vcs_test.go
+++ b/internal/proc/vcs_test.go
@@ -18,39 +18,46 @@ func TestVCSCommandDeadlineKeepsFailureEvidence(t *testing.T) {
 			name = "cancellation"
 		}
 		t.Run(name, func(t *testing.T) {
-			dir := t.TempDir()
-			body := "#!/bin/sh\necho waiting-for-remote >&2\nsleep 30\n"
-			if runtime.GOOS == "windows" {
-				body = "@echo off\r\necho waiting-for-remote 1>&2\r\nping -n 30 127.0.0.1 >nul\r\n"
-			}
-			script := writeScript(t, dir, "blocked-git", body)
-			stderr := filepath.Join(dir, "git.stderr.log")
-			ctx, cancel := context.WithCancel(t.Context())
-			defer cancel()
-			timeout := 200 * time.Millisecond
-			wantErr := ErrTimeout
-			if canceled {
-				timeout = 30 * time.Second
-				wantErr = ErrKilled
-				timer := time.AfterFunc(200*time.Millisecond, cancel)
-				defer timer.Stop()
-			}
-			result, err := runVCSCommand(ctx, Command{WorkDir: dir, Argv: scriptArgv(script)}, RunOptions{StderrPath: stderr}, timeout)
-			if !errors.Is(err, wantErr) || result.TimedOut == canceled {
-				t.Fatalf("not bounded: %#v %v", result, err)
-			}
-			if result.Duration >= processCancelWaitLimit {
-				t.Fatalf("child retained output pipes after cancellation: %s", result.Duration)
-			}
-			if !strings.Contains(err.Error(), "waiting-for-remote") {
-				t.Fatalf("failure lost stderr: %v", err)
-			}
-			if data, err := os.ReadFile(stderr); err != nil || !strings.Contains(string(data), "waiting-for-remote") {
-				t.Fatalf("lost capture %q: %v", data, err)
-			}
-			if err := os.Remove(stderr); err != nil {
-				t.Fatalf("capture still open after command returned: %v", err)
-			}
+			assertBoundedVCSFailureKeepsEvidence(t, canceled)
 		})
+	}
+}
+
+// assertBoundedVCSFailureKeepsEvidence pins that a blocked VCS command is bounded
+// by deadline or cancellation and keeps stderr in the error and evidence file.
+func assertBoundedVCSFailureKeepsEvidence(t *testing.T, canceled bool) {
+	t.Helper()
+	dir := t.TempDir()
+	body := "#!/bin/sh\necho waiting-for-remote >&2\nsleep 30\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho waiting-for-remote 1>&2\r\nping -n 30 127.0.0.1 >nul\r\n"
+	}
+	script := writeScript(t, dir, "blocked-git", body)
+	stderr := filepath.Join(dir, "git.stderr.log")
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	timeout := 200 * time.Millisecond
+	wantErr := ErrTimeout
+	if canceled {
+		timeout = 30 * time.Second
+		wantErr = ErrKilled
+		timer := time.AfterFunc(200*time.Millisecond, cancel)
+		defer timer.Stop()
+	}
+	result, err := runVCSCommand(ctx, Command{WorkDir: dir, Argv: scriptArgv(script)}, RunOptions{StderrPath: stderr}, timeout)
+	if !errors.Is(err, wantErr) || result.TimedOut == canceled {
+		t.Fatalf("not bounded: %#v %v", result, err)
+	}
+	if result.Duration >= processCancelWaitLimit {
+		t.Fatalf("child retained output pipes after cancellation: %s", result.Duration)
+	}
+	if !strings.Contains(err.Error(), "waiting-for-remote") {
+		t.Fatalf("failure lost stderr: %v", err)
+	}
+	if data, readErr := os.ReadFile(stderr); readErr != nil || !strings.Contains(string(data), "waiting-for-remote") {
+		t.Fatalf("lost capture %q: %v", data, readErr)
+	}
+	if err := os.Remove(stderr); err != nil {
+		t.Fatalf("capture still open after command returned: %v", err)
 	}
 }

--- a/internal/profile/executor_defaults_test.go
+++ b/internal/profile/executor_defaults_test.go
@@ -95,30 +95,9 @@ func TestEnvironmentExecutorDefaultCLIRuntimeAndSchemaParity(t *testing.T) {
 	}
 	executor := schema["properties"].(map[string]any)["executor"].(map[string]any)
 	execProps := executor["properties"].(map[string]any)
-	cliEnum := enumStrings(execProps["default_cli"].(map[string]any)["enum"].([]any))
-	if !containsString(cliEnum, "") {
-		t.Fatalf("executor.default_cli schema must accept empty string, got %#v", cliEnum)
-	}
-	for _, id := range provider.ExecutorIDs() {
-		if !containsString(cliEnum, id) {
-			t.Fatalf("executor.default_cli schema missing %q in %#v", id, cliEnum)
-		}
-	}
-
-	baseEnv := func() Environment {
-		return Environment{
-			ID:  "local",
-			CWD: "/tmp/repo",
-			Constraints: Constraints{
-				Network:             "approval_required",
-				SecretsPolicy:       "never_read_env_files",
-				DestructiveCommands: "deny",
-			},
-		}
-	}
+	assertDefaultCLIEnumCoversProviders(t, enumStrings(execProps["default_cli"].(map[string]any)["enum"].([]any)))
 
 	for _, tc := range executorDefaultCLIMatrix {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			doc := map[string]any{}
@@ -126,18 +105,7 @@ func TestEnvironmentExecutorDefaultCLIRuntimeAndSchemaParity(t *testing.T) {
 				doc["default_cli"] = tc.value
 			}
 			schemaValid := len(validateExecutorDefaultCLIDoc(executor, doc)) == 0
-
-			env := baseEnv()
-			if tc.set {
-				env.Executor = &ExecutorDefault{DefaultCLI: tc.value}
-			}
-			runtimeValid := true
-			for _, e := range ValidateEnvironment(env).Errors {
-				if strings.Contains(e, "executor.default_cli") {
-					runtimeValid = false
-					break
-				}
-			}
+			runtimeValid := runtimeAcceptsDefaultCLI(tc.set, tc.value)
 
 			if schemaValid != runtimeValid {
 				t.Fatalf("drift for %v: schema valid=%v runtime valid=%v schema_errs=%v",
@@ -148,6 +116,43 @@ func TestEnvironmentExecutorDefaultCLIRuntimeAndSchemaParity(t *testing.T) {
 			}
 		})
 	}
+}
+
+// assertDefaultCLIEnumCoversProviders pins that the schema enum accepts every
+// executor provider plus the empty string (default_cli omitted).
+func assertDefaultCLIEnumCoversProviders(t *testing.T, cliEnum []string) {
+	t.Helper()
+	if !containsString(cliEnum, "") {
+		t.Fatalf("executor.default_cli schema must accept empty string, got %#v", cliEnum)
+	}
+	for _, id := range provider.ExecutorIDs() {
+		if !containsString(cliEnum, id) {
+			t.Fatalf("executor.default_cli schema missing %q in %#v", id, cliEnum)
+		}
+	}
+}
+
+// runtimeAcceptsDefaultCLI reports whether ValidateEnvironment accepts the
+// value, ignoring errors from unrelated fields.
+func runtimeAcceptsDefaultCLI(set bool, value string) bool {
+	env := Environment{
+		ID:  "local",
+		CWD: "/tmp/repo",
+		Constraints: Constraints{
+			Network:             "approval_required",
+			SecretsPolicy:       "never_read_env_files",
+			DestructiveCommands: "deny",
+		},
+	}
+	if set {
+		env.Executor = &ExecutorDefault{DefaultCLI: value}
+	}
+	for _, e := range ValidateEnvironment(env).Errors {
+		if strings.Contains(e, "executor.default_cli") {
+			return false
+		}
+	}
+	return true
 }
 
 func validateExecutorDefaultCLIDoc(executor, doc map[string]any) []string {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -166,27 +166,44 @@ func LoadEnvironment(path string) (Environment, error) {
 
 func LoadBundle(qualityPath, environmentPath string) (Bundle, error) {
 	var bundle Bundle
-	if qualityPath != "" {
-		quality, err := LoadQuality(qualityPath)
-		if err != nil {
-			return Bundle{}, err
-		}
-		if result := ValidateQuality(quality); !result.Valid() {
-			return Bundle{}, fmt.Errorf("invalid quality profile %s: %s", qualityPath, strings.Join(result.Errors, "; "))
-		}
-		bundle.Quality = &quality
+	quality, err := loadValidQuality(qualityPath)
+	if err != nil {
+		return Bundle{}, err
 	}
-	if environmentPath != "" {
-		env, err := LoadEnvironment(environmentPath)
-		if err != nil {
-			return Bundle{}, err
-		}
-		if result := ValidateEnvironment(env); !result.Valid() {
-			return Bundle{}, fmt.Errorf("invalid environment profile %s: %s", environmentPath, strings.Join(result.Errors, "; "))
-		}
-		bundle.Environment = &env
+	env, err := loadValidEnvironment(environmentPath)
+	if err != nil {
+		return Bundle{}, err
 	}
+	bundle.Quality, bundle.Environment = quality, env
 	return bundle, nil
+}
+
+func loadValidQuality(path string) (*Quality, error) {
+	if path == "" {
+		return nil, nil
+	}
+	quality, err := LoadQuality(path)
+	if err != nil {
+		return nil, err
+	}
+	if result := ValidateQuality(quality); !result.Valid() {
+		return nil, fmt.Errorf("invalid quality profile %s: %s", path, strings.Join(result.Errors, "; "))
+	}
+	return &quality, nil
+}
+
+func loadValidEnvironment(path string) (*Environment, error) {
+	if path == "" {
+		return nil, nil
+	}
+	env, err := LoadEnvironment(path)
+	if err != nil {
+		return nil, err
+	}
+	if result := ValidateEnvironment(env); !result.Valid() {
+		return nil, fmt.Errorf("invalid environment profile %s: %s", path, strings.Join(result.Errors, "; "))
+	}
+	return &env, nil
 }
 
 func ValidateQuality(q Quality) ValidationResult {
@@ -234,69 +251,94 @@ func ValidateEnvironment(env Environment) ValidationResult {
 	require(&result, env.Constraints.Network != "", "constraints.network is required")
 	require(&result, env.Constraints.SecretsPolicy != "", "constraints.secrets_policy is required")
 	require(&result, env.Constraints.DestructiveCommands != "", "constraints.destructive_commands is required")
-	if env.Executor != nil && env.Executor.DefaultCLI != "" {
-		require(&result, validExecutorCLI(env.Executor.DefaultCLI), "executor.default_cli must be one of: %s", strings.Join(provider.ExecutorIDs(), ", "))
-	}
-	if env.Executor != nil && env.Executor.Effort != "" {
-		if env.Executor.DefaultCLI != "" {
-			if efforts, ok := provider.EffortsForID(env.Executor.DefaultCLI); ok {
-				require(&result, slices.Contains(efforts, env.Executor.Effort), "executor.effort for %s must be one of: %s", env.Executor.DefaultCLI, strings.Join(efforts, ", "))
-			}
-		} else {
-			require(&result, slices.Contains(provider.ExecutorEfforts(), env.Executor.Effort), "executor.effort must be one of: %s", strings.Join(provider.ExecutorEfforts(), ", "))
-		}
-	}
-	if env.Supervisor != nil && env.Supervisor.DefaultCLI != "" {
-		require(&result, provider.IsSupervisor(env.Supervisor.DefaultCLI), "supervisor.default_cli must be one of: %s", strings.Join(provider.SupervisorIDs(), ", "))
-	}
-	if env.Supervisor != nil && env.Supervisor.Effort != "" {
-		// Without default_cli, profile validation can enforce only the provider union; preflight narrows it later.
-		if env.Supervisor.DefaultCLI != "" {
-			if efforts, ok := provider.EffortsForID(env.Supervisor.DefaultCLI); ok {
-				require(&result, slices.Contains(efforts, env.Supervisor.Effort), "supervisor.effort for %s must be one of: %s", env.Supervisor.DefaultCLI, strings.Join(efforts, ", "))
-			}
-		} else {
-			require(&result, slices.Contains(provider.SupervisorEfforts(), env.Supervisor.Effort), "supervisor.effort must be one of: %s", strings.Join(provider.SupervisorEfforts(), ", "))
-		}
-	}
-	if env.RequiredChecks.Shell != "" {
-		require(&result, validRequiredCheckShell(env.RequiredChecks.Shell), "required_checks.shell must be one of: auto, sh, bash, cmd, powershell, pwsh")
-	}
-	if env.RequiredChecks.ShellPath != "" {
-		if strings.TrimSpace(env.RequiredChecks.ShellPath) != env.RequiredChecks.ShellPath {
-			result.Errors = append(result.Errors, "required_checks.shell_path must not have leading or trailing whitespace")
-		}
-		// required_checks.shell_path is the more specific executable selection.
-		// When the executable basename is one of the recognized shells, Galley
-		// can infer the invocation style and shell_path may stand alone. When
-		// the basename is not recognized, an explicit non-auto
-		// required_checks.shell is required as fallback kind metadata.
-		if InferRequiredCheckShellKind(env.RequiredChecks.ShellPath) == "" {
-			switch env.RequiredChecks.Shell {
-			case "", "auto":
-				result.Errors = append(result.Errors, "required_checks.shell_path basename is not a recognized shell executable; set an explicit required_checks.shell kind (sh, bash, cmd, powershell, or pwsh) as fallback metadata")
-			}
-		}
-	}
+	validateExecutorDefault(&result, env.Executor)
+	validateSupervisorDefault(&result, env.Supervisor)
+	validateRequiredChecks(&result, env.RequiredChecks)
 	if env.PR.Comments.Reply && !env.PR.Comments.Enabled {
 		result.Warnings = append(result.Warnings, "pr.comments.reply is set while pr.comments.enabled is false")
 	}
-	if env.Setup != nil {
-		if len(env.Setup.Commands) == 0 {
-			result.Errors = append(result.Errors, "setup.commands must not be empty when setup is present")
+	validateSetupPlan(&result, env.Setup)
+	return result
+}
+
+func validateExecutorDefault(result *ValidationResult, executor *ExecutorDefault) {
+	if executor == nil {
+		return
+	}
+	if executor.DefaultCLI != "" {
+		require(result, validExecutorCLI(executor.DefaultCLI), "executor.default_cli must be one of: %s", strings.Join(provider.ExecutorIDs(), ", "))
+	}
+	if executor.Effort == "" {
+		return
+	}
+	if executor.DefaultCLI == "" {
+		require(result, slices.Contains(provider.ExecutorEfforts(), executor.Effort), "executor.effort must be one of: %s", strings.Join(provider.ExecutorEfforts(), ", "))
+		return
+	}
+	if efforts, ok := provider.EffortsForID(executor.DefaultCLI); ok {
+		require(result, slices.Contains(efforts, executor.Effort), "executor.effort for %s must be one of: %s", executor.DefaultCLI, strings.Join(efforts, ", "))
+	}
+}
+
+func validateSupervisorDefault(result *ValidationResult, supervisor *SupervisorDefault) {
+	if supervisor == nil {
+		return
+	}
+	if supervisor.DefaultCLI != "" {
+		require(result, provider.IsSupervisor(supervisor.DefaultCLI), "supervisor.default_cli must be one of: %s", strings.Join(provider.SupervisorIDs(), ", "))
+	}
+	if supervisor.Effort == "" {
+		return
+	}
+	// Without default_cli, profile validation can enforce only the provider
+	// union; preflight narrows it later.
+	if supervisor.DefaultCLI == "" {
+		require(result, slices.Contains(provider.SupervisorEfforts(), supervisor.Effort), "supervisor.effort must be one of: %s", strings.Join(provider.SupervisorEfforts(), ", "))
+		return
+	}
+	if efforts, ok := provider.EffortsForID(supervisor.DefaultCLI); ok {
+		require(result, slices.Contains(efforts, supervisor.Effort), "supervisor.effort for %s must be one of: %s", supervisor.DefaultCLI, strings.Join(efforts, ", "))
+	}
+}
+
+func validateRequiredChecks(result *ValidationResult, checks RequiredCheckEnvironment) {
+	if checks.Shell != "" {
+		require(result, validRequiredCheckShell(checks.Shell), "required_checks.shell must be one of: auto, sh, bash, cmd, powershell, pwsh")
+	}
+	if checks.ShellPath == "" {
+		return
+	}
+	if strings.TrimSpace(checks.ShellPath) != checks.ShellPath {
+		result.Errors = append(result.Errors, "required_checks.shell_path must not have leading or trailing whitespace")
+	}
+	// A recognized shell_path basename lets Galley infer the invocation style, so
+	// shell_path stands alone; otherwise an explicit shell kind supplies it.
+	if InferRequiredCheckShellKind(checks.ShellPath) != "" {
+		return
+	}
+	switch checks.Shell {
+	case "", "auto":
+		result.Errors = append(result.Errors, "required_checks.shell_path basename is not a recognized shell executable; set an explicit required_checks.shell kind (sh, bash, cmd, powershell, or pwsh) as fallback metadata")
+	}
+}
+
+func validateSetupPlan(result *ValidationResult, setup *SetupPlan) {
+	if setup == nil {
+		return
+	}
+	if len(setup.Commands) == 0 {
+		result.Errors = append(result.Errors, "setup.commands must not be empty when setup is present")
+	}
+	for i, cmd := range setup.Commands {
+		prefix := fmt.Sprintf("setup.commands[%d]", i)
+		if strings.TrimSpace(cmd.Run) == "" {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s.run is required", prefix))
 		}
-		for i, cmd := range env.Setup.Commands {
-			prefix := fmt.Sprintf("setup.commands[%d]", i)
-			if strings.TrimSpace(cmd.Run) == "" {
-				result.Errors = append(result.Errors, fmt.Sprintf("%s.run is required", prefix))
-			}
-			validateSetupCommandText(&result, prefix+".run", cmd.Run, MaxSetupCommandRunLength)
-			if cmd.Why != "" {
-				validateSetupCommandText(&result, prefix+".why", cmd.Why, MaxSetupCommandWhyLength)
-			}
+		validateSetupCommandText(result, prefix+".run", cmd.Run, MaxSetupCommandRunLength)
+		if cmd.Why != "" {
+			validateSetupCommandText(result, prefix+".why", cmd.Why, MaxSetupCommandWhyLength)
 		}
 	}
-	return result
 }
 
 func validateSetupCommandText(result *ValidationResult, field, value string, max int) {
@@ -423,7 +465,7 @@ func replaceEnvironmentSetup(root *yaml.Node, plan SetupPlan) error {
 	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "setup"}
 	valueNode := &yaml.Node{}
 	if err := valueNode.Encode(plan); err != nil {
-		return err
+		return fmt.Errorf("encode executor plan: %w", err)
 	}
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
 		if mapping.Content[i].Value == "setup" {
@@ -465,10 +507,10 @@ func loadYAML(path string, out any, schema map[string]any) error {
 func decodeProfileYAML(data []byte, out any, schema map[string]any) error {
 	var root yaml.Node
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return err
+		return fmt.Errorf("parse profile YAML: %w", err)
 	}
 	if err := root.Decode(out); err != nil {
-		return err
+		return fmt.Errorf("decode profile document: %w", err)
 	}
 	missing := missingRequiredYAMLFields(&root, schema, "")
 	if len(missing) > 0 {
@@ -478,61 +520,75 @@ func decodeProfileYAML(data []byte, out any, schema map[string]any) error {
 }
 
 func missingRequiredYAMLFields(node *yaml.Node, schema map[string]any, path string) []string {
-	if isYAMLNull(node) {
-		node = nil
-	}
-	if node != nil && node.Kind == yaml.DocumentNode {
-		if len(node.Content) == 0 {
-			node = nil
-		} else {
-			node = node.Content[0]
-		}
-	}
-
+	node = unwrapYAMLNode(node)
 	schemaType, _ := schema["type"].(string)
 	switch schemaType {
 	case "object":
-		if node == nil {
-			var missing []string
-			for _, key := range schemaRequiredFields(schema) {
-				missing = append(missing, yamlFieldPath(path, key))
-			}
-			return missing
-		}
-		if node.Kind != yaml.MappingNode {
-			return nil
-		}
-		var missing []string
-		for _, key := range schemaRequiredFields(schema) {
-			if isYAMLNull(yamlMappingValue(node, key)) {
-				missing = append(missing, yamlFieldPath(path, key))
-			}
-		}
-		properties, _ := schema["properties"].(map[string]any)
-		for i := 0; i+1 < len(node.Content); i += 2 {
-			childSchema, ok := properties[node.Content[i].Value].(map[string]any)
-			if !ok {
-				continue
-			}
-			missing = append(missing, missingRequiredYAMLFields(node.Content[i+1], childSchema, yamlFieldPath(path, node.Content[i].Value))...)
-		}
-		return missing
+		return missingObjectFields(node, schema, path)
 	case "array":
-		if node == nil || node.Kind != yaml.SequenceNode {
-			return nil
-		}
-		itemSchema, ok := schema["items"].(map[string]any)
-		if !ok {
-			return nil
-		}
-		var missing []string
-		for i, item := range node.Content {
-			missing = append(missing, missingRequiredYAMLFields(item, itemSchema, fmt.Sprintf("%s[%d]", path, i))...)
-		}
-		return missing
+		return missingArrayFields(node, schema, path)
 	default:
 		return nil
 	}
+}
+
+// unwrapYAMLNode resolves a document node to its content and normalizes an
+// explicit YAML null to a nil node, so callers see one absent representation.
+func unwrapYAMLNode(node *yaml.Node) *yaml.Node {
+	if isYAMLNull(node) {
+		return nil
+	}
+	if node == nil || node.Kind != yaml.DocumentNode {
+		return node
+	}
+	if len(node.Content) == 0 {
+		return nil
+	}
+	return node.Content[0]
+}
+
+// missingObjectFields reports the required fields absent from an object node.
+// An absent node means every required field is missing.
+func missingObjectFields(node *yaml.Node, schema map[string]any, path string) []string {
+	var missing []string
+	if node == nil {
+		for _, key := range schemaRequiredFields(schema) {
+			missing = append(missing, yamlFieldPath(path, key))
+		}
+		return missing
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for _, key := range schemaRequiredFields(schema) {
+		if isYAMLNull(yamlMappingValue(node, key)) {
+			missing = append(missing, yamlFieldPath(path, key))
+		}
+	}
+	properties, _ := schema["properties"].(map[string]any)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		childSchema, ok := properties[node.Content[i].Value].(map[string]any)
+		if !ok {
+			continue
+		}
+		missing = append(missing, missingRequiredYAMLFields(node.Content[i+1], childSchema, yamlFieldPath(path, node.Content[i].Value))...)
+	}
+	return missing
+}
+
+func missingArrayFields(node *yaml.Node, schema map[string]any, path string) []string {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	itemSchema, ok := schema["items"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	var missing []string
+	for i, item := range node.Content {
+		missing = append(missing, missingRequiredYAMLFields(item, itemSchema, fmt.Sprintf("%s[%d]", path, i))...)
+	}
+	return missing
 }
 
 func schemaRequiredFields(schema map[string]any) []string {

--- a/internal/profile/schema.go
+++ b/internal/profile/schema.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/shinpr/galley/internal/provider"
 )
@@ -206,7 +207,7 @@ func marshalSchema(schema map[string]any) ([]byte, error) {
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(schema); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode profile schema: %w", err)
 	}
 	return buf.Bytes(), nil
 }

--- a/internal/profilecmd/shell.go
+++ b/internal/profilecmd/shell.go
@@ -12,8 +12,10 @@ import (
 
 // LookupFunc and StatFunc let tests exercise shell discovery without relying
 // on the host machine's PATH or filesystem.
-type LookupFunc func(string) (string, error)
-type StatFunc func(string) (os.FileInfo, error)
+type (
+	LookupFunc func(string) (string, error)
+	StatFunc   func(string) (os.FileInfo, error)
+)
 
 // Resolver controls the host interactions used by ShellArgvForOS.
 type Resolver struct {
@@ -36,11 +38,20 @@ func (r Resolver) withDefaults() Resolver {
 // resolved shell kind. It is shared by required checks and environment.setup so
 // both surfaces honor required_checks.shell and required_checks.shell_path.
 func ShellArgvForOS(goos, command, scratchDir string, shell profile.RequiredCheckEnvironment) ([]string, func(), string, error) {
-	return ShellArgvForOSWithResolver(goos, command, scratchDir, shell, Resolver{})
+	return ShellArgvForOSWithResolver(ShellRequest{GOOS: goos, Command: command, ScratchDir: scratchDir, Shell: shell}, Resolver{})
 }
 
 // ShellArgvForOSWithResolver is ShellArgvForOS with injectable host lookups.
-func ShellArgvForOSWithResolver(goos, command, scratchDir string, shell profile.RequiredCheckEnvironment, resolver Resolver) ([]string, func(), string, error) {
+// ShellRequest is one required-check command and the shell it runs under.
+type ShellRequest struct {
+	GOOS       string
+	Command    string
+	ScratchDir string
+	Shell      profile.RequiredCheckEnvironment
+}
+
+func ShellArgvForOSWithResolver(req ShellRequest, resolver Resolver) ([]string, func(), string, error) {
+	goos, command, scratchDir, shell := req.GOOS, req.Command, req.ScratchDir, req.Shell
 	resolver = resolver.withDefaults()
 	resolved, err := resolveShellForOS(goos, shell.Shell, shell.ShellPath, resolver)
 	if err != nil {
@@ -49,30 +60,11 @@ func ShellArgvForOSWithResolver(goos, command, scratchDir string, shell profile.
 	if goos != "windows" {
 		return shellArgv(resolved, command), nil, resolved.Kind, nil
 	}
-	dir := scratchDir
-	cleanup := func() {}
-	if dir == "" {
-		tmp, err := os.MkdirTemp("", "galley-windows-check-*")
-		if err != nil {
-			return nil, nil, "", fmt.Errorf("create windows verification script dir: %w", err)
-		}
-		dir = tmp
-		cleanup = func() { _ = os.RemoveAll(tmp) }
-	} else if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, nil, "", fmt.Errorf("create windows verification script dir %s: %w", dir, err)
+	dir, cleanup, err := windowsScriptDir(scratchDir)
+	if err != nil {
+		return nil, nil, "", err
 	}
-	ext := ".cmd"
-	body := []byte("@echo off\r\n" + command + "\r\n")
-	if resolved.Kind == "bash" {
-		ext = ".sh"
-		body = []byte("#!/usr/bin/env bash\nset -e\n" + command + "\n")
-	} else if resolved.Kind == "sh" {
-		ext = ".sh"
-		body = []byte("set -e\n" + command + "\n")
-	} else if resolved.Kind == "powershell" || resolved.Kind == "pwsh" {
-		ext = ".ps1"
-		body = []byte("$ErrorActionPreference = 'Stop'\r\n" + command + "\r\n")
-	}
+	ext, body := windowsScriptBody(resolved.Kind, command)
 	scriptPath := filepath.Join(dir, "galley-verification"+ext)
 	if err := os.WriteFile(scriptPath, body, 0o600); err != nil {
 		cleanup()
@@ -228,5 +220,36 @@ func shellScriptArgv(shell resolvedShell, scriptPath string) []string {
 		return []string{shell.Bin, "-NoProfile", "-File", scriptPath}
 	default:
 		return []string{shell.Bin, "/C", scriptPath}
+	}
+}
+
+// windowsScriptDir returns the directory the generated verification script is
+// written to, plus the cleanup for a directory this call created.
+func windowsScriptDir(scratchDir string) (string, func(), error) {
+	if scratchDir == "" {
+		tmp, err := os.MkdirTemp("", "galley-windows-check-*")
+		if err != nil {
+			return "", nil, fmt.Errorf("create windows verification script dir: %w", err)
+		}
+		return tmp, func() { _ = os.RemoveAll(tmp) }, nil
+	}
+	if err := os.MkdirAll(scratchDir, 0o700); err != nil {
+		return "", nil, fmt.Errorf("create windows verification script dir %s: %w", scratchDir, err)
+	}
+	return scratchDir, func() {}, nil
+}
+
+// windowsScriptBody returns the script extension and contents for the resolved
+// shell kind; an unrecognized kind falls back to a cmd batch file.
+func windowsScriptBody(kind, command string) (string, []byte) {
+	switch kind {
+	case "bash":
+		return ".sh", []byte("#!/usr/bin/env bash\nset -e\n" + command + "\n")
+	case "sh":
+		return ".sh", []byte("set -e\n" + command + "\n")
+	case "powershell", "pwsh":
+		return ".ps1", []byte("$ErrorActionPreference = 'Stop'\r\n" + command + "\r\n")
+	default:
+		return ".cmd", []byte("@echo off\r\n" + command + "\r\n")
 	}
 }

--- a/internal/profilecmd/shell_test.go
+++ b/internal/profilecmd/shell_test.go
@@ -12,9 +12,9 @@ import (
 func TestShellArgvForOSHonorsExplicitShellPathWithoutDiscovery(t *testing.T) {
 	lookCalls := 0
 	statCalls := 0
-	argv, cleanup, shell, err := ShellArgvForOSWithResolver("linux", "echo ok", "", profile.RequiredCheckEnvironment{
+	argv, cleanup, shell, err := ShellArgvForOSWithResolver(ShellRequest{GOOS: "linux", Command: "echo ok", ScratchDir: "", Shell: profile.RequiredCheckEnvironment{
 		ShellPath: "/opt/galley/bin/bash",
-	}, Resolver{
+	}}, Resolver{
 		LookPath: func(string) (string, error) {
 			lookCalls++
 			return "", os.ErrNotExist
@@ -42,9 +42,9 @@ func TestShellArgvForOSHonorsExplicitShellPathWithoutDiscovery(t *testing.T) {
 }
 
 func TestShellArgvForOSWindowsBashRejectsNonStandardPathDiscovery(t *testing.T) {
-	_, cleanup, _, err := ShellArgvForOSWithResolver("windows", "echo ok", t.TempDir(), profile.RequiredCheckEnvironment{
+	_, cleanup, _, err := ShellArgvForOSWithResolver(ShellRequest{GOOS: "windows", Command: "echo ok", ScratchDir: t.TempDir(), Shell: profile.RequiredCheckEnvironment{
 		Shell: "bash",
-	}, Resolver{
+	}}, Resolver{
 		LookPath: func(file string) (string, error) {
 			if file == "bash.exe" || file == "bash" {
 				return `C:\Windows\System32\bash.exe`, nil

--- a/internal/profilecmd/shell_windows_path_test.go
+++ b/internal/profilecmd/shell_windows_path_test.go
@@ -39,55 +39,70 @@ func TestShellArgvForOSWindowsAutoPrefersStandardGitForWindowsInstalls(t *testin
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			oldLook := lookPath
-			oldStat := statFile
-			// PATH always exposes a non-standard WindowsApps bash to confirm
-			// the standard install wins.
-			lookPath = func(file string) (string, error) {
-				switch file {
-				case "bash.exe", "bash":
-					return `C:\Users\runner\AppData\Local\Microsoft\WindowsApps\bash.exe`, nil
-				case "git.exe", "git":
-					if tc.gitPath != "" {
-						return tc.gitPath, nil
-					}
-					return "", os.ErrNotExist
-				}
-				return "", os.ErrNotExist
-			}
-			statFile = func(name string) (os.FileInfo, error) {
-				if tc.statFromB && name == tc.stdPath {
-					return fakeFileInfo{}, nil
-				}
-				if !tc.statFromB && name == tc.wantBin {
-					return fakeFileInfo{}, nil
-				}
-				return nil, os.ErrNotExist
-			}
-			defer func() {
-				lookPath = oldLook
-				statFile = oldStat
-			}()
-
-			argv, cleanup, shell, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if cleanup != nil {
-				defer cleanup()
-			}
-			if shell != "bash" {
-				t.Fatalf("resolved shell got %q, want bash", shell)
-			}
-			if argv[0] != tc.wantBin {
-				t.Fatalf("argv[0] got %q, want %q", argv[0], tc.wantBin)
-			}
-			if !strings.HasSuffix(argv[1], ".sh") {
-				t.Fatalf("argv[1] should reference a .sh script, got %q", argv[1])
-			}
+			assertStandardInstallWins(t, gitBashLayout{
+				StdPath: tc.stdPath, GitPath: tc.gitPath, WantBin: tc.wantBin, StatFromB: tc.statFromB,
+				PathBash: `C:\Users\runner\AppData\Local\Microsoft\WindowsApps\bash.exe`,
+			})
 		})
+	}
+}
+
+// assertStandardInstallWins pins that a recognized Git for Windows install wins
+// even while PATH exposes a non-standard WindowsApps bash.
+
+// gitBashLayout is one Git for Windows install layout under discovery.
+type gitBashLayout struct {
+	StdPath   string // standard install path visible to statFile
+	GitPath   string // git.exe path on PATH; empty means no git
+	WantBin   string // bash binary the resolver must select
+	StatFromB bool   // statFile recognizes StdPath (true) or the inferred WantBin (false)
+	PathBash  string // bash the PATH lookup always returns
+	Shell     string // configured required_checks.shell
+}
+
+func assertStandardInstallWins(t *testing.T, layout gitBashLayout) {
+	t.Helper()
+	stdPath, gitPath, wantBin, statFromB := layout.StdPath, layout.GitPath, layout.WantBin, layout.StatFromB
+	oldLook, oldStat := lookPath, statFile
+	lookPath = func(file string) (string, error) {
+		switch file {
+		case "bash.exe", "bash":
+			return layout.PathBash, nil
+		case "git.exe", "git":
+			if gitPath != "" {
+				return gitPath, nil
+			}
+		}
+		return "", os.ErrNotExist
+	}
+	statFile = func(name string) (os.FileInfo, error) {
+		recognized := stdPath
+		if !statFromB {
+			recognized = wantBin
+		}
+		if name == recognized {
+			return fakeFileInfo{}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	defer func() { lookPath, statFile = oldLook, oldStat }()
+
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "grep -F ok proof.txt", ScratchDir: t.TempDir(), ConfiguredShell: layout.Shell})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if shell != "bash" {
+		t.Fatalf("resolved shell got %q, want bash", shell)
+	}
+	if argv[0] != wantBin {
+		t.Fatalf("argv[0] got %q, want %q", argv[0], wantBin)
+	}
+	if !strings.HasSuffix(argv[1], ".sh") {
+		t.Fatalf("argv[1] should reference a .sh script, got %q", argv[1])
 	}
 }
 
@@ -95,122 +110,97 @@ func TestShellArgvForOSWindowsAutoPrefersStandardGitForWindowsInstalls(t *testin
 // C:\Windows\System32\bash.exe or a WindowsApps bash.exe, the Windows
 // auto-discovery path shall NOT select those entries as Git Bash. If no
 // usable Git Bash is found, Galley shall fall back to cmd.exe.
+// autoResolveCase is one PATH-discovered bash layout and the shell Galley must
+// select for it.
+type autoResolveCase struct {
+	name          string
+	pathBash      string
+	standardBash  string
+	command       string
+	wantShell     string
+	wantArgv0     string
+	wantArgv0Note string
+}
+
 func TestShellArgvForOSWindowsAutoRejectsWSLLauncherBashAndFallsBackToCmd(t *testing.T) {
-	t.Run("WSLSystem32FallsBackToCmd", func(t *testing.T) {
-		oldLook := lookPath
-		oldStat := statFile
-		lookPath = func(file string) (string, error) {
-			if file == "bash.exe" || file == "bash" {
-				return `C:\Windows\System32\bash.exe`, nil
-			}
-			return "", os.ErrNotExist
-		}
-		statFile = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-		defer func() { lookPath = oldLook; statFile = oldStat }()
+	// Only a recognized Git for Windows install is auto-selected; WSL, MSYS2, and
+	// the WindowsApps shim fall back to cmd.exe.
+	cases := []autoResolveCase{
+		{
+			name:      "WSLSystem32FallsBackToCmd",
+			pathBash:  `C:\Windows\System32\bash.exe`,
+			command:   "go test ./...",
+			wantShell: "cmd",
+			wantArgv0: "cmd.exe",
+		},
+		{
+			name:          "NonStandardMSYS2PathFallsBackToCmd",
+			pathBash:      `C:\msys64\usr\bin\bash.exe`,
+			command:       "go test ./...",
+			wantShell:     "cmd",
+			wantArgv0:     "cmd.exe",
+			wantArgv0Note: "non-standard MSYS2 bash must not be auto-selected",
+		},
+		{
+			name:      "WindowsAppsShimFallsBackToCmd",
+			pathBash:  `C:\Users\runner\AppData\Local\Microsoft\WindowsApps\bash.exe`,
+			command:   "go test ./...",
+			wantShell: "cmd",
+			wantArgv0: "cmd.exe",
+		},
+		{
+			name:         "WSLLauncherWithStandardInstallStillPrefersStandard",
+			pathBash:     `C:\Windows\System32\bash.exe`,
+			standardBash: `C:\Program Files\Git\bin\bash.exe`,
+			command:      "grep -F ok proof.txt",
+			wantShell:    "bash",
+			wantArgv0:    `C:\Program Files\Git\bin\bash.exe`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertAutoResolvedShell(t, tc)
+		})
+	}
+}
 
-		argv, cleanup, shell, err := shellArgvForOS("windows", "go test ./...", t.TempDir(), "", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-		if shell != "cmd" {
-			t.Fatalf("resolved shell got %q, want cmd", shell)
-		}
-		if argv[0] != "cmd.exe" {
-			t.Fatalf("argv[0] got %q, want cmd.exe", argv[0])
-		}
-	})
-	t.Run("NonStandardMSYS2PathFallsBackToCmd", func(t *testing.T) {
-		// Regression: PATH-discovered bash that points at a non-standard,
-		// non-Git-for-Windows install (here MSYS2) must NOT be auto-selected
-		// because Galley cannot guarantee it is Git Bash. No standard install
-		// path is visible to statFile and no git.exe is on PATH, so the
-		// resolver must fall back to cmd.exe rather than silently switching
-		// required checks to MSYS2's bash.
-		oldLook := lookPath
-		oldStat := statFile
-		lookPath = func(file string) (string, error) {
-			if file == "bash.exe" || file == "bash" {
-				return `C:\msys64\usr\bin\bash.exe`, nil
-			}
-			return "", os.ErrNotExist
-		}
-		statFile = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-		defer func() { lookPath = oldLook; statFile = oldStat }()
+func assertAutoResolvedShell(t *testing.T, tc autoResolveCase) {
+	t.Helper()
+	restore := stubShellDiscovery(tc.pathBash, tc.standardBash)
+	defer restore()
 
-		argv, cleanup, shell, err := shellArgvForOS("windows", "go test ./...", t.TempDir(), "", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-		if shell != "cmd" {
-			t.Fatalf("resolved shell got %q, want cmd (non-standard MSYS2 bash must not be auto-selected)", shell)
-		}
-		if argv[0] != "cmd.exe" {
-			t.Fatalf("argv[0] got %q, want cmd.exe", argv[0])
-		}
-	})
-	t.Run("WindowsAppsShimFallsBackToCmd", func(t *testing.T) {
-		oldLook := lookPath
-		oldStat := statFile
-		lookPath = func(file string) (string, error) {
-			if file == "bash.exe" || file == "bash" {
-				return `C:\Users\runner\AppData\Local\Microsoft\WindowsApps\bash.exe`, nil
-			}
-			return "", os.ErrNotExist
-		}
-		statFile = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
-		defer func() { lookPath = oldLook; statFile = oldStat }()
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: tc.command, ScratchDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if shell != tc.wantShell {
+		t.Fatalf("resolved shell got %q, want %q %s", shell, tc.wantShell, tc.wantArgv0Note)
+	}
+	if argv[0] != tc.wantArgv0 {
+		t.Fatalf("argv[0] got %q, want %q", argv[0], tc.wantArgv0)
+	}
+}
 
-		argv, cleanup, shell, err := shellArgvForOS("windows", "go test ./...", t.TempDir(), "", "")
-		if err != nil {
-			t.Fatal(err)
+// stubShellDiscovery makes bash resolve to pathBash on PATH and makes
+// standardBash the only path visible to statFile (none when empty).
+func stubShellDiscovery(pathBash, standardBash string) func() {
+	oldLook, oldStat := lookPath, statFile
+	lookPath = func(file string) (string, error) {
+		if file == "bash.exe" || file == "bash" {
+			return pathBash, nil
 		}
-		if cleanup != nil {
-			defer cleanup()
+		return "", os.ErrNotExist
+	}
+	statFile = func(name string) (os.FileInfo, error) {
+		if standardBash != "" && name == standardBash {
+			return fakeFileInfo{}, nil
 		}
-		if shell != "cmd" {
-			t.Fatalf("resolved shell got %q, want cmd", shell)
-		}
-		if argv[0] != "cmd.exe" {
-			t.Fatalf("argv[0] got %q, want cmd.exe", argv[0])
-		}
-	})
-	t.Run("WSLLauncherWithStandardInstallStillPrefersStandard", func(t *testing.T) {
-		oldLook := lookPath
-		oldStat := statFile
-		lookPath = func(file string) (string, error) {
-			if file == "bash.exe" || file == "bash" {
-				return `C:\Windows\System32\bash.exe`, nil
-			}
-			return "", os.ErrNotExist
-		}
-		statFile = func(name string) (os.FileInfo, error) {
-			if name == `C:\Program Files\Git\bin\bash.exe` {
-				return fakeFileInfo{}, nil
-			}
-			return nil, os.ErrNotExist
-		}
-		defer func() { lookPath = oldLook; statFile = oldStat }()
-
-		argv, cleanup, shell, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if cleanup != nil {
-			defer cleanup()
-		}
-		if shell != "bash" {
-			t.Fatalf("resolved shell got %q, want bash", shell)
-		}
-		if argv[0] != `C:\Program Files\Git\bin\bash.exe` {
-			t.Fatalf("argv[0] got %q, want standard Git for Windows bash", argv[0])
-		}
-	})
+		return nil, os.ErrNotExist
+	}
+	return func() { lookPath, statFile = oldLook, oldStat }
 }
 
 // AC3 (result-side): When required_checks.shell_path is set with an
@@ -244,7 +234,7 @@ func TestShellArgvForOSWindowsUsesExplicitRequiredCheckShellPathWithoutDiscovery
 			}
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			argv, cleanup, shell, err := shellArgvForOS("windows", "echo ok", t.TempDir(), tc.shell, tc.shellPath)
+			argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "echo ok", ScratchDir: t.TempDir(), ConfiguredShell: tc.shell, ConfiguredShellPath: tc.shellPath})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -279,7 +269,7 @@ func TestShellArgvForOSExplicitRequiredCheckShellPathHonoredOnUnix(t *testing.T)
 	statFile = func(string) (os.FileInfo, error) { statCalls++; return nil, os.ErrNotExist }
 	defer func() { lookPath = oldLook; statFile = oldStat }()
 
-	argv, cleanup, shell, err := shellArgvForOS("linux", "echo ok", "", "bash", "/opt/galley/custom-bash")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "linux", Command: "echo ok", ScratchDir: "", ConfiguredShell: "bash", ConfiguredShellPath: "/opt/galley/custom-bash"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +317,7 @@ func TestShellArgvForOSInferShellKindFromShellPathBasenameWithoutExplicitShell(t
 			statFile = func(string) (os.FileInfo, error) { statCalls++; return nil, os.ErrNotExist }
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			argv, cleanup, shell, err := shellArgvForOS(tc.goos, "echo ok", t.TempDir(), "", tc.shellPath)
+			argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: tc.goos, Command: "echo ok", ScratchDir: t.TempDir(), ConfiguredShellPath: tc.shellPath})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -343,15 +333,7 @@ func TestShellArgvForOSInferShellKindFromShellPathBasenameWithoutExplicitShell(t
 			if lookCalls != 0 || statCalls != 0 {
 				t.Fatalf("shell_path inference must skip discovery hooks (look=%d stat=%d)", lookCalls, statCalls)
 			}
-			if tc.goos == "windows" {
-				if !strings.HasSuffix(argv[len(argv)-1], tc.wantArgvOp) {
-					t.Fatalf("argv[-1] %q must end with %q", argv[len(argv)-1], tc.wantArgvOp)
-				}
-			} else {
-				if argv[1] != tc.wantArgvOp {
-					t.Fatalf("argv[1] got %q, want %q", argv[1], tc.wantArgvOp)
-				}
-			}
+			assertInvocationOperand(t, tc.goos, argv, tc.wantArgvOp)
 		})
 	}
 }
@@ -412,7 +394,7 @@ func TestShellArgvForOSShellPathInferredKindOverridesIncompatibleConfiguredShell
 			statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			argv, cleanup, shell, err := shellArgvForOS(tc.goos, "echo ok", t.TempDir(), tc.configuredShell, tc.shellPath)
+			argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: tc.goos, Command: "echo ok", ScratchDir: t.TempDir(), ConfiguredShell: tc.configuredShell, ConfiguredShellPath: tc.shellPath})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -425,13 +407,7 @@ func TestShellArgvForOSShellPathInferredKindOverridesIncompatibleConfiguredShell
 			if argv[0] != tc.shellPath {
 				t.Fatalf("argv[0] got %q, want %q (verbatim shell_path)", argv[0], tc.shellPath)
 			}
-			if tc.goos == "windows" {
-				if !strings.HasSuffix(argv[len(argv)-1], tc.wantInvocation) {
-					t.Fatalf("argv[-1] %q must end with %q (invocation style must match resolved kind)", argv[len(argv)-1], tc.wantInvocation)
-				}
-			} else if len(argv) < 2 || argv[1] != tc.wantInvocation {
-				t.Fatalf("argv got %#v, want argv[1]=%q (invocation style must match resolved kind)", argv, tc.wantInvocation)
-			}
+			assertInvocationOperand(t, tc.goos, argv, tc.wantInvocation)
 		})
 	}
 }
@@ -459,7 +435,7 @@ func TestShellArgvForOSUnrecognizedShellPathFallsBackToConfiguredShellKindMetada
 			statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			argv, cleanup, shell, err := shellArgvForOS(tc.goos, "echo ok", t.TempDir(), tc.configuredShell, tc.shellPath)
+			argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: tc.goos, Command: "echo ok", ScratchDir: t.TempDir(), ConfiguredShell: tc.configuredShell, ConfiguredShellPath: tc.shellPath})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -498,7 +474,7 @@ func TestShellArgvForOSUnrecognizedShellPathWithoutConfiguredShellReturnsError(t
 			statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			_, _, _, err := shellArgvForOS("linux", "echo ok", t.TempDir(), tc.configuredShell, "/opt/galley/custom-bash")
+			_, _, _, err := shellArgvForOS(shellArgvSpec{GOOS: "linux", Command: "echo ok", ScratchDir: t.TempDir(), ConfiguredShell: tc.configuredShell, ConfiguredShellPath: "/opt/galley/custom-bash"})
 			if err == nil {
 				t.Fatal("expected error: unrecognized shell_path without fallback shell kind")
 			}
@@ -527,48 +503,13 @@ func TestShellArgvForOSWindowsExplicitBashPrefersGitForWindowsOverWSL(t *testing
 		{name: "PortableGitFromGitExe", gitPath: `C:\PortableGit\cmd\git.exe`, wantBin: `C:/PortableGit/bin/bash.exe`, statKeyFB: false},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			oldLook := lookPath
-			oldStat := statFile
-			lookPath = func(file string) (string, error) {
-				switch file {
-				case "bash.exe", "bash":
-					// PATH bash is always the WSL launcher to confirm Git for
-					// Windows discovery wins over PATH lookup.
-					return `C:\Windows\System32\bash.exe`, nil
-				case "git.exe", "git":
-					if tc.gitPath != "" {
-						return tc.gitPath, nil
-					}
-					return "", os.ErrNotExist
-				}
-				return "", os.ErrNotExist
-			}
-			statFile = func(name string) (os.FileInfo, error) {
-				if tc.statKeyFB && name == tc.stdPath {
-					return fakeFileInfo{}, nil
-				}
-				if !tc.statKeyFB && name == tc.wantBin {
-					return fakeFileInfo{}, nil
-				}
-				return nil, os.ErrNotExist
-			}
-			defer func() { lookPath = oldLook; statFile = oldStat }()
-
-			argv, cleanup, shell, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "bash", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if cleanup != nil {
-				defer cleanup()
-			}
-			if shell != "bash" {
-				t.Fatalf("resolved shell got %q, want bash", shell)
-			}
-			if argv[0] != tc.wantBin {
-				t.Fatalf("argv[0] got %q, want %q (Git for Windows discovery must win over WSL launcher PATH lookup)", argv[0], tc.wantBin)
-			}
+			// PATH bash is always the WSL launcher to confirm Git for Windows
+			// discovery wins over PATH lookup.
+			assertStandardInstallWins(t, gitBashLayout{
+				StdPath: tc.stdPath, GitPath: tc.gitPath, WantBin: tc.wantBin, StatFromB: tc.statKeyFB,
+				PathBash: `C:\Windows\System32\bash.exe`, Shell: "bash",
+			})
 		})
 	}
 }
@@ -589,7 +530,7 @@ func TestShellArgvForOSWindowsExplicitBashErrorsWhenNoStandardBashDiscoverable(t
 	statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	defer func() { lookPath = oldLook; statFile = oldStat }()
 
-	argv, cleanup, _, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "bash", "")
+	argv, cleanup, _, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "grep -F ok proof.txt", ScratchDir: t.TempDir(), ConfiguredShell: "bash", ConfiguredShellPath: ""})
 	if cleanup != nil {
 		defer cleanup()
 	}
@@ -637,7 +578,7 @@ func TestShellArgvForOSWindowsExplicitBashErrorsWhenOnlyNonStandardBashOnPath(t 
 			statFile = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 			defer func() { lookPath = oldLook; statFile = oldStat }()
 
-			argv, cleanup, _, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "bash", "")
+			argv, cleanup, _, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "grep -F ok proof.txt", ScratchDir: t.TempDir(), ConfiguredShell: "bash", ConfiguredShellPath: ""})
 			if cleanup != nil {
 				defer cleanup()
 			}
@@ -654,5 +595,20 @@ func TestShellArgvForOSWindowsExplicitBashErrorsWhenOnlyNonStandardBashOnPath(t 
 				t.Fatalf("resolver must NOT return the rejected PATH entry %q as argv[0]; got argv %#v", tc.pathBash, argv)
 			}
 		})
+	}
+}
+
+// assertInvocationOperand checks where the operand lands: Windows uses the
+// trailing generated-script path, every other OS uses argv[1].
+func assertInvocationOperand(t *testing.T, goos string, argv []string, wantOperand string) {
+	t.Helper()
+	if goos == "windows" {
+		if !strings.HasSuffix(argv[len(argv)-1], wantOperand) {
+			t.Fatalf("argv[-1] %q must end with %q", argv[len(argv)-1], wantOperand)
+		}
+		return
+	}
+	if argv[1] != wantOperand {
+		t.Fatalf("argv[1] got %q, want %q", argv[1], wantOperand)
 	}
 }

--- a/internal/profilecmd/shell_windows_routing_test.go
+++ b/internal/profilecmd/shell_windows_routing_test.go
@@ -19,11 +19,21 @@ var (
 	statFile = os.Stat
 )
 
-func shellArgvForOS(goos, command, scratchDir, configuredShell, configuredShellPath string) ([]string, func(), string, error) {
-	return ShellArgvForOSWithResolver(goos, command, scratchDir, profile.RequiredCheckEnvironment{
+type shellArgvSpec struct {
+	GOOS                string
+	Command             string
+	ScratchDir          string
+	ConfiguredShell     string
+	ConfiguredShellPath string
+}
+
+func shellArgvForOS(spec shellArgvSpec) ([]string, func(), string, error) {
+	goos, command, scratchDir := spec.GOOS, spec.Command, spec.ScratchDir
+	configuredShell, configuredShellPath := spec.ConfiguredShell, spec.ConfiguredShellPath
+	return ShellArgvForOSWithResolver(ShellRequest{GOOS: goos, Command: command, ScratchDir: scratchDir, Shell: profile.RequiredCheckEnvironment{
 		Shell:     configuredShell,
 		ShellPath: configuredShellPath,
-	}, Resolver{
+	}}, Resolver{
 		LookPath: lookPath,
 		StatFile: statFile,
 	})
@@ -36,7 +46,7 @@ func TestShellArgvForOSWindowsCmdPreservesMultilineVerbatim(t *testing.T) {
 	scratch := t.TempDir()
 	command := "if exist build.bat (\r\n  build.bat\r\n) else (\r\n  echo skip\r\n)"
 
-	argv, cleanup, _, err := shellArgvForOS("windows", command, scratch, "cmd", "")
+	argv, cleanup, _, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: command, ScratchDir: scratch, ConfiguredShell: "cmd", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +74,7 @@ func TestShellArgvForOSWindowsUsesScriptFile(t *testing.T) {
 	scratch := t.TempDir()
 	command := strings.Repeat("echo placeholder && ", 400) + "echo done"
 
-	argv, cleanup, shell, err := shellArgvForOS("windows", command, scratch, "cmd", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: command, ScratchDir: scratch, ConfiguredShell: "cmd", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +120,7 @@ func TestShellArgvForOSWindowsUsesScriptFile(t *testing.T) {
 // execution shape is independent of command length.
 func TestShellArgvForOSWindowsShortCommandAlsoUsesScriptFile(t *testing.T) {
 	scratch := t.TempDir()
-	argv, cleanup, shell, err := shellArgvForOS("windows", "go test ./...", scratch, "cmd", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "go test ./...", ScratchDir: scratch, ConfiguredShell: "cmd", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +147,7 @@ func TestShellArgvForOSWindowsShortCommandAlsoUsesScriptFile(t *testing.T) {
 
 func TestShellArgvForOSWindowsCreatesScratchDir(t *testing.T) {
 	scratch := t.TempDir() + "/nested/checks"
-	argv, cleanup, _, err := shellArgvForOS("windows", "go test ./...", scratch, "cmd", "")
+	argv, cleanup, _, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "go test ./...", ScratchDir: scratch, ConfiguredShell: "cmd", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +166,7 @@ func TestShellArgvForOSWindowsCreatesScratchDir(t *testing.T) {
 // use /bin/sh -c and the existing argv shape regardless of command length.
 func TestShellArgvForOSNonWindowsKeepsShape(t *testing.T) {
 	long := strings.Repeat("echo placeholder && ", 1000) + "echo done"
-	argv, cleanup, shell, err := shellArgvForOS("linux", long, "", "", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "linux", Command: long, ScratchDir: "", ConfiguredShell: "", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +196,7 @@ func TestShellArgvForOSWindowsAutoPrefersBashWhenPresent(t *testing.T) {
 	}()
 
 	scratch := t.TempDir()
-	argv, cleanup, shell, err := shellArgvForOS("windows", "grep -F ok proof.txt", scratch, "", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "grep -F ok proof.txt", ScratchDir: scratch, ConfiguredShell: "", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,10 +221,10 @@ func TestShellArgvForOSWindowsAutoPrefersBashWhenPresent(t *testing.T) {
 func TestShellArgvForOSWindowsAutoFallsBackToCmdWhenBashMissing(t *testing.T) {
 	old := lookPath
 	oldStat := statFile
-	lookPath = func(file string) (string, error) {
+	lookPath = func(_ string) (string, error) {
 		return "", os.ErrNotExist
 	}
-	statFile = func(name string) (os.FileInfo, error) {
+	statFile = func(_ string) (os.FileInfo, error) {
 		return nil, os.ErrNotExist
 	}
 	defer func() {
@@ -222,7 +232,7 @@ func TestShellArgvForOSWindowsAutoFallsBackToCmdWhenBashMissing(t *testing.T) {
 		statFile = oldStat
 	}()
 
-	argv, cleanup, shell, err := shellArgvForOS("windows", "go test ./...", t.TempDir(), "", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "go test ./...", ScratchDir: t.TempDir(), ConfiguredShell: "", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +269,7 @@ func TestShellArgvForOSWindowsAutoFindsGitBashFromGitPath(t *testing.T) {
 		statFile = oldStat
 	}()
 
-	argv, cleanup, shell, err := shellArgvForOS("windows", "grep -F ok proof.txt", t.TempDir(), "", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "grep -F ok proof.txt", ScratchDir: t.TempDir(), ConfiguredShell: "", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +285,7 @@ func TestShellArgvForOSWindowsAutoFindsGitBashFromGitPath(t *testing.T) {
 }
 
 func TestShellArgvForOSWindowsExplicitPwshUsesPowerShellScript(t *testing.T) {
-	argv, cleanup, shell, err := shellArgvForOS("windows", "Write-Output ok", t.TempDir(), "pwsh", "")
+	argv, cleanup, shell, err := shellArgvForOS(shellArgvSpec{GOOS: "windows", Command: "Write-Output ok", ScratchDir: t.TempDir(), ConfiguredShell: "pwsh", ConfiguredShellPath: ""})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/queue/owner.go
+++ b/internal/queue/owner.go
@@ -32,7 +32,7 @@ func OwnerPath(runningPath string) string {
 func WriteOwner(runningPath string, owner Owner) error {
 	data, err := json.Marshal(owner)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode owner: %w", err)
 	}
 	if err := os.WriteFile(OwnerPath(runningPath), data, 0o600); err != nil {
 		return fmt.Errorf("write task owner %s: %w", OwnerPath(runningPath), err)
@@ -45,7 +45,7 @@ func WriteOwner(runningPath string, owner Owner) error {
 func ReadOwner(runningPath string) (Owner, error) {
 	data, err := os.ReadFile(OwnerPath(runningPath))
 	if err != nil {
-		return Owner{}, err
+		return Owner{}, fmt.Errorf("read owner %s: %w", OwnerPath(runningPath), err)
 	}
 	var owner Owner
 	if err := json.Unmarshal(data, &owner); err != nil || owner.PID <= 0 {
@@ -57,7 +57,7 @@ func ReadOwner(runningPath string) (Owner, error) {
 // RemoveOwner removes the owner sidecar for a running task if present.
 func RemoveOwner(runningPath string) error {
 	if err := os.Remove(OwnerPath(runningPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+		return fmt.Errorf("remove owner %s: %w", OwnerPath(runningPath), err)
 	}
 	return nil
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -27,7 +27,7 @@ func EnsureLayout(root string) error {
 	}
 	paths = append(paths, filepath.Join(root, "runs"))
 	for _, path := range paths {
-		if err := os.MkdirAll(path, 0o755); err != nil {
+		if err := os.MkdirAll(path, 0o700); err != nil {
 			return fmt.Errorf("create %s: %w", path, err)
 		}
 	}
@@ -144,13 +144,11 @@ func RecoverStaleClaimsExcept(root string, ttl time.Duration, now time.Time, act
 		if now.Sub(info.ModTime()) < ttl {
 			continue
 		}
-		if entry.Type().IsRegular() && isTaskYAMLName(entry.Name()) {
-			if err := requeueRunningTask(root, path); err != nil {
-				if errors.Is(err, os.ErrExist) {
-					continue
-				}
-				return err
-			}
+		if !entry.Type().IsRegular() || !isTaskYAMLName(entry.Name()) {
+			continue
+		}
+		if err := requeueRunningTask(root, path); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
 		}
 	}
 	return nil
@@ -189,15 +187,7 @@ func removeStaleLocks(dir string, ttl time.Duration, now time.Time, active map[s
 func requeueRunningTask(root, runningPath string) error {
 	loaded, err := task.Load(runningPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		if moveErr := taskstate.QuarantineUnreadableClaim(root, runningPath, err); moveErr != nil {
-			return errors.Join(err, moveErr)
-		}
-		_ = RemoveOwner(runningPath)
-		fmt.Fprintf(os.Stderr, "galley: quarantined unreadable running task: %v\n", err)
-		return nil
+		return quarantineUnreadableRunningTask(root, runningPath, err)
 	}
 	loaded.Status = task.StatusQueued
 	if err := task.Save(runningPath, loaded); err != nil {
@@ -223,4 +213,18 @@ func noOverwriteRename(src, dst string) error {
 			return fileutil.RenameNoReplaceUnderMarker(src, dst)
 		})
 	})
+}
+
+// quarantineUnreadableRunningTask moves an unparseable running task out of the
+// queue so recovery stops retrying it; an already-gone file needs no action.
+func quarantineUnreadableRunningTask(root, runningPath string, loadErr error) error {
+	if errors.Is(loadErr, os.ErrNotExist) {
+		return nil
+	}
+	if moveErr := taskstate.QuarantineUnreadableClaim(root, runningPath, loadErr); moveErr != nil {
+		return errors.Join(loadErr, moveErr)
+	}
+	_ = RemoveOwner(runningPath)
+	fmt.Fprintf(os.Stderr, "galley: quarantined unreadable running task: %v\n", loadErr)
+	return nil
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -188,7 +188,7 @@ func TestRecoverStaleClaimsIgnoresQueuedDestinationConflict(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := running.Status, "queued"; got != want {
+	if got, want := running.Status, task.Status("queued"); got != want {
 		t.Fatalf("running status got %q, want %q", got, want)
 	}
 	queued, err := task.Load(queuedPath)

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -62,6 +62,7 @@ var sleep = func(ctx context.Context, d time.Duration) error {
 // so the schedule asserts against the documented base delays.
 var jitter = func() float64 {
 	// rand.Float64 returns [0.0, 1.0). (rand*2 - 1) maps to [-1, 1).
+	//nolint:gosec // G404: jitter only spreads retry timing; unpredictability is not required
 	return 1 + (rand.Float64()*2-1)*JitterRatio
 }
 
@@ -96,11 +97,13 @@ func SetHooksForTest(
 // would see in the no-retry path.
 func Do(ctx context.Context, fn func(context.Context) error) error {
 	if err := ctx.Err(); err != nil {
+		//nolint:wrapcheck // Do documents that it returns ctx.Err(); wrapping would change the documented return
 		return err
 	}
 	var lastErr error
 	for attempt := 0; attempt < MaxAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
+			//nolint:wrapcheck // Do documents that it returns ctx.Err(); wrapping would change the documented return
 			return err
 		}
 		err := fn(ctx)

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -84,6 +84,8 @@ func TestDo_ExhaustionReturnsLastError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Do returned nil, want last error")
 	}
+	// Do returns fn's final error unchanged, so identity is the contract.
+	//nolint:errorlint // identity, not chain membership, is the asserted contract
 	if err != lastErr {
 		t.Fatalf("Do returned %v, want %v (identical to fn's last return)", err, lastErr)
 	}

--- a/internal/runlog/runlog.go
+++ b/internal/runlog/runlog.go
@@ -1,6 +1,7 @@
 package runlog
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,7 +17,7 @@ func LatestTaskRunDir(root, taskID string) (string, error) {
 		if os.IsNotExist(err) {
 			return "", nil
 		}
-		return "", err
+		return "", fmt.Errorf("read runs dir %s: %w", runsDir, err)
 	}
 	best := ""
 	var bestN uint64
@@ -45,7 +46,7 @@ func LatestAttemptDir(runDir string) (string, int, error) {
 		if os.IsNotExist(err) {
 			return "", -1, nil
 		}
-		return "", -1, err
+		return "", -1, fmt.Errorf("read run dir %s: %w", runDir, err)
 	}
 	best := ""
 	bestN := -1

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -140,27 +140,14 @@ func buildClaudeArgv(opts ClaudeOptions, fileValue func(label, path string) (str
 	common := buildClaudeCommonArgs(opts)
 	argv := append(baseClaudeArgv(opts), common.Prefix...)
 	if opts.SystemPromptFile != "" || opts.SystemPrompt != "" {
-		systemPrompt := opts.SystemPrompt
-		if opts.SystemPromptFile != "" {
-			var err error
-			systemPrompt, err = fileValue("system prompt", opts.SystemPromptFile)
-			if err != nil {
-				return nil, err
-			}
+		systemPrompt, err := inlineOrFile(opts.SystemPrompt, opts.SystemPromptFile, "system prompt", fileValue)
+		if err != nil {
+			return nil, err
 		}
 		argv = append(argv, "--system-prompt", systemPrompt)
 	}
 	if opts.JSONSchemaFile != "" || opts.JSONSchema != "" {
-		schema := opts.JSONSchema
-		if opts.JSONSchemaFile != "" {
-			var err error
-			schema, err = fileValue("JSON schema", opts.JSONSchemaFile)
-			if err != nil {
-				return nil, err
-			}
-		}
-		var err error
-		schema, err = ClaudeCompatibleJSONSchema(schema)
+		schema, err := claudeSchemaArg(opts, fileValue)
 		if err != nil {
 			return nil, err
 		}
@@ -333,14 +320,35 @@ func claudeWarnings(opts ClaudeOptions) []string {
 	return warnings
 }
 
+func isShellSafeRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("-_./:=@", r)
+}
+
 func shellToken(s string) string {
 	if s == "" {
 		return "''"
 	}
-	if strings.IndexFunc(s, func(r rune) bool {
-		return !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("-_./:=@", r))
-	}) == -1 {
+	if !strings.ContainsFunc(s, func(r rune) bool { return !isShellSafeRune(r) }) {
 		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// inlineOrFile prefers the file form when a path is set, so a caller can supply
+// either an inline value or a path without the caller branching.
+func inlineOrFile(inline, path, label string, fileValue func(label, path string) (string, error)) (string, error) {
+	if path == "" {
+		return inline, nil
+	}
+	return fileValue(label, path)
+}
+
+// claudeSchemaArg resolves the schema from its inline or file form and
+// normalizes it for the Claude CLI.
+func claudeSchemaArg(opts ClaudeOptions, fileValue func(label, path string) (string, error)) (string, error) {
+	schema, err := inlineOrFile(opts.JSONSchema, opts.JSONSchemaFile, "JSON schema", fileValue)
+	if err != nil {
+		return "", err
+	}
+	return ClaudeCompatibleJSONSchema(schema)
 }

--- a/internal/runner/claude_guard_plugin/embed.go
+++ b/internal/runner/claude_guard_plugin/embed.go
@@ -31,7 +31,7 @@ func Ensure(dst string) (string, error) {
 	dst = filepath.Join(dst, version)
 	if _, err := os.Stat(filepath.Join(dst, ".complete")); err == nil {
 		return dst, nil
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if !os.IsNotExist(err) {
 		return "", fmt.Errorf("inspect guard plugin dir %s: %w", dst, err)
 	}
 	parent := filepath.Dir(dst)

--- a/internal/runner/claude_guard_plugin/embed_test.go
+++ b/internal/runner/claude_guard_plugin/embed_test.go
@@ -239,7 +239,7 @@ func TestRequireFinalJSONSetupCorrectionIncludesRequiredReadyFields(t *testing.T
 func pythonCommand(t *testing.T, script string) *exec.Cmd {
 	t.Helper()
 	if runtime.GOOS != "windows" {
-		return exec.Command(script)
+		return exec.CommandContext(t.Context(), script)
 	}
 	python, err := exec.LookPath("python")
 	if err != nil {
@@ -248,5 +248,5 @@ func pythonCommand(t *testing.T, script string) *exec.Cmd {
 	if err != nil {
 		t.Skipf("python not available: %v", err)
 	}
-	return exec.Command(python, script)
+	return exec.CommandContext(t.Context(), python, script)
 }

--- a/internal/runner/claude_provider.go
+++ b/internal/runner/claude_provider.go
@@ -2,8 +2,9 @@ package runner
 
 import (
 	"fmt"
-	"github.com/shinpr/galley/internal/proc"
 	"strings"
+
+	"github.com/shinpr/galley/internal/proc"
 )
 
 const (

--- a/internal/runner/claude_provider_test.go
+++ b/internal/runner/claude_provider_test.go
@@ -1,9 +1,10 @@
 package runner
 
 import (
-	"github.com/shinpr/galley/internal/proc"
 	"strings"
 	"testing"
+
+	"github.com/shinpr/galley/internal/proc"
 )
 
 func TestConfigureClaudeProviderKimiUsesDedicatedEndpointAndAPIKey(t *testing.T) {

--- a/internal/runner/codex_argv_test.go
+++ b/internal/runner/codex_argv_test.go
@@ -70,7 +70,6 @@ func TestCodexArgvDoesNotEmitUnsupportedFlags(t *testing.T) {
 	if plan.Argv[len(plan.Argv)-1] != "-" {
 		t.Fatalf("argv must end with the `-` stdin marker; full argv=%v", plan.Argv)
 	}
-
 }
 
 func TestCodexCommandPlanPassesExpandedEffortLiterals(t *testing.T) {

--- a/internal/runner/codex_output_capture_test.go
+++ b/internal/runner/codex_output_capture_test.go
@@ -188,49 +188,61 @@ func TestCodexCommandPlanConvergesCanonicalSchemaInputs(t *testing.T) {
 	}
 	derivatives := make([][]byte, 0, len(cases))
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			attemptDir := t.TempDir()
-			opts := CodexFromTask(minimalCodexTask())
-			opts.WorkDir = "/tmp/codex-schema-boundary"
-			opts.AttemptDir = attemptDir
-			opts.JSONSchema = tc.inline
-			opts.JSONSchemaFile = tc.file
-			opts.Prompt = "work order"
-
-			plan, err := CodexCommandPlan(opts)
-			if err != nil {
-				t.Fatalf("CodexCommandPlan: %v", err)
-			}
-			schemaFlag := flagValue(t, plan.Argv, "--output-schema")
-			if schemaFlag == "" {
-				t.Fatalf("argv missing --output-schema: %v", plan.Argv)
-			}
-			if filepath.Dir(schemaFlag) != attemptDir {
-				t.Fatalf("output-schema must be attempt-scoped derivative: got %q, want under %q", schemaFlag, attemptDir)
-			}
-			if tc.file != "" && schemaFlag == tc.file {
-				t.Fatalf("argv must reference normalized derivative, not canonical file %q", tc.file)
-			}
-			derivative, err := os.ReadFile(schemaFlag)
-			if err != nil {
-				t.Fatalf("read materialized derivative: %v", err)
-			}
-			assertCodexNormalized(t, derivative)
-			if tc.file != "" {
-				source, err := os.ReadFile(tc.file)
-				if err != nil {
-					t.Fatalf("read canonical source: %v", err)
-				}
-				if !bytes.Equal(source, []byte(canonical)) {
-					t.Fatalf("canonical source file must not be mutated")
-				}
-			}
-			derivatives = append(derivatives, derivative)
+			derivatives = append(derivatives, materializeCodexSchemaDerivative(t, tc.inline, tc.file, canonical))
 		})
 	}
 	if !bytes.Equal(derivatives[0], derivatives[1]) {
 		t.Fatalf("canonical inputs must converge on one normalized artifact")
+	}
+}
+
+// materializeCodexSchemaDerivative builds the plan and returns the attempt-scoped
+// normalized schema; any canonical source file stays unmutated.
+func materializeCodexSchemaDerivative(t *testing.T, inline, file, canonical string) []byte {
+	t.Helper()
+	attemptDir := t.TempDir()
+	opts := CodexFromTask(minimalCodexTask())
+	opts.WorkDir = "/tmp/codex-schema-boundary"
+	opts.AttemptDir = attemptDir
+	opts.JSONSchema = inline
+	opts.JSONSchemaFile = file
+	opts.Prompt = "work order"
+
+	plan, err := CodexCommandPlan(opts)
+	if err != nil {
+		t.Fatalf("CodexCommandPlan: %v", err)
+	}
+	schemaFlag := flagValue(t, plan.Argv, "--output-schema")
+	if schemaFlag == "" {
+		t.Fatalf("argv missing --output-schema: %v", plan.Argv)
+	}
+	if filepath.Dir(schemaFlag) != attemptDir {
+		t.Fatalf("output-schema must be attempt-scoped derivative: got %q, want under %q", schemaFlag, attemptDir)
+	}
+	if file != "" && schemaFlag == file {
+		t.Fatalf("argv must reference normalized derivative, not canonical file %q", file)
+	}
+	derivative, err := os.ReadFile(schemaFlag)
+	if err != nil {
+		t.Fatalf("read materialized derivative: %v", err)
+	}
+	assertCodexNormalized(t, derivative)
+	assertCanonicalSourceUnchanged(t, file, canonical)
+	return derivative
+}
+
+func assertCanonicalSourceUnchanged(t *testing.T, file, canonical string) {
+	t.Helper()
+	if file == "" {
+		return
+	}
+	source, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read canonical source: %v", err)
+	}
+	if !bytes.Equal(source, []byte(canonical)) {
+		t.Fatalf("canonical source file must not be mutated")
 	}
 }
 
@@ -347,10 +359,10 @@ func TestPrepareCodexOutputSchemaRejectsAliasedDestination(t *testing.T) {
 		name  string
 		setup func(t *testing.T) (destDir, filename string)
 	}{
-		{name: "exact-path", setup: func(t *testing.T) (string, string) {
+		{name: "exact-path", setup: func(_ *testing.T) (string, string) {
 			return filepath.Dir(sourcePath), filepath.Base(sourcePath)
 		}},
-		{name: "cleaned-path", setup: func(t *testing.T) (string, string) {
+		{name: "cleaned-path", setup: func(_ *testing.T) (string, string) {
 			return filepath.Dir(sourcePath), "./" + filepath.Base(sourcePath)
 		}},
 		{name: "symlink-alias", setup: func(t *testing.T) (string, string) {
@@ -577,23 +589,6 @@ func objectProp(t *testing.T, parent map[string]any, name string) map[string]any
 		t.Fatalf("property %q is not an object: %#v", name, parent[name])
 	}
 	return got
-}
-
-func assertNoSchemaKeyword(t *testing.T, node any, keyword string) {
-	t.Helper()
-	switch value := node.(type) {
-	case map[string]any:
-		if _, ok := value[keyword]; ok {
-			t.Fatalf("Codex output schema contains unsupported %q keyword: %#v", keyword, value)
-		}
-		for _, child := range value {
-			assertNoSchemaKeyword(t, child, keyword)
-		}
-	case []any:
-		for _, child := range value {
-			assertNoSchemaKeyword(t, child, keyword)
-		}
-	}
 }
 
 func requiredSet(t *testing.T, schema map[string]any) map[string]bool {

--- a/internal/runner/executor_result.go
+++ b/internal/runner/executor_result.go
@@ -89,20 +89,18 @@ func ExtractExecutorResultFile(path string) (ExecutorResult, error) {
 	if err != nil {
 		return ExecutorResult{}, fmt.Errorf("open executor output %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	reader := bufio.NewReader(file)
 	var firstErr error
 	for {
 		line, readErr := reader.ReadString('\n')
-		if line != "" {
-			result, found, err := extractExecutorResultLine(strings.TrimSpace(line))
-			if found && err == nil {
-				return result, nil
-			}
-			if found && firstErr == nil && err != nil {
-				firstErr = err
-			}
+		result, found, err := extractExecutorResultLine(strings.TrimSpace(line))
+		if found && err == nil {
+			return result, nil
+		}
+		if found && err != nil && firstErr == nil {
+			firstErr = err
 		}
 		if readErr != nil {
 			break
@@ -115,7 +113,28 @@ func ExtractExecutorResultFile(path string) (ExecutorResult, error) {
 }
 
 // Validate requires explicit arrays so persisted evidence has a stable shape.
+// Validate checks the executor result against the output contract; each
+// collection has its own function so a failure names the section it came from.
 func (r ExecutorResult) Validate() error {
+	for _, check := range []func() error{
+		r.validateShape,
+		r.validateAcceptanceCriteria,
+		r.validateVerification,
+		r.validateScopeExpansions,
+		r.validateDecisions,
+		r.validateRisks,
+		r.validateHardStop,
+	} {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateShape checks the status and required collections. A nil collection
+// means an omitted field, which the contract requires even when empty.
+func (r ExecutorResult) validateShape() error {
 	switch r.Status {
 	case "completed", "completed_with_risks", "hard_stop":
 	default:
@@ -124,23 +143,21 @@ func (r ExecutorResult) Validate() error {
 	if r.Summary == "" {
 		return fmt.Errorf("executor result summary is required")
 	}
-	if r.FilesModified == nil {
-		return fmt.Errorf("executor result files_modified is required")
+	required := []struct {
+		present bool
+		field   string
+	}{
+		{r.FilesModified != nil, "files_modified"},
+		{r.AcceptanceCriteria != nil, "acceptance_criteria"},
+		{r.Verification != nil, "verification"},
+		{r.ScopeExpansions != nil, "scope_expansions"},
+		{r.Decisions != nil, "decisions"},
+		{r.Risks != nil, "risks"},
 	}
-	if r.AcceptanceCriteria == nil {
-		return fmt.Errorf("executor result acceptance_criteria is required")
-	}
-	if r.Verification == nil {
-		return fmt.Errorf("executor result verification is required")
-	}
-	if r.ScopeExpansions == nil {
-		return fmt.Errorf("executor result scope_expansions is required")
-	}
-	if r.Decisions == nil {
-		return fmt.Errorf("executor result decisions is required")
-	}
-	if r.Risks == nil {
-		return fmt.Errorf("executor result risks is required")
+	for _, field := range required {
+		if !field.present {
+			return fmt.Errorf("executor result %s is required", field.field)
+		}
 	}
 	if r.Status == "hard_stop" && r.HardStop == nil {
 		return fmt.Errorf("executor hard_stop result requires hard_stop details")
@@ -148,6 +165,10 @@ func (r ExecutorResult) Validate() error {
 	if r.Status != "hard_stop" && r.HardStop != nil {
 		return fmt.Errorf("executor non-hard-stop result must not include hard_stop details")
 	}
+	return nil
+}
+
+func (r ExecutorResult) validateAcceptanceCriteria() error {
 	for i, ac := range r.AcceptanceCriteria {
 		if ac.ID == "" {
 			return fmt.Errorf("executor acceptance_criteria[%d].id is required", i)
@@ -161,6 +182,10 @@ func (r ExecutorResult) Validate() error {
 			return fmt.Errorf("executor acceptance_criteria[%d].evidence is required", i)
 		}
 	}
+	return nil
+}
+
+func (r ExecutorResult) validateVerification() error {
 	for i, verification := range r.Verification {
 		if verification.Command == "" {
 			return fmt.Errorf("executor verification[%d].command is required", i)
@@ -174,6 +199,10 @@ func (r ExecutorResult) Validate() error {
 			return fmt.Errorf("executor verification[%d].reason is required", i)
 		}
 	}
+	return nil
+}
+
+func (r ExecutorResult) validateScopeExpansions() error {
 	for i, expansion := range r.ScopeExpansions {
 		if expansion.Path == "" {
 			return fmt.Errorf("executor scope_expansions[%d].path is required", i)
@@ -191,6 +220,10 @@ func (r ExecutorResult) Validate() error {
 			return fmt.Errorf("executor scope_expansions[%d].minimality is required", i)
 		}
 	}
+	return nil
+}
+
+func (r ExecutorResult) validateDecisions() error {
 	for i, decision := range r.Decisions {
 		if decision.Question == "" {
 			return fmt.Errorf("executor decisions[%d].question is required", i)
@@ -207,6 +240,10 @@ func (r ExecutorResult) Validate() error {
 			return fmt.Errorf("invalid executor decisions[%d].reversibility %q", i, decision.Reversibility)
 		}
 	}
+	return nil
+}
+
+func (r ExecutorResult) validateRisks() error {
 	for i, risk := range r.Risks {
 		switch risk.Type {
 		case "ambiguous_requirement", "partial_verification", "external_dependency", "technical_debt", "other":
@@ -220,16 +257,21 @@ func (r ExecutorResult) Validate() error {
 			return fmt.Errorf("executor risks[%d].mitigation is required", i)
 		}
 	}
-	if r.HardStop != nil {
-		if r.HardStop.Reason == "" {
-			return fmt.Errorf("executor hard_stop.reason is required")
-		}
-		if r.HardStop.Attempted == nil {
-			return fmt.Errorf("executor hard_stop.attempted is required")
-		}
-		if r.HardStop.NeededToContinue == nil {
-			return fmt.Errorf("executor hard_stop.needed_to_continue is required")
-		}
+	return nil
+}
+
+func (r ExecutorResult) validateHardStop() error {
+	if r.HardStop == nil {
+		return nil
+	}
+	if r.HardStop.Reason == "" {
+		return fmt.Errorf("executor hard_stop.reason is required")
+	}
+	if r.HardStop.Attempted == nil {
+		return fmt.Errorf("executor hard_stop.attempted is required")
+	}
+	if r.HardStop.NeededToContinue == nil {
+		return fmt.Errorf("executor hard_stop.needed_to_continue is required")
 	}
 	return nil
 }
@@ -274,6 +316,7 @@ func extractExecutorResultLine(line string) (ExecutorResult, bool, error) {
 	}
 	var event map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		//nolint:nilerr // a non-JSON line simply is not a result
 		return ExecutorResult{}, false, nil
 	}
 	for _, key := range []string{"result", "response", "message"} {

--- a/internal/runner/glm_test.go
+++ b/internal/runner/glm_test.go
@@ -1,9 +1,10 @@
 package runner
 
 import (
-	"github.com/shinpr/galley/internal/proc"
 	"strings"
 	"testing"
+
+	"github.com/shinpr/galley/internal/proc"
 )
 
 func TestConfigureClaudeProviderGLMInjectsEndpointAndTokenViaEnvOnly(t *testing.T) {

--- a/internal/runner/grok.go
+++ b/internal/runner/grok.go
@@ -162,7 +162,7 @@ func WriteGrokCompletionMetadata(path string, data []byte) error {
 	}
 	body, err := json.MarshalIndent(metadata, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("encode grok completion metadata: %w", err)
 	}
 	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write grok completion metadata: %w", err)

--- a/internal/runner/terminal.go
+++ b/internal/runner/terminal.go
@@ -5,9 +5,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/shinpr/galley/internal/proc"
 	"io"
 	"strings"
+
+	"github.com/shinpr/galley/internal/proc"
 )
 
 // ExecutorTerminal is Galley's routing decision for one executor process exit.
@@ -127,14 +128,15 @@ func scanClaudeStream(provider string, stdout []byte) ExecutorTerminal {
 	var failure *claudeResultEvent
 	forEachLine(stdout, func(line string) {
 		var ev claudeResultEvent
-		if err := json.Unmarshal([]byte(line), &ev); err == nil && ev.Type == "result" {
-			captured := ev
-			if !captured.IsError && captured.Subtype == "success" {
-				success = &captured
-			} else {
-				failure = &captured
-			}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil || ev.Type != "result" {
+			return
 		}
+		captured := ev
+		if !captured.IsError && captured.Subtype == "success" {
+			success = &captured
+			return
+		}
+		failure = &captured
 	})
 	// An explicit failure result wins over any later success event, so a normal
 	// terminal never masks an earlier provider failure; a missing or unknown

--- a/internal/runner/terminal_test.go
+++ b/internal/runner/terminal_test.go
@@ -2,8 +2,9 @@ package runner
 
 import (
 	"errors"
-	"github.com/shinpr/galley/internal/proc"
 	"testing"
+
+	"github.com/shinpr/galley/internal/proc"
 )
 
 // validExecutorResultLine is a minimal executor result that passes Validate; a

--- a/internal/supervisor/adapter.go
+++ b/internal/supervisor/adapter.go
@@ -79,7 +79,7 @@ func RunAdapter(ctx context.Context, opts AdapterOptions, evidence Evidence) (Ve
 	request.Evidence.WorktreeCWD = opts.WorkDir
 	payload, err := json.Marshal(request)
 	if err != nil {
-		return Verdict{}, err
+		return Verdict{}, fmt.Errorf("encode supervisor request: %w", err)
 	}
 	output, err := RunAdapterPayload(ctx, opts, payload)
 	if err != nil {
@@ -309,22 +309,11 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 		"--output-format", "text",
 	}
 	args = runner.AppendProviderModelEffortArgs(args, provider.TransportClaude, opts.Model, opts.Effort)
-	if goos == "windows" {
-		systemPromptPath := filepath.Join(dir, ClaudeSupervisorSystemPromptFilename)
-		if err := writeSupervisorFile(systemPromptPath, []byte(prompts.ClaudeSupervisor())); err != nil {
-			return nil, err
-		}
-		args = append(args, "--system-prompt-file", systemPromptPath)
-	} else {
-		schema, err := runner.ClaudeCompatibleJSONSchema(schemas.SupervisorVerdict)
-		if err != nil {
-			return nil, fmt.Errorf("prepare Claude supervisor schema: %w", err)
-		}
-		args = append(args,
-			"--system-prompt", prompts.ClaudeSupervisor(),
-			"--json-schema", schema,
-		)
+	promptArgs, err := claudeSupervisorPromptArgs(dir, goos)
+	if err != nil {
+		return nil, err
 	}
+	args = append(args, promptArgs...)
 	args = append(args, "--plugin-dir", guardDir)
 	if opts.ArtifactDir != "" {
 		args = append(args, "--debug-file", debugPath)
@@ -357,26 +346,19 @@ func runClaudeAdapterForOS(ctx context.Context, opts AdapterOptions, request []b
 
 func supervisorArtifactDir(dir, pattern string) (string, func(), error) {
 	if dir != "" {
-		absolute, err := filepath.Abs(dir)
-		if err != nil {
-			return "", func() {}, fmt.Errorf("resolve supervisor artifact dir: %w", err)
-		}
-		dir = absolute
-		if err := os.MkdirAll(dir, 0o700); err != nil {
-			return "", func() {}, fmt.Errorf("create supervisor artifact dir: %w", err)
-		}
-		return dir, func() {}, nil
+		resolved, err := ensureSupervisorArtifactDir(dir)
+		return resolved, func() {}, err
 	}
 	tmp, err := os.MkdirTemp("", pattern)
 	if err != nil {
-		return "", func() {}, err
+		return "", func() {}, fmt.Errorf("create supervisor temp dir: %w", err)
 	}
 	return tmp, func() { _ = os.RemoveAll(tmp) }, nil
 }
 
 func writeSupervisorFile(path string, body []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
+		return fmt.Errorf("create supervisor file dir %s: %w", filepath.Dir(path), err)
 	}
 	if err := os.WriteFile(path, body, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
@@ -389,4 +371,40 @@ func errorString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+func writeClaudeSupervisorPrompt(dir string) (string, error) {
+	path := filepath.Join(dir, ClaudeSupervisorSystemPromptFilename)
+	if err := writeSupervisorFile(path, []byte(prompts.ClaudeSupervisor())); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ensureSupervisorArtifactDir(dir string) (string, error) {
+	absolute, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve supervisor artifact dir: %w", err)
+	}
+	if err := os.MkdirAll(absolute, 0o700); err != nil {
+		return "", fmt.Errorf("create supervisor artifact dir: %w", err)
+	}
+	return absolute, nil
+}
+
+// claudeSupervisorPromptArgs supplies the system prompt and verdict schema;
+// Windows passes the prompt as a file because its argv length limit is tight.
+func claudeSupervisorPromptArgs(dir, goos string) ([]string, error) {
+	if goos == "windows" {
+		path, err := writeClaudeSupervisorPrompt(dir)
+		if err != nil {
+			return nil, err
+		}
+		return []string{"--system-prompt-file", path}, nil
+	}
+	schema, err := runner.ClaudeCompatibleJSONSchema(schemas.SupervisorVerdict)
+	if err != nil {
+		return nil, fmt.Errorf("prepare Claude supervisor schema: %w", err)
+	}
+	return []string{"--system-prompt", prompts.ClaudeSupervisor(), "--json-schema", schema}, nil
 }

--- a/internal/supervisor/review_progress.go
+++ b/internal/supervisor/review_progress.go
@@ -232,14 +232,6 @@ func acceptanceIDs(value task.Task) []string {
 	return ids
 }
 
-func acceptanceIDSet(value task.Task) map[string]struct{} {
-	ids := make(map[string]struct{}, len(value.AcceptanceCriteria))
-	for _, criterion := range value.AcceptanceCriteria {
-		ids[criterion.ID] = struct{}{}
-	}
-	return ids
-}
-
 func qualityIDs(quality *profile.Quality) []string {
 	if quality == nil {
 		return nil

--- a/internal/supervisor/review_progress_test.go
+++ b/internal/supervisor/review_progress_test.go
@@ -38,7 +38,6 @@ func TestApplyReviewProgressReplacesPassLists(t *testing.T) {
 	if loaded.AcceptanceCriteria[0].Status != "pending" || loaded.AcceptanceCriteria[1].Status != "satisfied" {
 		t.Fatalf("acceptance statuses = %#v", loaded.AcceptanceCriteria)
 	}
-
 }
 
 func TestReconcileReviewProgressResetsWhenReviewContractChanges(t *testing.T) {

--- a/internal/task/archive.go
+++ b/internal/task/archive.go
@@ -75,16 +75,10 @@ func archiveCurrentSchema(path string, loaded Task, opts ArchiveOptions) (Archiv
 		return ArchiveResult{}, fmt.Errorf("task %s has an open PR; close or merge the PR before archiving", loaded.ID)
 	}
 	loaded.Status = StatusArchived
-	appendLifecycleAttempt(&loaded, "archived", opts.Reason, "Task archived.", time.Now())
+	appendLifecycleAttempt(&loaded, lifecycleAttempt{Verdict: "archived", Reason: opts.Reason, Fallback: "Task archived."}, time.Now())
 	nextPath := siblingTaskPath(path, WorkflowStateArchived)
-	if nextPath == path {
-		if err := Save(path, loaded); err != nil {
-			return ArchiveResult{}, err
-		}
-	} else {
-		if err := WriteMovedTask(path, nextPath, loaded); err != nil {
-			return ArchiveResult{}, err
-		}
+	if err := saveOrMoveTask(path, nextPath, loaded, true); err != nil {
+		return ArchiveResult{}, err
 	}
 	return ArchiveResult{Task: loaded, From: path, To: nextPath, Mode: "current_schema"}, nil
 }
@@ -99,18 +93,11 @@ func archiveUnreadable(path string, opts ArchiveOptions, loadErr error) (Archive
 
 	// Try the safe top-level status edit via a yaml.Node round-trip. This
 	// preserves the rest of the YAML document exactly as authored.
-	if updated, ok, editErr := editTopLevelStatus(data, StatusArchived); ok && editErr == nil {
-		if nextPath == path {
-			// In-place lenient edit: overwrite the existing file. Lossy struct
-			// round-tripping is avoided because updated[] came from a YAML
-			// node mutation rather than yaml.Marshal(Task).
-			if err := fileutil.WriteFileAtomic(path, updated, 0o600); err != nil {
-				return ArchiveResult{}, err
-			}
-		} else {
-			if err := moveYAMLNoOverwrite(path, nextPath, updated); err != nil {
-				return ArchiveResult{}, err
-			}
+	// A non-nil editErr marks an editing-unsafe document; both it and a parse
+	// failure fall through to the move-unchanged path.
+	if updated, ok, editErr := editTopLevelStatus(data, string(StatusArchived)); ok && editErr == nil {
+		if err := writeLenientArchive(path, nextPath, updated); err != nil {
+			return ArchiveResult{}, err
 		}
 		summary, _ := lenientHeader(updated)
 		summary.Status = "archived"
@@ -121,11 +108,6 @@ func archiveUnreadable(path string, opts ArchiveOptions, loadErr error) (Archive
 			Mode:    "lenient_status_edit",
 			Warning: fmt.Sprintf("task load failed (%v); archived with safe top-level status edit only", loadErr),
 		}, nil
-	} else if editErr != nil {
-		// editTopLevelStatus reported an editing-unsafe condition (not a YAML
-		// parse error). Fall through to the move-unchanged path so archive
-		// can still evacuate the file from normal scans.
-		_ = editErr
 	}
 
 	// Fall back: move the file unchanged so it leaves normal scans without
@@ -163,6 +145,7 @@ func archiveUnreadable(path string, opts ArchiveOptions, loadErr error) (Archive
 func editTopLevelStatus(data []byte, value string) ([]byte, bool, error) {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
+		//nolint:nilerr // documented contract: unparseable means "move unchanged"
 		return nil, false, nil
 	}
 	var mapping *yaml.Node
@@ -194,7 +177,7 @@ func editTopLevelStatus(data []byte, value string) ([]byte, bool, error) {
 		val.Style = yaml.DoubleQuotedStyle
 		buf, err := yaml.Marshal(&doc)
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("encode task document: %w", err)
 		}
 		return buf, true, nil
 	}
@@ -205,7 +188,7 @@ func editTopLevelStatus(data []byte, value string) ([]byte, bool, error) {
 	mapping.Content = append(mapping.Content, keyNode, valNode)
 	buf, err := yaml.Marshal(&doc)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("encode task document: %w", err)
 	}
 	return buf, true, nil
 }
@@ -217,7 +200,7 @@ func editTopLevelStatus(data []byte, value string) ([]byte, bool, error) {
 func lenientHeader(data []byte) (Task, error) {
 	var t Task
 	if err := yaml.Unmarshal(data, &t); err != nil {
-		return Task{}, err
+		return Task{}, fmt.Errorf("parse task YAML: %w", err)
 	}
 	return t, nil
 }
@@ -241,4 +224,13 @@ func moveYAMLNoOverwrite(src, dst string, data []byte) error {
 		return fmt.Errorf("remove moved task %s: %w", src, err)
 	}
 	return nil
+}
+
+// writeLenientArchive persists a status-edited YAML document, overwriting in
+// place when the destination is unchanged. The bytes come from a node mutation.
+func writeLenientArchive(path, nextPath string, updated []byte) error {
+	if nextPath == path {
+		return fileutil.WriteFileAtomic(path, updated, 0o600)
+	}
+	return moveYAMLNoOverwrite(path, nextPath, updated)
 }

--- a/internal/task/executor_schema_parity_test.go
+++ b/internal/task/executor_schema_parity_test.go
@@ -157,43 +157,69 @@ func runtimeTaskExecutorValid(c executorFieldCase) bool {
 }
 
 func validateTaskExecutorDoc(executor, doc map[string]any) []string {
-	var errs []string
 	props := executor["properties"].(map[string]any)
+	var errs []string
+	errs = append(errs, validateExecutorCLIField(props, doc)...)
+	errs = append(errs, validateExecutorModelField(props, doc)...)
+	errs = append(errs, validateExecutorEffortField(executor, props, doc)...)
+	return errs
+}
 
-	if cli, present := doc["cli"]; present {
-		if !effortEnumContains(props["cli"].(map[string]any)["enum"].([]any), cli) {
-			errs = append(errs, fmt.Sprintf("cli %v not in enum", cli))
-		}
+func validateExecutorCLIField(props, doc map[string]any) []string {
+	cli, present := doc["cli"]
+	if !present {
+		return nil
 	}
-	if model, present := doc["model"]; present {
-		// Model is free-form string; empty is allowed. Only type is constrained.
-		if _, ok := model.(string); !ok {
-			errs = append(errs, fmt.Sprintf("model %v is not a string", model))
-		}
-		if min, ok := props["model"].(map[string]any)["minLength"].(float64); ok {
-			if s, _ := model.(string); len(s) < int(min) {
-				errs = append(errs, fmt.Sprintf("model %q shorter than minLength %v", model, min))
-			}
-		}
+	if effortEnumContains(props["cli"].(map[string]any)["enum"].([]any), cli) {
+		return nil
 	}
-	if effort, present := doc["effort"]; present {
-		if !effortEnumContains(props["effort"].(map[string]any)["enum"].([]any), effort) {
-			errs = append(errs, fmt.Sprintf("effort %v not in base enum", effort))
+	return []string{fmt.Sprintf("cli %v not in enum", cli)}
+}
+
+// validateExecutorModelField checks the free-form model string; empty is
+// allowed, so only the type and minLength are constrained.
+func validateExecutorModelField(props, doc map[string]any) []string {
+	model, present := doc["model"]
+	if !present {
+		return nil
+	}
+	var errs []string
+	if _, ok := model.(string); !ok {
+		errs = append(errs, fmt.Sprintf("model %v is not a string", model))
+	}
+	min, ok := props["model"].(map[string]any)["minLength"].(float64)
+	if !ok {
+		return errs
+	}
+	if s, _ := model.(string); len(s) < int(min) {
+		errs = append(errs, fmt.Sprintf("model %q shorter than minLength %v", model, min))
+	}
+	return errs
+}
+
+func validateExecutorEffortField(executor, props, doc map[string]any) []string {
+	effort, present := doc["effort"]
+	if !present {
+		return nil
+	}
+	var errs []string
+	if !effortEnumContains(props["effort"].(map[string]any)["enum"].([]any), effort) {
+		errs = append(errs, fmt.Sprintf("effort %v not in base enum", effort))
+	}
+	// The provider-conditioned allOf applies only when cli is present and set.
+	cli, _ := doc["cli"].(string)
+	if cli == "" {
+		return errs
+	}
+	for _, raw := range executor["allOf"].([]any) {
+		rule := raw.(map[string]any)
+		ifConst := rule["if"].(map[string]any)["properties"].(map[string]any)["cli"].(map[string]any)["const"].(string)
+		if ifConst != cli {
+			continue
 		}
-		// Apply provider-conditioned allOf when cli is present (including empty).
-		cli, cliPresent := doc["cli"].(string)
-		if cliPresent && cli != "" {
-			for _, raw := range executor["allOf"].([]any) {
-				rule := raw.(map[string]any)
-				ifConst := rule["if"].(map[string]any)["properties"].(map[string]any)["cli"].(map[string]any)["const"].(string)
-				if ifConst != cli {
-					continue
-				}
-				enum := rule["then"].(map[string]any)["properties"].(map[string]any)["effort"].(map[string]any)["enum"].([]any)
-				if !effortEnumContains(enum, effort) {
-					errs = append(errs, fmt.Sprintf("effort %v not accepted for cli %q", effort, cli))
-				}
-			}
+		enum := rule["then"].(map[string]any)["properties"].(map[string]any)["effort"].(map[string]any)["enum"].([]any)
+		if !effortEnumContains(enum, effort) {
+			errs = append(errs, fmt.Sprintf("effort %v not accepted for cli %q", effort, cli))
 		}
 	}
 	return errs

--- a/internal/task/files.go
+++ b/internal/task/files.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 )
@@ -11,7 +12,7 @@ func YAMLFiles(dir string) ([]string, error) {
 	for _, ext := range []string{"*.yaml", "*.yml"} {
 		paths, err := filepath.Glob(filepath.Join(dir, ext))
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("glob %s in %s: %w", ext, dir, err)
 		}
 		matches = append(matches, paths...)
 	}

--- a/internal/task/lifecycle_attempt.go
+++ b/internal/task/lifecycle_attempt.go
@@ -6,7 +6,15 @@ import (
 	"github.com/shinpr/galley/internal/strutil"
 )
 
-func appendLifecycleAttempt(t *Task, verdict, reason, fallback string, now time.Time) {
+// lifecycleAttempt is one non-executor attempt recorded on the task.
+type lifecycleAttempt struct {
+	Verdict  string
+	Reason   string
+	Fallback string
+}
+
+func appendLifecycleAttempt(t *Task, entry lifecycleAttempt, now time.Time) {
+	verdict, reason, fallback := entry.Verdict, entry.Reason, entry.Fallback
 	timestamp := now.UTC().Format(time.RFC3339Nano)
 	t.Attempts = append(t.Attempts, Attempt{
 		Number:            len(t.Attempts) + 1,

--- a/internal/task/lifecycle_attempt_test.go
+++ b/internal/task/lifecycle_attempt_test.go
@@ -9,7 +9,7 @@ func TestAppendLifecycleAttemptRecordsOneInstant(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 25, 10, 11, 12, 13, time.FixedZone("offset", 9*60*60))
 	task := Task{Attempts: []Attempt{{Number: 1}}}
-	appendLifecycleAttempt(&task, "requeued", "", "fallback", now)
+	appendLifecycleAttempt(&task, lifecycleAttempt{Verdict: "requeued", Reason: "", Fallback: "fallback"}, now)
 
 	got := task.Attempts[1]
 	if got.Number != 2 || got.StartedAt != got.CompletedAt {

--- a/internal/task/queue.go
+++ b/internal/task/queue.go
@@ -63,17 +63,11 @@ func queue(path string, opts QueueOptions, readTaskID func(string) (string, erro
 	if err := rejectDuplicateTaskID(path, loaded.ID, opts.Root, readTaskID); err != nil {
 		return QueueResult{}, err
 	}
-	appendLifecycleAttempt(&loaded, "queued", opts.Reason, "Task queued for daemon execution.", time.Now())
+	appendLifecycleAttempt(&loaded, lifecycleAttempt{Verdict: "queued", Reason: opts.Reason, Fallback: "Task queued for daemon execution."}, time.Now())
 	nextPath := queuedPathFor(path, opts.Root)
-	if nextPath == path {
-		if err := Save(path, loaded); err != nil {
-			return QueueResult{}, err
-		}
-	} else {
-		removeSource := opts.MoveSource || taskPathUnderRoot(path, opts.Root)
-		if err := writeQueuedTask(path, nextPath, loaded, removeSource); err != nil {
-			return QueueResult{}, err
-		}
+	removeSource := opts.MoveSource || taskPathUnderRoot(path, opts.Root)
+	if err := saveOrMoveTask(path, nextPath, loaded, removeSource); err != nil {
+		return QueueResult{}, err
 	}
 	return QueueResult{Task: loaded, From: path, To: nextPath}, nil
 }
@@ -85,7 +79,7 @@ func rejectDuplicateTaskID(path, id, root string, readTaskID func(string) (strin
 	}
 	current, err := filepath.Abs(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve task path %s: %w", path, err)
 	}
 	for attempt := 0; attempt < duplicateScanMaxAttempts; attempt++ {
 		duplicatePath, moved, err := scanForDuplicateTaskID(root, current, id, readTaskID)
@@ -116,7 +110,7 @@ func scanForDuplicateTaskID(root, current, id string, readTaskID func(string) (s
 	for _, match := range matches {
 		absMatch, err := filepath.Abs(match)
 		if err != nil {
-			return "", false, err
+			return "", false, fmt.Errorf("resolve task path %s: %w", match, err)
 		}
 		if absMatch == current {
 			continue
@@ -138,12 +132,13 @@ func scanForDuplicateTaskID(root, current, id string, readTaskID func(string) (s
 func taskIDFromFile(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read task file %s: %w", path, err)
 	}
 	var header struct {
 		ID string `yaml:"id"`
 	}
 	if err := yaml.Unmarshal(data, &header); err != nil {
+		//nolint:nilerr // an unparseable file has no ID to report
 		return "", nil
 	}
 	return header.ID, nil

--- a/internal/task/queue_move_race_test.go
+++ b/internal/task/queue_move_race_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // writeTaskFileWithID writes a valid task file at path with the given ID and status.
-func writeTaskFileWithID(t *testing.T, path, id, status string) {
+func writeTaskFileWithID(t *testing.T, path, id string, status Status) {
 	t.Helper()
 	base := writeTaskYAML(t, "loop_budget: 3")
 	loaded, err := Load(base)

--- a/internal/task/queue_test.go
+++ b/internal/task/queue_test.go
@@ -267,9 +267,8 @@ func TestQueueDuplicateTaskIDSkipsMalformedExistingTask(t *testing.T) {
 
 func TestQueueRejectsNonAuthoringStatuses(t *testing.T) {
 	t.Parallel()
-	for _, status := range []string{"ready", "queued", "running", "needs_supervisor_review", "accepted", "pr_opened", "failed"} {
-		status := status
-		t.Run(status, func(t *testing.T) {
+	for _, status := range []Status{"ready", "queued", "running", "needs_supervisor_review", "accepted", "pr_opened", "failed"} {
+		t.Run(string(status), func(t *testing.T) {
 			t.Parallel()
 			path := writeTaskYAML(t, "loop_budget: 3")
 			loaded, err := Load(path)

--- a/internal/task/requeue.go
+++ b/internal/task/requeue.go
@@ -57,17 +57,11 @@ func Requeue(path string, opts RequeueOptions) (RequeueResult, error) {
 			loaded.RevisionRequests = append(loaded.RevisionRequests, request)
 		}
 	}
-	appendLifecycleAttempt(&loaded, "requeued", opts.Reason, "Task requeued for another executor attempt.", time.Now())
+	appendLifecycleAttempt(&loaded, lifecycleAttempt{Verdict: "requeued", Reason: opts.Reason, Fallback: "Task requeued for another executor attempt."}, time.Now())
 
 	nextPath := queuedPathFor(path, opts.Root)
-	if nextPath == path {
-		if err := Save(path, loaded); err != nil {
-			return RequeueResult{}, err
-		}
-	} else {
-		if err := writeQueuedTask(path, nextPath, loaded, taskPathUnderRoot(path, opts.Root)); err != nil {
-			return RequeueResult{}, err
-		}
+	if err := saveOrMoveTask(path, nextPath, loaded, taskPathUnderRoot(path, opts.Root)); err != nil {
+		return RequeueResult{}, err
 	}
 	return RequeueResult{Task: loaded, From: path, To: nextPath}, nil
 }
@@ -86,6 +80,15 @@ func WriteMovedTask(src, dst string, loaded Task) error {
 	return writeQueuedTask(src, dst, loaded, true)
 }
 
+// saveOrMoveTask writes the task in place when the destination is unchanged
+// and otherwise moves it without overwriting an existing file.
+func saveOrMoveTask(src, dst string, loaded Task, removeSource bool) error {
+	if dst == src {
+		return Save(src, loaded)
+	}
+	return writeQueuedTask(src, dst, loaded, removeSource)
+}
+
 func writeQueuedTask(src, dst string, loaded Task, removeSource bool) error {
 	data, err := yaml.Marshal(loaded)
 	if err != nil {
@@ -94,19 +97,20 @@ func writeQueuedTask(src, dst string, loaded Task, removeSource bool) error {
 	if err := fileutil.WriteFileNoOverwriteAtomic(dst, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", dst, err)
 	}
-	if removeSource {
-		if err := os.Remove(src); err != nil {
-			rollbackErr := os.Remove(dst)
-			if rollbackErr != nil {
-				return errors.Join(
-					fmt.Errorf("remove moved task %s: %w", src, err),
-					fmt.Errorf("rollback queued task %s: %w", dst, rollbackErr),
-				)
-			}
-			return fmt.Errorf("remove moved task %s: %w", src, err)
-		}
+	if !removeSource {
+		return nil
 	}
-	return nil
+	err = os.Remove(src)
+	if err == nil {
+		return nil
+	}
+	if rollbackErr := os.Remove(dst); rollbackErr != nil {
+		return errors.Join(
+			fmt.Errorf("remove moved task %s: %w", src, err),
+			fmt.Errorf("rollback queued task %s: %w", dst, rollbackErr),
+		)
+	}
+	return fmt.Errorf("remove moved task %s: %w", src, err)
 }
 
 func containsString(values []string, want string) bool {

--- a/internal/task/schema.go
+++ b/internal/task/schema.go
@@ -3,6 +3,7 @@ package task
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 
 	"github.com/shinpr/galley/internal/provider"
 )
@@ -21,7 +22,7 @@ func TaskJSONSchema() ([]byte, error) {
 	schema["properties"] = map[string]any{
 		"id":                  stringSchema("pattern", validTaskIDPattern.String()),
 		"mode":                enumSchema(validModes),
-		"status":              enumSchema(validStatuses),
+		"status":              enumSchema(statusStrings(validStatuses)),
 		"goal":                stringSchema("minLength", 1),
 		"acceptance_criteria": arraySchema(acceptanceCriterionSchema(), "minItems", 1),
 		"files":               arraySchema(inputFileSchema()),
@@ -46,7 +47,7 @@ func TaskJSONSchema() ([]byte, error) {
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(schema); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode task schema: %w", err)
 	}
 	return buf.Bytes(), nil
 }
@@ -353,4 +354,12 @@ func applyKV(m map[string]any, kv ...any) {
 			m[key] = kv[i+1]
 		}
 	}
+}
+
+func statusStrings(values []Status) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, string(v))
+	}
+	return out
 }

--- a/internal/task/status.go
+++ b/internal/task/status.go
@@ -7,17 +7,21 @@ import (
 	"github.com/shinpr/galley/internal/provider"
 )
 
+// Status is a Galley-owned task status, distinct from the status an executor
+// reports, so the two vocabularies cannot be assigned to each other.
+type Status string
+
 const (
-	StatusDraft                 = "draft"
-	StatusQueued                = "queued"
-	StatusRunning               = "running"
-	StatusFailed                = "failed"
-	StatusNeedsSupervisorReview = "needs_supervisor_review"
-	StatusAccepted              = "accepted"
-	StatusPROpened              = "pr_opened"
-	StatusMerged                = "merged"
-	StatusClosed                = "closed"
-	StatusArchived              = "archived"
+	StatusDraft                 Status = "draft"
+	StatusQueued                Status = "queued"
+	StatusRunning               Status = "running"
+	StatusFailed                Status = "failed"
+	StatusNeedsSupervisorReview Status = "needs_supervisor_review"
+	StatusAccepted              Status = "accepted"
+	StatusPROpened              Status = "pr_opened"
+	StatusMerged                Status = "merged"
+	StatusClosed                Status = "closed"
+	StatusArchived              Status = "archived"
 )
 
 type WorkflowState string
@@ -31,7 +35,7 @@ const (
 	WorkflowStateArchived WorkflowState = "archived"
 )
 
-var allStatuses = []string{
+var allStatuses = []Status{
 	StatusDraft, StatusQueued, StatusRunning, StatusNeedsSupervisorReview,
 	StatusAccepted, StatusPROpened, StatusFailed, StatusClosed, StatusMerged, StatusArchived,
 }
@@ -41,15 +45,15 @@ var allWorkflowStates = []WorkflowState{
 	WorkflowStateDone, WorkflowStateFailed, WorkflowStateArchived,
 }
 
-func AllStatuses() []string {
-	return append([]string(nil), allStatuses...)
+func AllStatuses() []Status {
+	return append([]Status(nil), allStatuses...)
 }
 
 func AllWorkflowStates() []WorkflowState {
 	return append([]WorkflowState(nil), allWorkflowStates...)
 }
 
-func WorkflowStateForStatus(status string) (WorkflowState, error) {
+func WorkflowStateForStatus(status Status) (WorkflowState, error) {
 	switch status {
 	case StatusDraft:
 		return WorkflowStateDraft, nil
@@ -70,7 +74,7 @@ func WorkflowStateForStatus(status string) (WorkflowState, error) {
 
 // WorkflowStateForTransition resolves directory-ahead transitions whose file
 // move intentionally precedes the persisted status update.
-func WorkflowStateForTransition(from, to string) (WorkflowState, error) {
+func WorkflowStateForTransition(from, to Status) (WorkflowState, error) {
 	if from != StatusQueued || to != StatusRunning {
 		return "", fmt.Errorf("unsupported directory-ahead task transition %q -> %q", from, to)
 	}
@@ -85,23 +89,31 @@ func TaskStatePath(root string, state WorkflowState, name string) string {
 	return filepath.Join(TaskStateDir(root, state), name)
 }
 
-func CanQueue(status string) bool {
+func CanQueue(status Status) bool {
 	return status == StatusDraft
 }
 
-func CanArchive(status string) bool {
+// CanArchive reports whether a task has settled enough to archive; draft,
+// queued, and running are still live and archived is already there.
+func CanArchive(status Status) bool {
 	switch status {
 	case StatusAccepted, StatusPROpened, StatusFailed, StatusNeedsSupervisorReview, StatusMerged, StatusClosed:
 		return true
+	case StatusDraft, StatusQueued, StatusRunning, StatusArchived:
+		return false
 	default:
 		return false
 	}
 }
 
-func IsAcceptedTerminal(status string) bool {
+// IsAcceptedTerminal reports whether the supervisor accepted the work, so a
+// prior failed attempt is history rather than the active state.
+func IsAcceptedTerminal(status Status) bool {
 	switch status {
 	case StatusAccepted, StatusPROpened, StatusClosed, StatusMerged:
 		return true
+	case StatusDraft, StatusQueued, StatusRunning, StatusFailed, StatusNeedsSupervisorReview, StatusArchived:
+		return false
 	default:
 		return false
 	}

--- a/internal/task/status_contract_test.go
+++ b/internal/task/status_contract_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -14,7 +15,7 @@ import (
 
 func TestWorkflowStateForStatus(t *testing.T) {
 	t.Parallel()
-	tests := map[string]WorkflowState{
+	tests := map[Status]WorkflowState{
 		StatusDraft: WorkflowStateDraft, StatusQueued: WorkflowStateQueued,
 		StatusRunning: WorkflowStateRunning, StatusAccepted: WorkflowStateDone,
 		StatusPROpened: WorkflowStateDone, StatusMerged: WorkflowStateDone,
@@ -34,7 +35,7 @@ func TestWorkflowStateForStatus(t *testing.T) {
 
 func TestCanonicalListsAreStableDefensiveCopies(t *testing.T) {
 	statuses := AllStatuses()
-	wantStatuses := []string{"draft", "queued", "running", "needs_supervisor_review", "accepted", "pr_opened", "failed", "closed", "merged", "archived"}
+	wantStatuses := []Status{"draft", "queued", "running", "needs_supervisor_review", "accepted", "pr_opened", "failed", "closed", "merged", "archived"}
 	if !reflect.DeepEqual(statuses, wantStatuses) {
 		t.Fatalf("statuses = %v; want %v", statuses, wantStatuses)
 	}
@@ -79,7 +80,7 @@ func TestProductionTaskPathsUseWorkflowStateContract(t *testing.T) {
 		}
 		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse %s: %w", path, err)
 		}
 		ast.Inspect(file, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -11,7 +11,7 @@ import (
 type Task struct {
 	ID                 string                `yaml:"id" json:"id"`
 	Mode               string                `yaml:"mode" json:"mode"`
-	Status             string                `yaml:"status" json:"status"`
+	Status             Status                `yaml:"status" json:"status"`
 	Goal               string                `yaml:"goal" json:"goal"`
 	AcceptanceCriteria []AcceptanceCriterion `yaml:"acceptance_criteria" json:"acceptance_criteria"`
 	Files              []InputFile           `yaml:"files,omitempty" json:"files,omitempty"`
@@ -85,7 +85,9 @@ type AcceptanceCriterion struct {
 	ID           string `yaml:"id" json:"id"`
 	Text         string `yaml:"text" json:"text"`
 	Verification string `yaml:"verification" json:"verification"`
-	Status       string `yaml:"status" json:"status"`
+	// Status is the executor-reported acceptance vocabulary
+	// (satisfied/partially_satisfied/not_satisfied), not a task lifecycle Status.
+	Status string `yaml:"status" json:"status"`
 }
 
 // Scope constrains where and how a task may operate.
@@ -115,7 +117,11 @@ func (b LoopBudget) MarshalJSON() ([]byte, error) {
 	if !b.Set {
 		count = DefaultLoopBudget
 	}
-	return json.Marshal(count)
+	data, err := json.Marshal(count)
+	if err != nil {
+		return nil, fmt.Errorf("encode loop budget: %w", err)
+	}
+	return data, nil
 }
 
 // UnmarshalJSON accepts the integer shape emitted by MarshalJSON.
@@ -140,7 +146,7 @@ func (b *LoopBudget) UnmarshalYAML(value *yaml.Node) error {
 	}
 	var count int
 	if err := value.Decode(&count); err != nil {
-		return err
+		return fmt.Errorf("decode loop budget: %w", err)
 	}
 	b.Count = count
 	return nil
@@ -217,8 +223,10 @@ type RevisionRequest struct {
 	Source    string `yaml:"source" json:"source"`
 	CommentID string `yaml:"comment_id,omitempty" json:"comment_id,omitempty"`
 	Text      string `yaml:"text" json:"text"`
-	Status    string `yaml:"status" json:"status"`
-	Evidence  string `yaml:"evidence,omitempty" json:"evidence,omitempty"`
+	// Status is the revision-request vocabulary (pending/addressed), not a task
+	// lifecycle Status.
+	Status   string `yaml:"status" json:"status"`
+	Evidence string `yaml:"evidence,omitempty" json:"evidence,omitempty"`
 }
 
 // ReviewProgress is daemon-owned state for supervisor checks that remain

--- a/internal/task/validate.go
+++ b/internal/task/validate.go
@@ -95,7 +95,7 @@ func ValidateStructural(t Task) ValidationResult {
 		require(&result, validTaskIDPattern.MatchString(t.ID), "id must contain only letters, numbers, dot, underscore, and dash")
 	}
 	require(&result, slices.Contains(validModes, t.Mode), "mode must be one of: %s", strings.Join(validModes, ", "))
-	require(&result, slices.Contains(validStatuses, t.Status), "status must be one of: %s", strings.Join(validStatuses, ", "))
+	require(&result, slices.Contains(validStatuses, t.Status), "status must be one of: %s", strings.Join(statusStrings(validStatuses), ", "))
 	require(&result, t.Goal != "", "goal is required")
 
 	validateAcceptance(&result, t)
@@ -335,17 +335,7 @@ func validatePreflightOutputs(result *ValidationResult, t Task, cfg *AcceptanceS
 		require(result, out.Purpose != "", "%s.purpose is required", field)
 		if out.Path != "" {
 			validateRelativePath(result, field+".path", out.Path)
-			if !filepath.IsAbs(out.Path) {
-				clean := normalizeLogicalPath(out.Path)
-				if !logicalPathEscapes(clean) {
-					if !pathAllowedByScope(out.Path, t.Scope.AllowedPaths) {
-						result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must be inside scope.allowed_paths", field, out.Path))
-					}
-					if pathForbiddenByScope(out.Path, t.Scope.ForbiddenPaths) {
-						result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must not be inside scope.forbidden_paths", field, out.Path))
-					}
-				}
-			}
+			validateOutputPathScope(result, t.Scope, field, out.Path)
 		}
 	}
 }
@@ -385,4 +375,18 @@ func require(result *ValidationResult, ok bool, format string, args ...any) {
 		return
 	}
 	result.Errors = append(result.Errors, fmt.Sprintf(format, args...))
+}
+
+// validateOutputPathScope checks a relative, non-escaping path against the task
+// scope; validateRelativePath already reports absolute and escaping paths.
+func validateOutputPathScope(result *ValidationResult, scope Scope, field, path string) {
+	if filepath.IsAbs(path) || logicalPathEscapes(normalizeLogicalPath(path)) {
+		return
+	}
+	if !pathAllowedByScope(path, scope.AllowedPaths) {
+		result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must be inside scope.allowed_paths", field, path))
+	}
+	if pathForbiddenByScope(path, scope.ForbiddenPaths) {
+		result.Errors = append(result.Errors, fmt.Sprintf("%s.path %q must not be inside scope.forbidden_paths", field, path))
+	}
 }

--- a/internal/task/workorder.go
+++ b/internal/task/workorder.go
@@ -90,18 +90,9 @@ func renderRevisionContext(b *strings.Builder, t Task, requests []RevisionReques
 	}
 	fmt.Fprintf(b, "\nReturn each request as one `acceptance_criteria` entry with the displayed `revision:<id>`, status, evidence, and notes. A supervisor request is satisfied by a supported correction or evidence-backed withdrawal; explain which in notes for independent supervisor review. Human requests still require fulfillment of the amended contract, and finalize requests remain subject to Galley's finalization result. Group repairs by shared cause while preserving evidence for each request ID; report unresolved obligations accurately.\n\n")
 
-	if t.ReviewProgress != nil && (len(t.ReviewProgress.Acceptance) > 0 || len(t.ReviewProgress.Quality) > 0) {
-		fmt.Fprintf(b, "## Verified Passes To Preserve\n\n")
-		fmt.Fprintf(b, "The supervisor has already verified these items. Preserve them and recheck any item this attempt can affect.\n\n")
-		if len(t.ReviewProgress.Acceptance) > 0 {
-			fmt.Fprintf(b, "- acceptance: `%s`\n", strings.Join(t.ReviewProgress.Acceptance, "`, `"))
-		}
-		if len(t.ReviewProgress.Quality) > 0 {
-			fmt.Fprintf(b, "- quality: `%s`\n", strings.Join(t.ReviewProgress.Quality, "`, `"))
-		}
-		fmt.Fprintf(b, "\n")
-	}
+	writeVerifiedPasses(b, t.ReviewProgress)
 }
+
 func renderInputFiles(b *strings.Builder, t Task) {
 	if len(t.Files) == 0 {
 		return
@@ -132,19 +123,7 @@ func renderReviewContext(b *strings.Builder, t Task, includeRequeueInstructions 
 		otherRisks = append(otherRisks, risk)
 	}
 	if t.PR.URL != "" || (includeRequeueInstructions && len(requeueInstructions) > 0) {
-		fmt.Fprintf(b, "## PR Review Context\n\n")
-		if t.PR.URL != "" {
-			fmt.Fprintf(b, "- PR: `%s`\n", t.PR.URL)
-		}
-		if t.Supervisor.ReviewIterations > 0 {
-			fmt.Fprintf(b, "- review iteration: `%d`\n", t.Supervisor.ReviewIterations)
-		}
-		if includeRequeueInstructions {
-			for _, instruction := range requeueInstructions {
-				fmt.Fprintf(b, "- additional instruction `%s`: %s\n", instruction.ID, instruction.Detail)
-			}
-		}
-		fmt.Fprintf(b, "\n")
+		writePRReviewContext(b, t, requeueInstructions, includeRequeueInstructions)
 	}
 	if len(otherRisks) > 0 {
 		fmt.Fprintf(b, "## Existing Risks\n\n")
@@ -216,4 +195,37 @@ func renderProfileContext(b *strings.Builder, profiles profile.Bundle) {
 		fmt.Fprintf(b, "- secrets policy: `%s`\n", profiles.Environment.Constraints.SecretsPolicy)
 		fmt.Fprintf(b, "- destructive commands: `%s`\n", profiles.Environment.Constraints.DestructiveCommands)
 	}
+}
+
+// writeVerifiedPasses lists the items the supervisor already verified so the
+// next attempt preserves them.
+func writeVerifiedPasses(b *strings.Builder, progress *ReviewProgress) {
+	if progress == nil || (len(progress.Acceptance) == 0 && len(progress.Quality) == 0) {
+		return
+	}
+	fmt.Fprintf(b, "## Verified Passes To Preserve\n\n")
+	fmt.Fprintf(b, "The supervisor has already verified these items. Preserve them and recheck any item this attempt can affect.\n\n")
+	if len(progress.Acceptance) > 0 {
+		fmt.Fprintf(b, "- acceptance: `%s`\n", strings.Join(progress.Acceptance, "`, `"))
+	}
+	if len(progress.Quality) > 0 {
+		fmt.Fprintf(b, "- quality: `%s`\n", strings.Join(progress.Quality, "`, `"))
+	}
+	fmt.Fprintf(b, "\n")
+}
+
+func writePRReviewContext(b *strings.Builder, t Task, requeueInstructions []Risk, includeRequeueInstructions bool) {
+	fmt.Fprintf(b, "## PR Review Context\n\n")
+	if t.PR.URL != "" {
+		fmt.Fprintf(b, "- PR: `%s`\n", t.PR.URL)
+	}
+	if t.Supervisor.ReviewIterations > 0 {
+		fmt.Fprintf(b, "- review iteration: `%d`\n", t.Supervisor.ReviewIterations)
+	}
+	if includeRequeueInstructions {
+		for _, instruction := range requeueInstructions {
+			fmt.Fprintf(b, "- additional instruction `%s`: %s\n", instruction.ID, instruction.Detail)
+		}
+	}
+	fmt.Fprintf(b, "\n")
 }

--- a/internal/taskstate/state.go
+++ b/internal/taskstate/state.go
@@ -18,7 +18,7 @@ func moveToWorkflowState(root, currentPath string, state task.WorkflowState, upd
 			return err
 		}
 	}
-	if err := os.MkdirAll(filepath.Dir(nextPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(nextPath), 0o700); err != nil {
 		return fmt.Errorf("create task state dir %s: %w", filepath.Dir(nextPath), err)
 	}
 	if err := renameNoOverwrite(currentPath, nextPath); err != nil {
@@ -73,7 +73,7 @@ func RecoverUnreadableClaimToFailed(root, runningPath string, primary error) err
 func QuarantineUnreadableClaim(root, runningPath string, primary error) error {
 	failed := task.TaskStatePath(root, task.WorkflowStateFailed, filepath.Base(runningPath))
 	if err := os.MkdirAll(filepath.Dir(failed), 0o700); err != nil {
-		return err
+		return fmt.Errorf("create failed state dir %s: %w", filepath.Dir(failed), err)
 	}
 	return fileutil.WithExclusiveMarker(runningPath+".lock", func() error {
 		for suffix := 0; ; suffix++ {
@@ -85,7 +85,7 @@ func QuarantineUnreadableClaim(root, runningPath string, primary error) error {
 				if _, err := os.Lstat(candidate); err == nil {
 					return os.ErrExist
 				} else if !errors.Is(err, os.ErrNotExist) {
-					return err
+					return fmt.Errorf("stat task state destination: %w", err)
 				}
 				if err := jsonio.Write(candidate+".error.json", map[string]string{"source": runningPath, "error": fmt.Sprint(primary)}); err != nil {
 					return err

--- a/internal/taskstate/state_test.go
+++ b/internal/taskstate/state_test.go
@@ -100,7 +100,7 @@ func TestFailMovePreservesReviewStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := moved.Status, "needs_supervisor_review"; got != want {
+	if got, want := moved.Status, task.Status("needs_supervisor_review"); got != want {
 		t.Fatalf("status got %q, want %q", got, want)
 	}
 }
@@ -128,7 +128,7 @@ func TestFailMoveDefaultsRunningStatusToFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := moved.Status, "failed"; got != want {
+	if got, want := moved.Status, task.Status("failed"); got != want {
 		t.Fatalf("status got %q, want %q", got, want)
 	}
 }

--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -3,6 +3,7 @@
 package updatecheck
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -52,7 +53,7 @@ type latestRelease struct {
 
 // Run performs one advisory update check. It never reports an error and never
 // writes anywhere except the state file and the configured stderr writer.
-func Run(opts Options) {
+func Run(ctx context.Context, opts Options) {
 	isTTY := opts.IsTTY
 	if isTTY == nil {
 		isTTY = stderrIsTTY
@@ -76,7 +77,7 @@ func Run(opts Options) {
 	if err := writeState(root, now()); err != nil {
 		return
 	}
-	tag, ok := fetchLatestTag(opts)
+	tag, ok := fetchLatestTag(ctx, opts)
 	if !ok {
 		return
 	}
@@ -91,6 +92,7 @@ func Run(opts Options) {
 	if stderr == nil {
 		stderr = os.Stderr
 	}
+	//nolint:errcheck // stderr is the configured advisory stream; it cannot report its own write failure
 	fmt.Fprintf(stderr, "galley update available: %s -> %s\n", current, tag)
 }
 
@@ -107,10 +109,11 @@ func fileIsTerminal(f *os.File) bool {
 func readState(root string, now time.Time) (fresh bool, err error) {
 	data, err := os.ReadFile(filepath.Join(root, stateFileName))
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("read update-check state: %w", err)
 	}
 	var s state
 	if err := json.Unmarshal(data, &s); err != nil {
+		//nolint:nilerr // a corrupt state file is simply not fresh
 		return false, nil
 	}
 	// A future-dated record (negative age, e.g. after a clock rollback) is not
@@ -123,16 +126,19 @@ func writeState(root string, now time.Time) error {
 	// A newly created root is owner-only like other Galley root creators;
 	// MkdirAll leaves an existing root's permissions untouched.
 	if err := os.MkdirAll(root, 0o700); err != nil {
-		return err
+		return fmt.Errorf("create galley root %s: %w", root, err)
 	}
 	data, err := json.Marshal(state{LastAttempt: now.UTC()})
 	if err != nil {
-		return err
+		return fmt.Errorf("encode update-check state: %w", err)
 	}
-	return os.WriteFile(filepath.Join(root, stateFileName), data, 0o600)
+	if err := os.WriteFile(filepath.Join(root, stateFileName), data, 0o600); err != nil {
+		return fmt.Errorf("write update-check state: %w", err)
+	}
+	return nil
 }
 
-func fetchLatestTag(opts Options) (string, bool) {
+func fetchLatestTag(ctx context.Context, opts Options) (string, bool) {
 	do := opts.Do
 	if do == nil {
 		client := &http.Client{Timeout: Timeout}
@@ -142,7 +148,7 @@ func fetchLatestTag(opts Options) (string, bool) {
 	if endpoint == "" {
 		endpoint = Endpoint
 	}
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", false
 	}
@@ -151,7 +157,7 @@ func fetchLatestTag(opts Options) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", false
 	}

--- a/internal/updatecheck/updatecheck_posix_test.go
+++ b/internal/updatecheck/updatecheck_posix_test.go
@@ -15,18 +15,18 @@ func TestFileIsTerminalRejectsRedirectedDescriptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open %s: %v", os.DevNull, err)
 	}
-	defer devNull.Close()
+	defer func() { _ = devNull.Close() }()
 	regular, err := os.CreateTemp(t.TempDir(), "stderr")
 	if err != nil {
 		t.Fatalf("create regular file: %v", err)
 	}
-	defer regular.Close()
+	defer func() { _ = regular.Close() }()
 	pipeR, pipeW, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("create pipe: %v", err)
 	}
-	defer pipeR.Close()
-	defer pipeW.Close()
+	defer func() { _ = pipeR.Close() }()
+	defer func() { _ = pipeW.Close() }()
 
 	for name, f := range map[string]*os.File{
 		"null device":  devNull,
@@ -41,7 +41,7 @@ func TestFileIsTerminalRejectsRedirectedDescriptors(t *testing.T) {
 
 	// When the test process has a controlling terminal, it must stay eligible.
 	if tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0); err == nil {
-		defer tty.Close()
+		defer func() { _ = tty.Close() }()
 		if !fileIsTerminal(tty) {
 			t.Fatal("controlling terminal reported as non-TTY")
 		}
@@ -54,16 +54,16 @@ func TestRedirectedStderrMakesNoRequestAndNoState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open %s: %v", os.DevNull, err)
 	}
-	defer devNull.Close()
+	defer func() { _ = devNull.Close() }()
 
 	root := filepath.Join(t.TempDir(), "root")
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	opts := baseOptions(root, transport)
 	opts.IsTTY = func() bool { return fileIsTerminal(devNull) }
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if transport.calls != 0 {
 		t.Fatalf("redirected stderr made %d requests", transport.calls)
@@ -76,12 +76,12 @@ func TestRedirectedStderrMakesNoRequestAndNoState(t *testing.T) {
 func TestWriteStateCreatesOwnerOnlyRoot(t *testing.T) {
 	t.Parallel()
 	root := filepath.Join(t.TempDir(), "galley-root")
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	opts := baseOptions(root, transport)
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if transport.calls != 1 {
 		t.Fatalf("first start made %d requests, want 1", transport.calls)

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -65,13 +65,13 @@ func readAttemptTime(t *testing.T, root string) time.Time {
 func TestNonTTYSkipsRequestAndState(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	opts := baseOptions(root, transport)
 	opts.IsTTY = func() bool { return false }
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if transport.calls != 0 {
 		t.Fatalf("non-TTY run made %d requests", transport.calls)
@@ -84,12 +84,12 @@ func TestNonTTYSkipsRequestAndState(t *testing.T) {
 func TestStaleOrAbsentRecordChecksOnceThenSuppresses(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	opts := baseOptions(root, transport)
 
-	Run(opts)
+	Run(t.Context(), opts)
 	if transport.calls != 1 {
 		t.Fatalf("first start made %d requests, want 1", transport.calls)
 	}
@@ -103,7 +103,7 @@ func TestStaleOrAbsentRecordChecksOnceThenSuppresses(t *testing.T) {
 		}
 	}
 
-	Run(opts)
+	Run(t.Context(), opts)
 	if transport.calls != 1 {
 		t.Fatalf("fresh record start made %d requests, want 1 total", transport.calls)
 	}
@@ -119,11 +119,11 @@ func TestStaleRecordTriggersNewAttempt(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, stateFileName), stale, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 
-	Run(baseOptions(root, transport))
+	Run(t.Context(), baseOptions(root, transport))
 
 	if transport.calls != 1 {
 		t.Fatalf("stale record start made %d requests, want 1", transport.calls)
@@ -158,11 +158,11 @@ func TestRecordAgeBoundaries(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(root, stateFileName), data, 0o600); err != nil {
 				t.Fatal(err)
 			}
-			transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 				return releaseResponse(t, "v0.13.0"), nil
 			}}
 
-			Run(baseOptions(root, transport))
+			Run(t.Context(), baseOptions(root, transport))
 
 			if transport.calls != tc.wantCalls {
 				t.Fatalf("age %v: made %d requests, want %d", tc.age, transport.calls, tc.wantCalls)
@@ -177,12 +177,12 @@ func TestRecordAgeBoundaries(t *testing.T) {
 func TestFailedRequestStillRecordsAttempt(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return nil, errors.New("network down")
 	}}
 	opts := baseOptions(root, transport)
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if transport.calls != 1 {
 		t.Fatalf("failing start made %d requests, want 1", transport.calls)
@@ -194,7 +194,7 @@ func TestFailedRequestStillRecordsAttempt(t *testing.T) {
 		t.Fatalf("failed request leaked stderr output: %q", stderr)
 	}
 
-	Run(opts)
+	Run(t.Context(), opts)
 	if transport.calls != 1 {
 		t.Fatalf("failed attempt did not rate-limit: %d requests", transport.calls)
 	}
@@ -206,12 +206,12 @@ func TestUnpersistableStateSkipsRequest(t *testing.T) {
 	if err := os.WriteFile(blockingFile, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	opts := baseOptions(filepath.Join(blockingFile, "root"), transport)
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if transport.calls != 0 {
 		t.Fatalf("unpersistable state still made %d requests", transport.calls)
@@ -221,13 +221,13 @@ func TestUnpersistableStateSkipsRequest(t *testing.T) {
 func TestHTTPAndResponseFailuresStaySilent(t *testing.T) {
 	t.Parallel()
 	cases := map[string]func(*http.Request) (*http.Response, error){
-		"request error": func(req *http.Request) (*http.Response, error) {
+		"request error": func(_ *http.Request) (*http.Response, error) {
 			return nil, errors.New("timeout")
 		},
-		"non-200 status": func(req *http.Request) (*http.Response, error) {
+		"non-200 status": func(_ *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
 		},
-		"invalid JSON": func(req *http.Request) (*http.Response, error) {
+		"invalid JSON": func(_ *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("not json")), Header: make(http.Header)}, nil
 		},
 	}
@@ -239,7 +239,7 @@ func TestHTTPAndResponseFailuresStaySilent(t *testing.T) {
 			transport := &fakeTransport{handler: handler}
 			opts := baseOptions(root, transport)
 
-			Run(opts)
+			Run(t.Context(), opts)
 
 			if transport.calls != 1 {
 				t.Fatalf("made %d requests, want 1", transport.calls)
@@ -281,13 +281,13 @@ func TestVersionMatrixNoticeOnlyForNewerStable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()
-			transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+			transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 				return releaseResponse(t, tc.latest), nil
 			}}
 			opts := baseOptions(root, transport)
 			opts.CurrentVersion = tc.current
 
-			Run(opts)
+			Run(t.Context(), opts)
 
 			stderr := opts.Stderr.(*bytes.Buffer).String()
 			if tc.notice && stderr == "" {
@@ -303,14 +303,14 @@ func TestVersionMatrixNoticeOnlyForNewerStable(t *testing.T) {
 func TestNoticeIsConciseAndMachineRecognizable(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	transport := &fakeTransport{handler: func(req *http.Request) (*http.Response, error) {
+	transport := &fakeTransport{handler: func(_ *http.Request) (*http.Response, error) {
 		return releaseResponse(t, "v0.13.0"), nil
 	}}
 	var stderr bytes.Buffer
 	opts := baseOptions(root, transport)
 	opts.Stderr = &stderr
 
-	Run(opts)
+	Run(t.Context(), opts)
 
 	if got, want := stderr.String(), "galley update available: 0.12.0 -> v0.13.0\n"; got != want {
 		t.Fatalf("notice got %q, want %q", got, want)

--- a/internal/vcs/status_complete_test.go
+++ b/internal/vcs/status_complete_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestStatusPorcelainZRetainsAllPaths(t *testing.T) {
 	repo := t.TempDir()
-	if out, err := exec.Command("git", "init", repo).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(t.Context(), "git", "init", repo).CombinedOutput(); err != nil {
 		t.Fatalf("%s: %v", out, err)
 	}
 	const count = 16000
@@ -23,20 +23,20 @@ func TestStatusPorcelainZRetainsAllPaths(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	status, err := StatusPorcelainZ(t.Context(), Binaries{}, repo)
+	status, err := StatusPorcelainZ(t.Context(), Repo{WorkDir: repo})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if n := strings.Count(status, "\x00"); n != count {
 		t.Fatalf("got %d of %d paths", n, count)
 	}
-	if err := StagePathsForReview(t.Context(), Binaries{}, repo, t.TempDir(), paths); err != nil {
+	if err := StagePathsForReview(t.Context(), Repo{WorkDir: repo, RunDir: t.TempDir()}, paths); err != nil {
 		t.Fatal(err)
 	}
-	if err := AddPaths(t.Context(), Binaries{}, repo, t.TempDir(), paths); err != nil {
+	if err := AddPaths(t.Context(), Repo{WorkDir: repo, RunDir: t.TempDir()}, paths); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("git", "diff", "--cached", "--name-only", "-z")
+	cmd := exec.CommandContext(t.Context(), "git", "diff", "--cached", "--name-only", "-z")
 	cmd.Dir = repo
 	staged, err := cmd.Output()
 	if err != nil {

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -42,6 +42,37 @@ type Binaries struct {
 	GH  string
 }
 
+// Repo names the working tree a git or gh command runs in, its binaries, and
+// the run directory for evidence. RunDir is empty when no evidence is written.
+type Repo struct {
+	Bins    Binaries
+	WorkDir string
+	RunDir  string
+}
+
+// PullRequestSpec is the content of the pull request Galley opens.
+type PullRequestSpec struct {
+	Title    string
+	BodyPath string
+	Base     string
+}
+
+// ghAPIRequest is one `gh api` call: the API path, the label used in error and
+// evidence text, and any extra gh arguments.
+type ghAPIRequest struct {
+	Path      string
+	Label     string
+	ExtraArgs []string
+}
+
+// commandEvidence names where a command's evidence files land and how its
+// failure is described.
+type commandEvidence struct {
+	RunDir  string
+	Label   string
+	Failure string
+}
+
 func (b Binaries) git() string {
 	if b.Git != "" {
 		return b.Git
@@ -57,11 +88,11 @@ func (b Binaries) gh() string {
 }
 
 // AddPaths stages literal worktree paths, using stdin on Windows and for large sets.
-func AddPaths(ctx context.Context, bins Binaries, workDir, runDir string, paths []string) error {
-	return addPathsForOS(ctx, bins, workDir, runDir, paths, runtime.GOOS)
+func AddPaths(ctx context.Context, repo Repo, paths []string) error {
+	return addPathsForOS(ctx, repo, paths, runtime.GOOS)
 }
 
-func addPathsForOS(ctx context.Context, bins Binaries, workDir, runDir string, paths []string, goos string) error {
+func addPathsForOS(ctx context.Context, repo Repo, paths []string, goos string) error {
 	stagePaths := make([]string, 0, len(paths))
 	seen := make(map[string]bool, len(paths))
 	for _, path := range paths {
@@ -76,15 +107,15 @@ func addPathsForOS(ctx context.Context, bins Binaries, workDir, runDir string, p
 		return fmt.Errorf("git add paths is empty")
 	}
 	pathspecs := literalPathspecs(stagePaths)
-	cmd := proc.Command{WorkDir: workDir}
+	cmd := proc.Command{WorkDir: repo.WorkDir}
 	if goos == "windows" || len(strings.Join(pathspecs, "\x00")) > 32*1024 {
 		// Bound argv on every OS and preserve literal filename bytes via NUL separators.
-		cmd.Argv = proc.GitArgs(bins.git(), "add", "-A", "--pathspec-from-file=-", "--pathspec-file-nul")
+		cmd.Argv = proc.GitArgs(repo.Bins.git(), "add", "-A", "--pathspec-from-file=-", "--pathspec-file-nul")
 		cmd.Stdin = strings.Join(pathspecs, "\x00") + "\x00"
 	} else {
-		cmd.Argv = proc.GitArgs(bins.git(), append([]string{"add", "-A", "--"}, pathspecs...)...)
+		cmd.Argv = proc.GitArgs(repo.Bins.git(), append([]string{"add", "-A", "--"}, pathspecs...)...)
 	}
-	_, err := runCommandWithEvidence(ctx, cmd, runDir, "git_add", "git add failed")
+	_, err := runCommandWithEvidence(ctx, cmd, commandEvidence{RunDir: repo.RunDir, Label: "git_add", Failure: "git add failed"})
 	return err
 }
 
@@ -103,10 +134,10 @@ func addPathsForOS(ctx context.Context, bins Binaries, workDir, runDir string, p
 // directory and leak the context-only input into the supervisor diff. The
 // `all` mode emits one entry per untracked file, which is the resolution
 // the reviewable-path-set contract requires.
-func StatusPorcelainZ(ctx context.Context, bins Binaries, workDir string) (string, error) {
+func StatusPorcelainZ(ctx context.Context, repo Repo) (string, error) {
 	result, err := proc.RunVCSCommand(ctx, proc.Command{
-		WorkDir: workDir,
-		Argv:    proc.GitArgs(bins.git(), "status", "--porcelain=v1", "-z", "--untracked-files=all"),
+		WorkDir: repo.WorkDir,
+		Argv:    proc.GitArgs(repo.Bins.git(), "status", "--porcelain=v1", "-z", "--untracked-files=all"),
 	}, proc.RunOptions{TailBytes: -1})
 	if err != nil {
 		return "", fmt.Errorf("git status --porcelain -z (review staging discovery) failed: %w", err)
@@ -116,11 +147,11 @@ func StatusPorcelainZ(ctx context.Context, bins Binaries, workDir string) (strin
 
 // StagePathsForReview stages only literal executor-produced paths and records
 // skipped or completed staging evidence for the supervisor.
-func StagePathsForReview(ctx context.Context, bins Binaries, workDir, runDir string, paths []string) error {
-	return stagePathsForReviewForOS(ctx, bins, workDir, runDir, paths, runtime.GOOS)
+func StagePathsForReview(ctx context.Context, repo Repo, paths []string) error {
+	return stagePathsForReviewForOS(ctx, repo, paths, runtime.GOOS)
 }
 
-func stagePathsForReviewForOS(ctx context.Context, bins Binaries, workDir, runDir string, paths []string, goos string) error {
+func stagePathsForReviewForOS(ctx context.Context, repo Repo, paths []string, goos string) error {
 	stagePaths := dedupeReviewPaths(paths)
 	if len(stagePaths) == 0 {
 		// The executor produced no reviewable change. Persist a skipped
@@ -130,22 +161,22 @@ func stagePathsForReviewForOS(ctx context.Context, bins Binaries, workDir, runDi
 		// `git add -A` over the whole worktree would re-stage every
 		// dirty path (including context-only commit:false inputs),
 		// defeating the explicit reviewable-set contract.
-		return writeReviewStagingSkipped(runDir, "no executor-produced paths to stage")
+		return writeReviewStagingSkipped(repo.RunDir, "no executor-produced paths to stage")
 	}
 	pathspecs := literalPathspecs(stagePaths)
-	cmd := proc.Command{WorkDir: workDir}
+	cmd := proc.Command{WorkDir: repo.WorkDir}
 	if goos == "windows" || len(strings.Join(pathspecs, "\x00")) > 32*1024 {
 		// Large reviews use the same literal stdin pathspec protocol as finalization.
-		cmd.Argv = proc.GitArgs(bins.git(), "add", "-A", "--pathspec-from-file=-", "--pathspec-file-nul")
+		cmd.Argv = proc.GitArgs(repo.Bins.git(), "add", "-A", "--pathspec-from-file=-", "--pathspec-file-nul")
 		cmd.Stdin = strings.Join(pathspecs, "\x00") + "\x00"
 	} else {
-		cmd.Argv = proc.GitArgs(bins.git(), append([]string{"add", "-A", "--"}, pathspecs...)...)
+		cmd.Argv = proc.GitArgs(repo.Bins.git(), append([]string{"add", "-A", "--"}, pathspecs...)...)
 	}
 	result, err := proc.RunVCSCommand(ctx, cmd, proc.RunOptions{
-		StdoutPath: filepath.Join(runDir, "git_add_review.stdout.log"),
-		StderrPath: filepath.Join(runDir, "git_add_review.stderr.log"),
+		StdoutPath: filepath.Join(repo.RunDir, "git_add_review.stdout.log"),
+		StderrPath: filepath.Join(repo.RunDir, "git_add_review.stderr.log"),
 	})
-	writeErr := writeJSON(filepath.Join(runDir, "git_add_review_result.json"), result)
+	writeErr := writeJSON(filepath.Join(repo.RunDir, "git_add_review_result.json"), result)
 	if err != nil {
 		return errors.Join(fmt.Errorf("git add -A (review staging) failed: %w", err), writeErr)
 	}
@@ -191,10 +222,10 @@ func literalPathspecs(paths []string) []string {
 
 // IsAncestor reports whether ancestor is reachable from descendant in workDir.
 // Exit code 0 is yes, 1 is no, and any other exit code is an error.
-func IsAncestor(ctx context.Context, bins Binaries, workDir, ancestor, descendant string) (bool, error) {
+func IsAncestor(ctx context.Context, repo Repo, ancestor, descendant string) (bool, error) {
 	result, err := proc.RunVCSCommand(ctx, proc.Command{
-		WorkDir: workDir,
-		Argv:    proc.GitArgs(bins.git(), "merge-base", "--is-ancestor", ancestor, descendant),
+		WorkDir: repo.WorkDir,
+		Argv:    proc.GitArgs(repo.Bins.git(), "merge-base", "--is-ancestor", ancestor, descendant),
 	}, proc.RunOptions{})
 	if err == nil {
 		return true, nil
@@ -206,37 +237,37 @@ func IsAncestor(ctx context.Context, bins Binaries, workDir, ancestor, descendan
 }
 
 // Commit creates a git commit and writes command evidence.
-func Commit(ctx context.Context, bins Binaries, workDir, runDir, message string) error {
+func Commit(ctx context.Context, repo Repo, message string) error {
 	_, err := runCommandWithEvidence(ctx, proc.Command{
-		WorkDir: workDir,
-		Argv:    proc.GitArgs(bins.git(), "commit", "-m", message),
-	}, runDir, "git_commit", "git commit failed")
+		WorkDir: repo.WorkDir,
+		Argv:    proc.GitArgs(repo.Bins.git(), "commit", "-m", message),
+	}, commandEvidence{RunDir: repo.RunDir, Label: "git_commit", Failure: "git commit failed"})
 	return err
 }
 
 // PushCurrentBranch pushes HEAD to origin and writes command evidence.
-func PushCurrentBranch(ctx context.Context, bins Binaries, workDir, runDir string) error {
+func PushCurrentBranch(ctx context.Context, repo Repo) error {
 	_, err := runCommandWithEvidence(ctx, proc.Command{
-		WorkDir: workDir,
-		Argv:    proc.GitArgs(bins.git(), "push", "-u", "origin", "HEAD"),
-	}, runDir, "git_push", "git push failed")
+		WorkDir: repo.WorkDir,
+		Argv:    proc.GitArgs(repo.Bins.git(), "push", "-u", "origin", "HEAD"),
+	}, commandEvidence{RunDir: repo.RunDir, Label: "git_push", Failure: "git push failed"})
 	return err
 }
 
 // CreatePullRequest opens a GitHub PR with gh and writes command evidence.
-func CreatePullRequest(ctx context.Context, bins Binaries, workDir, runDir, bodyPath, base, title string) (string, error) {
-	absoluteBodyPath, err := filepath.Abs(bodyPath)
+func CreatePullRequest(ctx context.Context, repo Repo, spec PullRequestSpec) (string, error) {
+	absoluteBodyPath, err := filepath.Abs(spec.BodyPath)
 	if err != nil {
 		return "", fmt.Errorf("resolve pr body path: %w", err)
 	}
-	argv := []string{bins.gh(), "pr", "create", "--title", title, "--body-file", absoluteBodyPath}
-	if base != "" {
-		argv = append(argv, "--base", base)
+	argv := []string{repo.Bins.gh(), "pr", "create", "--title", spec.Title, "--body-file", absoluteBodyPath}
+	if spec.Base != "" {
+		argv = append(argv, "--base", spec.Base)
 	}
 	result, err := runCommandWithEvidence(ctx, proc.Command{
-		WorkDir: workDir,
+		WorkDir: repo.WorkDir,
 		Argv:    argv,
-	}, runDir, "gh_pr_create", "gh pr create failed")
+	}, commandEvidence{RunDir: repo.RunDir, Label: "gh_pr_create", Failure: "gh pr create failed"})
 	if err != nil {
 		return "", err
 	}
@@ -254,20 +285,18 @@ func CreatePullRequest(ctx context.Context, bins Binaries, workDir, runDir, body
 // response was lost, the URL is recovered; if no PR exists, the function
 // returns "" with a nil error so the caller can surface the original
 // create-failure unchanged.
-func FetchPRURLForCurrentBranch(ctx context.Context, bins Binaries, workDir, runDir string) (string, error) {
+func FetchPRURLForCurrentBranch(ctx context.Context, repo Repo) (string, error) {
 	cmd := proc.Command{
-		WorkDir: workDir,
-		Argv:    []string{bins.gh(), "pr", "view", "--json", "url", "-q", ".url"},
+		WorkDir: repo.WorkDir,
+		Argv:    []string{repo.Bins.gh(), "pr", "view", "--json", "url", "-q", ".url"},
 	}
-	result, runErr, writeErr := runCommandEvidence(ctx, cmd, runDir, "gh_pr_view")
-	if runErr != nil {
-		if isGHPRViewNoPullRequest(result.Stderr) {
-			if writeErr != nil {
-				return "", writeErr
-			}
-			return "", nil
-		}
+	result, runErr, writeErr := runCommandEvidence(ctx, cmd, repo.RunDir, "gh_pr_view")
+	if runErr != nil && !isGHPRViewNoPullRequest(result.Stderr) {
 		return "", errors.Join(fmt.Errorf("gh pr view failed: %w", runErr), writeErr)
+	}
+	if runErr != nil {
+		// No open PR for this branch: recover with an empty URL, not an error.
+		return "", writeErr
 	}
 	if writeErr != nil {
 		return "", writeErr
@@ -281,10 +310,10 @@ func isGHPRViewNoPullRequest(stderr string) bool {
 	return ghPRViewNoPullRequestPattern.MatchString(stderr)
 }
 
-func runCommandWithEvidence(ctx context.Context, cmd proc.Command, runDir, label, failure string) (proc.RunResult, error) {
-	result, runErr, writeErr := runCommandEvidence(ctx, cmd, runDir, label)
+func runCommandWithEvidence(ctx context.Context, cmd proc.Command, ev commandEvidence) (proc.RunResult, error) {
+	result, runErr, writeErr := runCommandEvidence(ctx, cmd, ev.RunDir, ev.Label)
 	if runErr != nil {
-		return result, errors.Join(fmt.Errorf("%s: %w", failure, runErr), writeErr)
+		return result, errors.Join(fmt.Errorf("%s: %w", ev.Failure, runErr), writeErr)
 	}
 	if writeErr != nil {
 		return result, writeErr
@@ -302,13 +331,13 @@ func runCommandEvidence(ctx context.Context, cmd proc.Command, runDir, label str
 }
 
 // FetchPRComments returns all PR comments using gh api pagination.
-func FetchPRComments(ctx context.Context, bins Binaries, root, prURL string) ([]PRComment, error) {
-	owner, repo, number, err := ParseGitHubPRURL(prURL)
+func FetchPRComments(ctx context.Context, repo Repo, prURL string) ([]PRComment, error) {
+	owner, repoName, number, err := ParseGitHubPRURL(prURL)
 	if err != nil {
 		return nil, err
 	}
-	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s/comments", owner, repo, number)
-	output, err := fetchGHAPIOutput(ctx, bins, root, apiPath, "PR comments", "--paginate", "--slurp")
+	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s/comments", owner, repoName, number)
+	output, err := fetchGHAPIOutput(ctx, repo, ghAPIRequest{Path: apiPath, Label: "PR comments", ExtraArgs: []string{"--paginate", "--slurp"}})
 	if err != nil {
 		return nil, err
 	}
@@ -320,19 +349,19 @@ func FetchPRComments(ctx context.Context, bins Binaries, root, prURL string) ([]
 }
 
 // PostPRComment posts a single GitHub PR comment via gh api.
-func PostPRComment(ctx context.Context, bins Binaries, root, prURL, body string) error {
-	owner, repo, number, err := ParseGitHubPRURL(prURL)
+func PostPRComment(ctx context.Context, repo Repo, prURL, body string) error {
+	owner, repoName, number, err := ParseGitHubPRURL(prURL)
 	if err != nil {
 		return err
 	}
-	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s/comments", owner, repo, number)
+	apiPath := fmt.Sprintf("repos/%s/%s/issues/%s/comments", owner, repoName, number)
 	payload, err := json.Marshal(map[string]string{"body": body})
 	if err != nil {
 		return fmt.Errorf("encode PR comment body: %w", err)
 	}
 	_, err = proc.RunVCSCommand(ctx, proc.Command{
-		WorkDir: root,
-		Argv:    []string{bins.gh(), "api", "-X", "POST", apiPath, "--input", "-"},
+		WorkDir: repo.WorkDir,
+		Argv:    []string{repo.Bins.gh(), "api", "-X", "POST", apiPath, "--input", "-"},
 		Stdin:   string(payload),
 	}, proc.RunOptions{})
 	if err != nil {
@@ -345,17 +374,17 @@ func PostPRComment(ctx context.Context, bins Binaries, root, prURL, body string)
 // Galley persists the result on the task PR record at PR creation time so
 // later PR comment authorization can verify the comment author matches the
 // PR author without re-fetching from GitHub.
-func FetchPRAuthorLogin(ctx context.Context, bins Binaries, root, prURL string) (string, error) {
-	owner, repo, number, err := ParseGitHubPRURL(prURL)
+func FetchPRAuthorLogin(ctx context.Context, repo Repo, prURL string) (string, error) {
+	owner, repoName, number, err := ParseGitHubPRURL(prURL)
 	if err != nil {
 		return "", err
 	}
-	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%s", owner, repo, number)
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%s", owner, repoName, number)
 	payload, err := fetchGHAPIJSON[struct {
 		User struct {
 			Login string `json:"login"`
 		} `json:"user"`
-	}](ctx, bins, root, apiPath, "PR author")
+	}](ctx, repo, ghAPIRequest{Path: apiPath, Label: "PR author"})
 	if err != nil {
 		return "", err
 	}
@@ -369,49 +398,49 @@ func FetchPRAuthorLogin(ctx context.Context, bins Binaries, root, prURL string) 
 }
 
 // FetchPRState returns the current GitHub PR state via gh api.
-func FetchPRState(ctx context.Context, bins Binaries, root, prURL string) (PullRequestState, error) {
-	owner, repo, number, err := ParseGitHubPRURL(prURL)
+func FetchPRState(ctx context.Context, repo Repo, prURL string) (PullRequestState, error) {
+	owner, repoName, number, err := ParseGitHubPRURL(prURL)
 	if err != nil {
 		return PullRequestState{}, err
 	}
-	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%s", owner, repo, number)
-	return fetchGHAPIJSON[PullRequestState](ctx, bins, root, apiPath, "PR state")
+	apiPath := fmt.Sprintf("repos/%s/%s/pulls/%s", owner, repoName, number)
+	return fetchGHAPIJSON[PullRequestState](ctx, repo, ghAPIRequest{Path: apiPath, Label: "PR state"})
 }
 
-func fetchGHAPIJSON[T any](ctx context.Context, bins Binaries, root, apiPath, label string, extraArgs ...string) (T, error) {
+func fetchGHAPIJSON[T any](ctx context.Context, repo Repo, req ghAPIRequest) (T, error) {
 	var zero T
-	output, err := fetchGHAPIOutput(ctx, bins, root, apiPath, label, extraArgs...)
+	output, err := fetchGHAPIOutput(ctx, repo, req)
 	if err != nil {
 		return zero, err
 	}
 	var value T
 	if err := json.Unmarshal(output, &value); err != nil {
-		return zero, fmt.Errorf("decode %s: %w", label, err)
+		return zero, fmt.Errorf("decode %s: %w", req.Label, err)
 	}
 	return value, nil
 }
 
-func fetchGHAPIOutput(ctx context.Context, bins Binaries, root, apiPath, label string, extraArgs ...string) ([]byte, error) {
+func fetchGHAPIOutput(ctx context.Context, repo Repo, req ghAPIRequest) ([]byte, error) {
 	stdoutFile, err := os.CreateTemp("", "galley-gh-api-*.json")
 	if err != nil {
-		return nil, fmt.Errorf("create %s temp file: %w", label, err)
+		return nil, fmt.Errorf("create %s temp file: %w", req.Label, err)
 	}
 	stdoutPath := stdoutFile.Name()
 	if err := stdoutFile.Close(); err != nil {
-		return nil, fmt.Errorf("close %s temp file: %w", label, err)
+		return nil, fmt.Errorf("close %s temp file: %w", req.Label, err)
 	}
-	defer os.Remove(stdoutPath)
-	argv := append([]string{bins.gh(), "api", apiPath}, extraArgs...)
+	defer func() { _ = os.Remove(stdoutPath) }()
+	argv := append([]string{repo.Bins.gh(), "api", req.Path}, req.ExtraArgs...)
 	_, err = proc.RunVCSCommand(ctx, proc.Command{
-		WorkDir: root,
+		WorkDir: repo.WorkDir,
 		Argv:    argv,
 	}, proc.RunOptions{StdoutPath: stdoutPath})
 	if err != nil {
-		return nil, fmt.Errorf("gh api %s failed: %w", label, err)
+		return nil, fmt.Errorf("gh api %s failed: %w", req.Label, err)
 	}
 	output, err := os.ReadFile(stdoutPath)
 	if err != nil {
-		return nil, fmt.Errorf("read %s response: %w", label, err)
+		return nil, fmt.Errorf("read %s response: %w", req.Label, err)
 	}
 	return output, nil
 }
@@ -428,7 +457,7 @@ func DecodePRComments(stdout string) ([]PRComment, error) {
 	}
 	var comments []PRComment
 	if err := json.Unmarshal([]byte(stdout), &comments); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode PR comments: %w", err)
 	}
 	return comments, nil
 }

--- a/internal/vcs/vcs_addpaths_windows_routing_test.go
+++ b/internal/vcs/vcs_addpaths_windows_routing_test.go
@@ -42,7 +42,7 @@ cat > `+stdinPath+`
 		paths[i] = paths[i] + filepath.ToSlash("/idx_"+fmt.Sprintf("%06d", i))
 	}
 
-	if err := addPathsForOS(t.Context(), Binaries{Git: fakeGit}, workDir, runDir, paths, "windows"); err != nil {
+	if err := addPathsForOS(t.Context(), Repo{Bins: Binaries{Git: fakeGit}, WorkDir: workDir, RunDir: runDir}, paths, "windows"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ printf '%s\n' "$*" > `+capturePath+`
 		t.Fatal(err)
 	}
 
-	if err := addPathsForOS(t.Context(), Binaries{Git: fakeGit}, workDir, runDir, []string{"internal/foo.go", "internal/bar.go"}, "linux"); err != nil {
+	if err := addPathsForOS(t.Context(), Repo{Bins: Binaries{Git: fakeGit}, WorkDir: workDir, RunDir: runDir}, []string{"internal/foo.go", "internal/bar.go"}, "linux"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/vcs/vcs_isancestor_test.go
+++ b/internal/vcs/vcs_isancestor_test.go
@@ -27,15 +27,15 @@ func TestIsAncestorSeparatesReachableUnreachableAndUnknown(t *testing.T) {
 	runGit(t, repo, "commit", "-q", "-m", "next")
 	head := strings.TrimSpace(string(runGitOutput(t, repo, "rev-parse", "HEAD")))
 
-	ancestor, err := IsAncestor(t.Context(), Binaries{}, repo, base, head)
+	ancestor, err := IsAncestor(t.Context(), Repo{WorkDir: repo}, base, head)
 	if err != nil || !ancestor {
 		t.Fatalf("base->head got (%v, %v), want (true, nil)", ancestor, err)
 	}
-	ancestor, err = IsAncestor(t.Context(), Binaries{}, repo, head, base)
+	ancestor, err = IsAncestor(t.Context(), Repo{WorkDir: repo}, head, base)
 	if err != nil || ancestor {
 		t.Fatalf("head->base got (%v, %v), want (false, nil)", ancestor, err)
 	}
-	if _, err := IsAncestor(t.Context(), Binaries{}, repo, strings.Repeat("0", 40), head); err == nil {
+	if _, err := IsAncestor(t.Context(), Repo{WorkDir: repo}, strings.Repeat("0", 40), head); err == nil {
 		t.Fatal("unknown revision must return an error, not a false negative")
 	}
 }

--- a/internal/vcs/vcs_longpaths_test.go
+++ b/internal/vcs/vcs_longpaths_test.go
@@ -61,38 +61,38 @@ func TestVCSGitInvocationsApplyLongpathsFlag(t *testing.T) {
 		{
 			name: "AddPaths",
 			run: func(t *testing.T, git string) error {
-				return AddPaths(t.Context(), Binaries{Git: git}, t.TempDir(), t.TempDir(), []string{"a.txt"})
+				return AddPaths(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir(), RunDir: t.TempDir()}, []string{"a.txt"})
 			},
 		},
 		{
 			name: "StatusPorcelainZ",
 			run: func(t *testing.T, git string) error {
-				_, err := StatusPorcelainZ(t.Context(), Binaries{Git: git}, t.TempDir())
+				_, err := StatusPorcelainZ(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir()})
 				return err
 			},
 		},
 		{
 			name: "StagePathsForReview",
 			run: func(t *testing.T, git string) error {
-				return StagePathsForReview(t.Context(), Binaries{Git: git}, t.TempDir(), t.TempDir(), []string{"changed.go"})
+				return StagePathsForReview(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir(), RunDir: t.TempDir()}, []string{"changed.go"})
 			},
 		},
 		{
 			name: "Commit",
 			run: func(t *testing.T, git string) error {
-				return Commit(t.Context(), Binaries{Git: git}, t.TempDir(), t.TempDir(), "msg")
+				return Commit(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir(), RunDir: t.TempDir()}, "msg")
 			},
 		},
 		{
 			name: "PushCurrentBranch",
 			run: func(t *testing.T, git string) error {
-				return PushCurrentBranch(t.Context(), Binaries{Git: git}, t.TempDir(), t.TempDir())
+				return PushCurrentBranch(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir(), RunDir: t.TempDir()})
 			},
 		},
 		{
 			name: "addPathsForOS_windows",
 			run: func(t *testing.T, git string) error {
-				return addPathsForOS(t.Context(), Binaries{Git: git}, t.TempDir(), t.TempDir(), []string{"a.go", "b.go"}, "windows")
+				return addPathsForOS(t.Context(), Repo{Bins: Binaries{Git: git}, WorkDir: t.TempDir(), RunDir: t.TempDir()}, []string{"a.go", "b.go"}, "windows")
 			},
 			requireStdin: true,
 		},

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -32,7 +32,7 @@ printf '%s' '[[{"id":1,"body":"`+longBody+`","html_url":"https://github.com/exam
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	comments, err := FetchPRComments(t.Context(), Binaries{}, t.TempDir(), "https://github.com/example/galley/pull/1")
+	comments, err := FetchPRComments(t.Context(), Repo{WorkDir: t.TempDir()}, "https://github.com/example/galley/pull/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ cat > `+bodyPath+`
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := PostPRComment(t.Context(), Binaries{}, t.TempDir(), "https://github.com/example/galley/pull/1", "@owner please check"); err != nil {
+	if err := PostPRComment(t.Context(), Repo{WorkDir: t.TempDir()}, "https://github.com/example/galley/pull/1", "@owner please check"); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(bodyPath)
@@ -76,7 +76,7 @@ printf '%s\n' 'https://github.com/example/galley/pull/42'
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	url, err := FetchPRURLForCurrentBranch(t.Context(), Binaries{}, t.TempDir(), t.TempDir())
+	url, err := FetchPRURLForCurrentBranch(t.Context(), Repo{WorkDir: t.TempDir(), RunDir: t.TempDir()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ exit 1
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	url, err := FetchPRURLForCurrentBranch(t.Context(), Binaries{}, t.TempDir(), t.TempDir())
+	url, err := FetchPRURLForCurrentBranch(t.Context(), Repo{WorkDir: t.TempDir(), RunDir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("expected nil error for missing PR, got %v", err)
 	}
@@ -133,7 +133,7 @@ exit 1
 			}
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-			if _, err := FetchPRURLForCurrentBranch(t.Context(), Binaries{}, t.TempDir(), t.TempDir()); err == nil {
+			if _, err := FetchPRURLForCurrentBranch(t.Context(), Repo{WorkDir: t.TempDir(), RunDir: t.TempDir()}); err == nil {
 				t.Fatal("expected error for non-missing-PR failure")
 			}
 		})
@@ -152,7 +152,7 @@ printf '%s' '{"state":"open","merged":false,"padding":"`+padding+`"}'
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	state, err := FetchPRState(t.Context(), Binaries{}, t.TempDir(), "https://github.com/example/galley/pull/1")
+	state, err := FetchPRState(t.Context(), Repo{WorkDir: t.TempDir()}, "https://github.com/example/galley/pull/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ printf '%s' '{"user":{"login":"pr-author"}}'
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	login, err := FetchPRAuthorLogin(t.Context(), Binaries{}, t.TempDir(), "https://github.com/example/galley/pull/1")
+	login, err := FetchPRAuthorLogin(t.Context(), Repo{WorkDir: t.TempDir()}, "https://github.com/example/galley/pull/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ printf '%s' '`+tc.payload+`'
 			}
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-			login, err := FetchPRAuthorLogin(t.Context(), Binaries{}, t.TempDir(), "https://github.com/example/galley/pull/1")
+			login, err := FetchPRAuthorLogin(t.Context(), Repo{WorkDir: t.TempDir()}, "https://github.com/example/galley/pull/1")
 			if err == nil {
 				t.Fatalf("expected error for empty login payload %q, got login=%q", tc.payload, login)
 			}
@@ -252,7 +252,7 @@ func TestStagePathsForReviewTreatsPathspecMagicAsLiteral(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := StagePathsForReview(t.Context(), Binaries{}, repo, runDir, []string{":(glob)*"}); err != nil {
+	if err := StagePathsForReview(t.Context(), Repo{WorkDir: repo, RunDir: runDir}, []string{":(glob)*"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -283,7 +283,7 @@ func TestAddPathsTreatsPathspecMagicAsLiteral(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := AddPaths(t.Context(), Binaries{}, repo, runDir, []string{":(glob)*"}); err != nil {
+	if err := AddPaths(t.Context(), Repo{WorkDir: repo, RunDir: runDir}, []string{":(glob)*"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -295,7 +295,7 @@ func TestAddPathsTreatsPathspecMagicAsLiteral(t *testing.T) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
@@ -304,7 +304,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 
 func runGitOutput(t *testing.T, dir string, args ...string) []byte {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)

--- a/internal/workspace/worktree.go
+++ b/internal/workspace/worktree.go
@@ -84,10 +84,12 @@ func Prepare(ctx context.Context, sourceCWD string, spec task.Worktree, opts Opt
 	}
 	worktreePath = filepath.Clean(worktreePath)
 	if _, err := os.Stat(worktreePath); err == nil {
-		return reuseExistingWorktree(ctx, sourceCWD, worktreePath, spec.Branch, opts)
+		return reuseExistingWorktree(ctx, worktreeReuse{SourceCWD: sourceCWD, WorktreePath: worktreePath, Branch: spec.Branch}, opts)
 	} else if !os.IsNotExist(err) {
 		return Prepared{}, fmt.Errorf("inspect worktree path %s: %w", worktreePath, err)
 	}
+	// The worktree sits beside the user's repository and follows its conventions.
+	//nolint:gosec // G301: user-visible checkout parent, not Galley state
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 		return Prepared{}, fmt.Errorf("create worktree parent %s: %w", filepath.Dir(worktreePath), err)
 	}
@@ -130,7 +132,15 @@ func Prepare(ctx context.Context, sourceCWD string, spec task.Worktree, opts Opt
 	}, nil
 }
 
-func reuseExistingWorktree(ctx context.Context, sourceCWD, worktreePath, branch string, opts Options) (Prepared, error) {
+// worktreeReuse identifies an existing worktree that a task reuses.
+type worktreeReuse struct {
+	SourceCWD    string
+	WorktreePath string
+	Branch       string
+}
+
+func reuseExistingWorktree(ctx context.Context, req worktreeReuse, opts Options) (Prepared, error) {
+	sourceCWD, worktreePath, branch := req.SourceCWD, req.WorktreePath, req.Branch
 	inside, err := gitOutput(ctx, opts, worktreePath, "rev-parse", "--is-inside-work-tree")
 	if err != nil || inside != "true" {
 		return Prepared{}, fmt.Errorf("worktree path already exists and is not a git worktree: %s", worktreePath)
@@ -145,11 +155,11 @@ func reuseExistingWorktree(ctx context.Context, sourceCWD, worktreePath, branch 
 	}
 	sourceInfo, err := os.Stat(sourceCommon)
 	if err != nil {
-		return Prepared{}, err
+		return Prepared{}, fmt.Errorf("stat source git common dir %s: %w", sourceCommon, err)
 	}
 	worktreeInfo, err := os.Stat(worktreeCommon)
 	if err != nil {
-		return Prepared{}, err
+		return Prepared{}, fmt.Errorf("stat worktree git common dir %s: %w", worktreeCommon, err)
 	}
 	if !os.SameFile(sourceInfo, worktreeInfo) {
 		return Prepared{}, fmt.Errorf("worktree path %s belongs to another repository (source %s)", worktreePath, sourceCWD)
@@ -243,13 +253,9 @@ func CaptureSnapshotFromBase(ctx context.Context, cwd, baseSHA string, opts Opti
 	branchDiff := ""
 	var branchFiles []string
 	if baseSHA != "" && baseSHA != head {
-		branchDiff, err = gitOutput(ctx, opts, cwd, "diff", "--binary", baseSHA+"..HEAD")
+		branchDiff, branchFiles, err = branchDiffFromBase(ctx, cwd, baseSHA, opts)
 		if err != nil {
-			return Snapshot{}, fmt.Errorf("git branch diff: %w", err)
-		}
-		branchFiles, err = gitChangedFiles(ctx, cwd, baseSHA+"..HEAD", opts)
-		if err != nil {
-			return Snapshot{}, fmt.Errorf("git branch changed files: %w", err)
+			return Snapshot{}, err
 		}
 	}
 	stagedDiff, err := gitOutput(ctx, opts, cwd, "diff", "--cached", "--binary")
@@ -326,23 +332,15 @@ func Remove(ctx context.Context, sourceCWD string, spec task.Worktree, opts Opti
 	}
 	gitResult, err := runGitCommand(ctx, opts, "", "-C", sourceCWD, "worktree", "remove", "--force", worktreePath)
 	if err != nil {
-		inside, insideErr := isGitWorktree(ctx, worktreePath, opts)
-		if insideErr == nil && !inside {
-			if validateErr := validateManagedLeftoverPath(sourceCWD, worktreePath); validateErr != nil {
-				return result, fmt.Errorf("git worktree remove --force: %w: %s; %v", err, strings.TrimSpace(gitResult.Stderr), validateErr)
-			}
-			if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
-				return result, fmt.Errorf("git worktree remove --force: %w: %s; remove leftover path: %v", err, strings.TrimSpace(gitResult.Stderr), removeErr)
-			}
-		} else {
-			return result, fmt.Errorf("git worktree remove --force: %w: %s", err, strings.TrimSpace(gitResult.Stderr))
+		failure := gitRemoveFailure{SourceCWD: sourceCWD, WorktreePath: worktreePath, GitErr: err, Stderr: gitResult.Stderr}
+		if removeErr := removeLeftoverAfterGitFailure(ctx, failure, opts); removeErr != nil {
+			return result, removeErr
 		}
-	} else if _, statErr := os.Stat(worktreePath); statErr == nil {
-		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
-			return result, fmt.Errorf("remove leftover worktree path %s: %w", worktreePath, removeErr)
-		}
-	} else if !os.IsNotExist(statErr) {
-		return result, fmt.Errorf("inspect removed worktree path %s: %w", worktreePath, statErr)
+		result.Removed = true
+		return result, nil
+	}
+	if err := removeLeftoverPath(worktreePath); err != nil {
+		return result, err
 	}
 	result.Removed = true
 	return result, nil
@@ -402,11 +400,11 @@ func isManagedWorktreeRoot(name, sourceBase string) bool {
 func canonicalExistingPath(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve absolute path %s: %w", path, err)
 	}
 	resolved, err := filepath.EvalSymlinks(abs)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolve symlinks for %s: %w", abs, err)
 	}
 	return filepath.Clean(resolved), nil
 }
@@ -425,4 +423,57 @@ func runGitCommand(ctx context.Context, opts Options, cwd string, args ...string
 		WorkDir: cwd,
 		Argv:    proc.GitArgs(opts.git(), args...),
 	}, proc.RunOptions{TailBytes: -1})
+}
+
+// removeLeftoverAfterGitFailure deletes what `git worktree remove` could not,
+// refusing any path that is still a worktree or not a Galley-managed leftover.
+func removeLeftoverAfterGitFailure(ctx context.Context, f gitRemoveFailure, opts Options) error {
+	stderr := strings.TrimSpace(f.Stderr)
+	inside, insideErr := isGitWorktree(ctx, f.WorktreePath, opts)
+	if insideErr != nil || inside {
+		return fmt.Errorf("git worktree remove --force: %w: %s", f.GitErr, stderr)
+	}
+	if validateErr := validateManagedLeftoverPath(f.SourceCWD, f.WorktreePath); validateErr != nil {
+		return fmt.Errorf("git worktree remove --force: %w: %s; %w", f.GitErr, stderr, validateErr)
+	}
+	if removeErr := os.RemoveAll(f.WorktreePath); removeErr != nil {
+		return fmt.Errorf("git worktree remove --force: %w: %s; remove leftover path: %w", f.GitErr, stderr, removeErr)
+	}
+	return nil
+}
+
+// gitRemoveFailure is a failed `git worktree remove --force` and its evidence.
+type gitRemoveFailure struct {
+	SourceCWD    string
+	WorktreePath string
+	GitErr       error
+	Stderr       string
+}
+
+func branchDiffFromBase(ctx context.Context, cwd, baseSHA string, opts Options) (string, []string, error) {
+	diff, err := gitOutput(ctx, opts, cwd, "diff", "--binary", baseSHA+"..HEAD")
+	if err != nil {
+		return "", nil, fmt.Errorf("git branch diff: %w", err)
+	}
+	files, err := gitChangedFiles(ctx, cwd, baseSHA+"..HEAD", opts)
+	if err != nil {
+		return "", nil, fmt.Errorf("git branch changed files: %w", err)
+	}
+	return diff, files, nil
+}
+
+// removeLeftoverPath deletes a path git reported as removed but that still
+// exists on disk. A path that is already gone is not an error.
+func removeLeftoverPath(worktreePath string) error {
+	_, statErr := os.Stat(worktreePath)
+	if os.IsNotExist(statErr) {
+		return nil
+	}
+	if statErr != nil {
+		return fmt.Errorf("inspect removed worktree path %s: %w", worktreePath, statErr)
+	}
+	if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+		return fmt.Errorf("remove leftover worktree path %s: %w", worktreePath, removeErr)
+	}
+	return nil
 }

--- a/internal/workspace/worktree_test.go
+++ b/internal/workspace/worktree_test.go
@@ -551,7 +551,7 @@ func initGitRepo(t *testing.T) string {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -561,7 +561,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 
 func mustGitOutput(t *testing.T, dir string, args ...string) []byte {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(t.Context(), "git", args...)
 	cmd.Dir = dir
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Why

`gofmt` and `go test` were Galley's only mechanical gates. Enum completeness, unchecked errors, path containment, and evidence economy were left to review round-trips, and every round-trip costs AFK throughput.

## What

Adds `.golangci.yml` and clears every finding it reports, in production and test code, on all three supported platforms.

### Configuration rationale

Thresholds come from how Go and this product behave, not from the current violation counts.

| Setting | Reason |
|---|---|
| `gocognit: 25` | Go charges an explicit branch per fallible step, so Sonar's exception-language calibration of 15 does not transfer |
| `nestif: 3` | nestif sums nesting and `else` branches rather than measuring depth; chosen by whether the fix it forces reduces the conditions a reader must hold |
| `govet shadow` off | In `if err := f(); err != nil` the inner binding dies at the closing brace, so no read is ambiguous |
| `gosec` G304/G204 excluded | SECURITY.md defines task/profile input as trusted, and neither rule separates a permitted operation from an escape |
| `errcheck` exclusions | Limited to `*strings.Builder`, `os.Stderr`, and the cobra accessors in the command packages; every other writer stays checked |

Every `//nolint` carries a reason, enforced by `nolintlint`.

### Notable code changes

- **`task.Status` is now a type.** A Galley task status can no longer be assigned to or from an executor-reported status. `exhaustive` immediately found three non-exhaustive switches. Serialization is unchanged.
- **Over-long parameter lists become named request types** (`vcs.Repo`, `attemptFailure`, `riskSpec`, `stopRequest`, …). 179 functions had adjacent same-type parameters that could be swapped without a compile error — `ensureUnderRoot(root, path)` among them.
- **84 errors crossing a standard-library boundary are wrapped** with the operation and target, so run evidence names the failing step.
- **Stage splits** in the daemon claim/setup/acceptance-skeleton path and in `daemon start` / `daemon stop`.
- **Queue and task-state directories are created with `0700`** instead of `0755`. Existing directories keep their permissions.

### CI

New `lint` and `race` jobs. `lint` runs as a `GOOS` matrix over darwin, linux, and windows, because build-tagged files are analyzed only for the target OS. The cross-OS test matrix is unchanged; the race detector needs cgo, so it runs on Linux only rather than replacing the matrix.

## Verification

`gofmt` · `golangci-lint run` (0 issues) · `go build` on macOS/Linux/Windows · `go vet ./...` · `go test ./...` · `go test -race ./...` · `scripts/smoke-local.sh` · `schema check` · example and JSON validation

## Review notes

Two regressions were introduced during the refactor and caught by existing tests: a lost early return in worktree cleanup, and a swallowed PR-comment reply error. Both are fixed. Paths without test coverage are unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
